### PR TITLE
Remove duplicate license info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,3 @@ Exercism exercises in C#
 The MIT License (MIT)
 
 Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
-## License
-The MIT License (MIT)
-
-Copyright (c) 2014 Katrina Owen, _@kytrinyx.com


### PR DESCRIPTION
Looks like there were still some issues from whatever happened earlier.
