### PR TITLE
Test for equivalence, not for ordering

### DIFF
--- a/anagram/AnagramTest.cs
+++ b/anagram/AnagramTest.cs
@@ -9,7 +9,7 @@ public class AnagramTest
         var detector = new Anagram("diaper");
         var words = new[] { "hello", "world", "zombies", "pants" };
         var results = new string[0];
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
     [Ignore]
@@ -19,7 +19,7 @@ public class AnagramTest
         var detector = new Anagram("ant");
         var words = new[] { "tan", "stand", "at" };
         var results = new[] { "tan" };
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
     [Ignore]
@@ -29,7 +29,7 @@ public class AnagramTest
         var detector = new Anagram("master");
         var words = new[] { "stream", "pigeon", "maters" };
         var results = new[] { "maters", "stream" };
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
     [Ignore]
@@ -39,7 +39,7 @@ public class AnagramTest
         var detector = new Anagram("galea");
         var words = new[] { "eagle" };
         var results = new string[0];
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
     [Ignore]
@@ -49,7 +49,7 @@ public class AnagramTest
         var detector = new Anagram("corn");
         var words = new[] { "corn", "dark", "Corn", "rank", "CORN", "cron", "park" };
         var results = new[] { "cron" };
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
     [Ignore]
@@ -59,7 +59,7 @@ public class AnagramTest
         var detector = new Anagram("mass");
         var words = new[] { "last" };
         var results = new string[0];
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
     [Ignore]
@@ -69,7 +69,7 @@ public class AnagramTest
         var detector = new Anagram("good");
         var words = new[] { "dog", "goody" };
         var results = new string[0];
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
     [Ignore]
@@ -79,7 +79,7 @@ public class AnagramTest
         var detector = new Anagram("allergy");
         var words = new[] { "gallery", "ballerina", "regally", "clergy", "largely", "leading" };
         var results = new[] { "gallery", "largely", "regally" };
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
     [Ignore]
@@ -89,7 +89,7 @@ public class AnagramTest
         var detector = new Anagram("Orchestra");
         var words = new[] { "cashregister", "Carthorse", "radishes" };
         var results = new[] { "Carthorse" };
-        Assert.That(detector.Match(words), Is.EqualTo(results));
+        Assert.That(detector.Match(words), Is.EquivalentTo(results));
     }
 
 }


### PR DESCRIPTION
At the moment, the unit tests for anagrams use `Is.EqualTo` to compare the expect anagrams with the actual anagrams. The problem is that `Is.EqualTo` requires the ordering to be the same, which should not be the case. This PR replaces the `Is.EqualTo` calls with `Is.EquivalentTo` calls that checks for the same elements to be in the collection, but not necessarily in the same order.
