### PR TITLE
Add tolerance checks for tests in space-age

### DIFF
--- a/space-age/SpaceAgeTest.cs
+++ b/space-age/SpaceAgeTest.cs
@@ -16,7 +16,7 @@ public class SpaceAgeTest
     public void Age_on_earth()
     {
         var age = new SpaceAge(1000000000);
-        Assert.That(age.OnEarth(), Is.EqualTo(31.69));
+        Assert.That(age.OnEarth(), Is.EqualTo(31.69).Within(1E-02));
     }
 
     [Ignore]
@@ -24,8 +24,8 @@ public class SpaceAgeTest
     public void Age_on_mercury()
     {
         var age = new SpaceAge(2134835688);
-        Assert.That(age.OnEarth(), Is.EqualTo(67.65));
-        Assert.That(age.OnMercury(), Is.EqualTo(280.88));
+        Assert.That(age.OnEarth(), Is.EqualTo(67.65).Within(1E-02));
+        Assert.That(age.OnMercury(), Is.EqualTo(280.88).Within(1E-02));
     }
 
     [Ignore]
@@ -33,8 +33,8 @@ public class SpaceAgeTest
     public void Age_on_venus()
     {
         var age = new SpaceAge(189839836);
-        Assert.That(age.OnEarth(), Is.EqualTo(6.02));
-        Assert.That(age.OnVenus(), Is.EqualTo(9.78));
+        Assert.That(age.OnEarth(), Is.EqualTo(6.02).Within(1E-02));
+        Assert.That(age.OnVenus(), Is.EqualTo(9.78).Within(1E-02));
     }
 
     [Ignore]
@@ -42,8 +42,8 @@ public class SpaceAgeTest
     public void Age_on_mars()
     {
         var age = new SpaceAge(2329871239);
-        Assert.That(age.OnEarth(), Is.EqualTo(73.83));
-        Assert.That(age.OnMars(), Is.EqualTo(39.25));
+        Assert.That(age.OnEarth(), Is.EqualTo(73.83).Within(1E-02));
+        Assert.That(age.OnMars(), Is.EqualTo(39.25).Within(1E-02));
     }
 
     [Ignore]
@@ -51,8 +51,8 @@ public class SpaceAgeTest
     public void Age_on_jupiter()
     {
         var age = new SpaceAge(901876382);
-        Assert.That(age.OnEarth(), Is.EqualTo(28.58));
-        Assert.That(age.OnJupiter(), Is.EqualTo(2.41));
+        Assert.That(age.OnEarth(), Is.EqualTo(28.58).Within(1E-02));
+        Assert.That(age.OnJupiter(), Is.EqualTo(2.41).Within(1E-02));
     }
 
     [Ignore]
@@ -60,8 +60,8 @@ public class SpaceAgeTest
     public void Age_on_saturn()
     {
         var age = new SpaceAge(3000000000);
-        Assert.That(age.OnEarth(), Is.EqualTo(95.06));
-        Assert.That(age.OnSaturn(), Is.EqualTo(3.23));
+        Assert.That(age.OnEarth(), Is.EqualTo(95.06).Within(1E-02));
+        Assert.That(age.OnSaturn(), Is.EqualTo(3.23).Within(1E-02));
     }
 
     [Ignore]
@@ -69,8 +69,8 @@ public class SpaceAgeTest
     public void Age_on_uranus()
     {
         var age = new SpaceAge(3210123456);
-        Assert.That(age.OnEarth(), Is.EqualTo(101.72));
-        Assert.That(age.OnUranus(), Is.EqualTo(1.21));
+        Assert.That(age.OnEarth(), Is.EqualTo(101.72).Within(1E-02));
+        Assert.That(age.OnUranus(), Is.EqualTo(1.21).Within(1E-02));
     }
 
     [Ignore]
@@ -78,7 +78,7 @@ public class SpaceAgeTest
     public void Age_on_neptune()
     {
         var age = new SpaceAge(8210123456);
-        Assert.That(age.OnEarth(), Is.EqualTo(260.16));
-        Assert.That(age.OnNeptune(), Is.EqualTo(1.58));
+        Assert.That(age.OnEarth(), Is.EqualTo(260.16).Within(1E-02));
+        Assert.That(age.OnNeptune(), Is.EqualTo(1.58).Within(1E-02));
     }
 }


### PR DESCRIPTION
The tests numbers are rounded off but don't have any tolerance checking.
They fail if the number isn't exactly the same.
