### PR TITLE
Updated the unit tests to match the spec in the Readme

### DIFF
--- a/crypto-square/CryptoSquareTest.cs
+++ b/crypto-square/CryptoSquareTest.cs
@@ -92,10 +92,10 @@ public class CryptoSquareTest
 
     [Ignore]
     [Test]
-    public void Normalized_ciphertext_is_split_by_5()
+    public void Normalized_ciphertext_is_split_by_height_of_square()
     {
         var crypto = new Crypto("Vampires are people too!");
-        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("vrela epems etpao oirpo"));
+        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("vrel aepe mset paoo irpo"));
     }
 
     [Ignore]
@@ -104,5 +104,29 @@ public class CryptoSquareTest
     {
         var crypto = new Crypto("Madness, and then illumination.");
         Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("msemo aanin dninn dlaet ltshu i"));
+    }
+
+    [Ignore]
+    [Test]
+    public void Normalized_ciphertext_is_split_into_segements_of_correct_size()
+    {
+        var crypto = new Crypto("If man was meant to stay on the ground god would have given us roots");
+        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghns seoau"));
+    }
+
+    [Ignore]
+    [Test]
+    public void Normalized_ciphertext_is_split_into_segements_of_correct_size_with_punctuation()
+    {
+        var crypto = new Crypto("Have a nice day. Feed the dog & chill out!");
+        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("hifei acedl veeol eddgo aatcu nyhht"));
+    }
+
+    [Ignore]
+    [Test]
+    public void Normalized_ciphertext_is_split_into_segements_of_correct_size_when_just_less_than_full_square()
+    {
+        var crypto = new Crypto("I am");
+        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("im a"));
     }
 }

--- a/crypto-square/Example.cs
+++ b/crypto-square/Example.cs
@@ -61,6 +61,8 @@ public class Crypto
 
     public string NormalizeCiphertext()
     {
-        return string.Join(" ", SegmentText(Ciphertext(), 5));
+        string cipher = Ciphertext();
+        int size = cipher.Length == Size * Size - Size ? Size : Size - 1;
+        return string.Join(" ", SegmentText(cipher, size) );
     }
 }


### PR DESCRIPTION
It looks like the Readme.md was updated after the unit tests for this problem were written. The unit tests split the ciphertext into word lengths of 5 which contradicts the readme. The readme splits the ciphertext into words that are the height of the square. For example, if the plaintext square is 5 by 4, the word length should be 4.

I modified the existing unit tests and added two new ones with the examples given in the Readme. The update in the example code is the simplest fix.
