### PR TITLE
Added test to bob, question with trailing space

### DIFF
--- a/bob/BobTest.cs
+++ b/bob/BobTest.cs
@@ -33,6 +33,13 @@ public class BobTest
 
     [Ignore]
     [Test]
+    public void Asking_a_question_with_a_trailing_space()
+    {
+        Assert.That(teenager.Hey("Do I like my  spacebar  too much?  "), Is.EqualTo("Sure."));
+    }
+
+    [Ignore]
+    [Test]
     public void Asking_a_numeric_question ()
     {
         Assert.That(teenager.Hey("You are, what, like 15?"), Is.EqualTo("Sure."));

--- a/bob/Example.cs
+++ b/bob/Example.cs
@@ -34,7 +34,7 @@ public class Bob
 
     private bool IsQuestion (string statement)
     {
-        return statement.EndsWith("?");
+        return statement.Trim().EndsWith("?");
     }
 
 }


### PR DESCRIPTION
Added a test to the bob exercise sending a question with a trailing
space. Implementations that look for "?" in the last character without
trimming trailing spaces will fail. This will probably break some
existing submissions.

Also updated the example implementation to pass the new test.
