### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ env:
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
 script:
   - ./bin/fetch-configlet
-  - ./bin/configlet .
+  - ./bin/configlet lint .
   - ./build.sh

--- a/circle.yml
+++ b/circle.yml
@@ -11,5 +11,5 @@ jobs:
       - checkout
       - run: apt-get -qq update; apt-get -y install unzip
       - run: ./bin/fetch-configlet
-      - run: ./bin/configlet .
+      - run: ./bin/configlet lint .
       - run: ./build.sh


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23