### PR TITLE
Generate exercise READMEs from templates

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -1,0 +1,16 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -1,0 +1,44 @@
+# Accumulate
+
+Implement the `accumulate` operation, which, given a collection and an
+operation to perform on each element of the collection, returns a new
+collection containing the result of applying that operation to each element of
+the input collection.
+
+Given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the operation:
+
+- square a number (`x => x * x`)
+
+Your code should be able to produce the collection of squares:
+
+- 1, 4, 9, 16, 25
+
+Check out the test suite to see the expected function signature.
+
+## Restrictions
+
+Keep your hands off that collect/map/fmap/whatchamacallit functionality
+provided by your standard library!
+Solve this one yourself using other basic tools instead.
+
+Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
+as this is idiomatic Lisp, not a library function.
+
+## Hints		
+This exercise requires you to write an extension method. For more information, see [this page](https://msdn.microsoft.com/en-us//library/bb383977.aspx).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -1,0 +1,21 @@
+# Acronym
+
+Convert a phrase to its acronym.
+
+Techies love their TLA (Three Letter Acronyms)!
+
+Help generate some jargon by writing a program that converts a long name
+like Portable Network Graphics to its acronym (PNG).
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Julien Vanier [https://github.com/monkbroc](https://github.com/monkbroc)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -1,0 +1,41 @@
+# All Your Base
+
+Convert a number, represented as a sequence of digits in one base, to any other base.
+
+Implement general base conversion. Given a number in base **a**,
+represented as a sequence of digits, convert it to base **b**.
+
+## Note
+- Try to implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
+## About [Positional Notation](https://en.wikipedia.org/wiki/Positional_notation)
+
+In positional notation, a number in base **b** can be understood as a linear
+combination of powers of **b**.
+
+The number 42, *in base 10*, means:
+
+(4 * 10^1) + (2 * 10^0)
+
+The number 101010, *in base 2*, means:
+
+(1 * 2^5) + (0 * 2^4) + (1 * 2^3) + (0 * 2^2) + (1 * 2^1) + (0 * 2^0)
+
+The number 1120, *in base 3*, means:
+
+(1 * 3^3) + (1 * 3^2) + (2 * 3^1) + (0 * 3^0)
+
+I think you got the idea!
+
+
+*Yes. Those three numbers above are exactly the same. Congratulations!*
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -1,0 +1,46 @@
+# Allergies
+
+Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
+
+An allergy test produces a single numeric score which contains the
+information about all the allergies the person has (that they were
+tested for).
+
+The list of items (and their value) that were tested are:
+
+* eggs (1)
+* peanuts (2)
+* shellfish (4)
+* strawberries (8)
+* tomatoes (16)
+* chocolate (32)
+* pollen (64)
+* cats (128)
+
+So if Tom is allergic to peanuts and chocolate, he gets a score of 34.
+
+Now, given just that score of 34, your program should be able to say:
+
+- Whether Tom is allergic to any one of those allergens listed above.
+- All the allergens Tom is allergic to.
+
+Note: a given score may include allergens **not** listed above (i.e.
+allergens that score 256, 512, 1024, etc.).  Your program should
+ignore those components of the score.  For example, if the allergy
+score is 257, your program should only report the eggs (1) allergy.
+
+
+## Hints
+This exercise requires you to use bitwise operations. For more information, see [this page](https://msdn.microsoft.com/en-us/library/6a71f45d.aspx). 
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Jumpstart Lab Warm-up [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -1,0 +1,48 @@
+# Alphametics
+
+Write a function to solve alphametics puzzles.
+
+[Alphametics](https://en.wikipedia.org/wiki/Alphametics) is a puzzle where
+letters in words are replaced with numbers.
+
+For example `SEND + MORE = MONEY`:
+
+```
+  S E N D
+  M O R E +
+-----------
+M O N E Y
+```
+
+Replacing these with valid numbers gives:
+
+```
+  9 5 6 7
+  1 0 8 5 +
+-----------
+1 0 6 5 2
+```
+
+This is correct because every letter is replaced by a different number and the
+words, translated into numbers, then make a valid sum.
+
+Each letter must represent a different digit, and the leading digit of
+a multi-digit number must not be zero.
+
+Write a function to solve alphametics puzzles.
+
+## Hints
+- To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/).
+- You can solve this exercise with a brute force algorithm, but this will possibly have a poor runtime performance.
+Try to find a more sophisticated solution. 
+- Hint: You could try the column-wise addition algorithm that is usually taught in school.
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -1,0 +1,19 @@
+# Anagram
+
+Given a word and a list of possible anagrams, select the correct sublist.
+
+Given `"listen"` and a list of candidates like `"enlists" "google"
+"inlets" "banana"` the program should return a list containing
+`"inlets"`.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -1,0 +1,40 @@
+# Atbash Cipher
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on
+transposing all the letters in the alphabet such that the resulting
+alphabet is backwards. The first letter is replaced with the last
+letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```plain
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is
+a simple monoalphabetic substitution cipher. However, this may not have
+been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size
+being 5 letters, and punctuation is excluded. This is to make it harder to guess
+things based on word boundaries.
+
+## Examples
+- Encoding `test` gives `gvhg`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -1,0 +1,41 @@
+# Bank Account
+
+Simulate a bank account supporting opening/closing, withdrawals, and deposits
+of money. Watch out for concurrent transactions!
+
+A bank account can be accessed in multiple ways. Clients can make
+deposits and withdrawals using the internet, mobile phones, etc. Shops
+can charge against the account.
+
+Create an account that can be accessed from multiple threads/processes
+(terminology depends on your programming language).
+
+It should be possible to close an account; operations against a closed
+account must fail.
+
+## Instructions
+
+Run the test file, and fix each of the errors in turn. When you get the
+first test to pass, go to the first pending or skipped test, and make
+that pass as well. When all of the tests are passing, feel free to
+submit.
+
+Remember that passing code is just the first step. The goal is to work
+towards a solution that is as readable and expressive as you can make
+it.
+
+Have fun!
+
+## Hints
+This exercise requires you to handle data related to currency and money. A normal approuch is to use the [Decimal](https://msdn.microsoft.com/en-US/library/system.decimal.aspx) struct to store currency values. 
+Note though that you then only store the numeric value of a currency. 
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,0 +1,336 @@
+# Beer Song
+
+Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
+
+Note that not all verses are identical.
+
+```plain
+99 bottles of beer on the wall, 99 bottles of beer.
+Take one down and pass it around, 98 bottles of beer on the wall.
+
+98 bottles of beer on the wall, 98 bottles of beer.
+Take one down and pass it around, 97 bottles of beer on the wall.
+
+97 bottles of beer on the wall, 97 bottles of beer.
+Take one down and pass it around, 96 bottles of beer on the wall.
+
+96 bottles of beer on the wall, 96 bottles of beer.
+Take one down and pass it around, 95 bottles of beer on the wall.
+
+95 bottles of beer on the wall, 95 bottles of beer.
+Take one down and pass it around, 94 bottles of beer on the wall.
+
+94 bottles of beer on the wall, 94 bottles of beer.
+Take one down and pass it around, 93 bottles of beer on the wall.
+
+93 bottles of beer on the wall, 93 bottles of beer.
+Take one down and pass it around, 92 bottles of beer on the wall.
+
+92 bottles of beer on the wall, 92 bottles of beer.
+Take one down and pass it around, 91 bottles of beer on the wall.
+
+91 bottles of beer on the wall, 91 bottles of beer.
+Take one down and pass it around, 90 bottles of beer on the wall.
+
+90 bottles of beer on the wall, 90 bottles of beer.
+Take one down and pass it around, 89 bottles of beer on the wall.
+
+89 bottles of beer on the wall, 89 bottles of beer.
+Take one down and pass it around, 88 bottles of beer on the wall.
+
+88 bottles of beer on the wall, 88 bottles of beer.
+Take one down and pass it around, 87 bottles of beer on the wall.
+
+87 bottles of beer on the wall, 87 bottles of beer.
+Take one down and pass it around, 86 bottles of beer on the wall.
+
+86 bottles of beer on the wall, 86 bottles of beer.
+Take one down and pass it around, 85 bottles of beer on the wall.
+
+85 bottles of beer on the wall, 85 bottles of beer.
+Take one down and pass it around, 84 bottles of beer on the wall.
+
+84 bottles of beer on the wall, 84 bottles of beer.
+Take one down and pass it around, 83 bottles of beer on the wall.
+
+83 bottles of beer on the wall, 83 bottles of beer.
+Take one down and pass it around, 82 bottles of beer on the wall.
+
+82 bottles of beer on the wall, 82 bottles of beer.
+Take one down and pass it around, 81 bottles of beer on the wall.
+
+81 bottles of beer on the wall, 81 bottles of beer.
+Take one down and pass it around, 80 bottles of beer on the wall.
+
+80 bottles of beer on the wall, 80 bottles of beer.
+Take one down and pass it around, 79 bottles of beer on the wall.
+
+79 bottles of beer on the wall, 79 bottles of beer.
+Take one down and pass it around, 78 bottles of beer on the wall.
+
+78 bottles of beer on the wall, 78 bottles of beer.
+Take one down and pass it around, 77 bottles of beer on the wall.
+
+77 bottles of beer on the wall, 77 bottles of beer.
+Take one down and pass it around, 76 bottles of beer on the wall.
+
+76 bottles of beer on the wall, 76 bottles of beer.
+Take one down and pass it around, 75 bottles of beer on the wall.
+
+75 bottles of beer on the wall, 75 bottles of beer.
+Take one down and pass it around, 74 bottles of beer on the wall.
+
+74 bottles of beer on the wall, 74 bottles of beer.
+Take one down and pass it around, 73 bottles of beer on the wall.
+
+73 bottles of beer on the wall, 73 bottles of beer.
+Take one down and pass it around, 72 bottles of beer on the wall.
+
+72 bottles of beer on the wall, 72 bottles of beer.
+Take one down and pass it around, 71 bottles of beer on the wall.
+
+71 bottles of beer on the wall, 71 bottles of beer.
+Take one down and pass it around, 70 bottles of beer on the wall.
+
+70 bottles of beer on the wall, 70 bottles of beer.
+Take one down and pass it around, 69 bottles of beer on the wall.
+
+69 bottles of beer on the wall, 69 bottles of beer.
+Take one down and pass it around, 68 bottles of beer on the wall.
+
+68 bottles of beer on the wall, 68 bottles of beer.
+Take one down and pass it around, 67 bottles of beer on the wall.
+
+67 bottles of beer on the wall, 67 bottles of beer.
+Take one down and pass it around, 66 bottles of beer on the wall.
+
+66 bottles of beer on the wall, 66 bottles of beer.
+Take one down and pass it around, 65 bottles of beer on the wall.
+
+65 bottles of beer on the wall, 65 bottles of beer.
+Take one down and pass it around, 64 bottles of beer on the wall.
+
+64 bottles of beer on the wall, 64 bottles of beer.
+Take one down and pass it around, 63 bottles of beer on the wall.
+
+63 bottles of beer on the wall, 63 bottles of beer.
+Take one down and pass it around, 62 bottles of beer on the wall.
+
+62 bottles of beer on the wall, 62 bottles of beer.
+Take one down and pass it around, 61 bottles of beer on the wall.
+
+61 bottles of beer on the wall, 61 bottles of beer.
+Take one down and pass it around, 60 bottles of beer on the wall.
+
+60 bottles of beer on the wall, 60 bottles of beer.
+Take one down and pass it around, 59 bottles of beer on the wall.
+
+59 bottles of beer on the wall, 59 bottles of beer.
+Take one down and pass it around, 58 bottles of beer on the wall.
+
+58 bottles of beer on the wall, 58 bottles of beer.
+Take one down and pass it around, 57 bottles of beer on the wall.
+
+57 bottles of beer on the wall, 57 bottles of beer.
+Take one down and pass it around, 56 bottles of beer on the wall.
+
+56 bottles of beer on the wall, 56 bottles of beer.
+Take one down and pass it around, 55 bottles of beer on the wall.
+
+55 bottles of beer on the wall, 55 bottles of beer.
+Take one down and pass it around, 54 bottles of beer on the wall.
+
+54 bottles of beer on the wall, 54 bottles of beer.
+Take one down and pass it around, 53 bottles of beer on the wall.
+
+53 bottles of beer on the wall, 53 bottles of beer.
+Take one down and pass it around, 52 bottles of beer on the wall.
+
+52 bottles of beer on the wall, 52 bottles of beer.
+Take one down and pass it around, 51 bottles of beer on the wall.
+
+51 bottles of beer on the wall, 51 bottles of beer.
+Take one down and pass it around, 50 bottles of beer on the wall.
+
+50 bottles of beer on the wall, 50 bottles of beer.
+Take one down and pass it around, 49 bottles of beer on the wall.
+
+49 bottles of beer on the wall, 49 bottles of beer.
+Take one down and pass it around, 48 bottles of beer on the wall.
+
+48 bottles of beer on the wall, 48 bottles of beer.
+Take one down and pass it around, 47 bottles of beer on the wall.
+
+47 bottles of beer on the wall, 47 bottles of beer.
+Take one down and pass it around, 46 bottles of beer on the wall.
+
+46 bottles of beer on the wall, 46 bottles of beer.
+Take one down and pass it around, 45 bottles of beer on the wall.
+
+45 bottles of beer on the wall, 45 bottles of beer.
+Take one down and pass it around, 44 bottles of beer on the wall.
+
+44 bottles of beer on the wall, 44 bottles of beer.
+Take one down and pass it around, 43 bottles of beer on the wall.
+
+43 bottles of beer on the wall, 43 bottles of beer.
+Take one down and pass it around, 42 bottles of beer on the wall.
+
+42 bottles of beer on the wall, 42 bottles of beer.
+Take one down and pass it around, 41 bottles of beer on the wall.
+
+41 bottles of beer on the wall, 41 bottles of beer.
+Take one down and pass it around, 40 bottles of beer on the wall.
+
+40 bottles of beer on the wall, 40 bottles of beer.
+Take one down and pass it around, 39 bottles of beer on the wall.
+
+39 bottles of beer on the wall, 39 bottles of beer.
+Take one down and pass it around, 38 bottles of beer on the wall.
+
+38 bottles of beer on the wall, 38 bottles of beer.
+Take one down and pass it around, 37 bottles of beer on the wall.
+
+37 bottles of beer on the wall, 37 bottles of beer.
+Take one down and pass it around, 36 bottles of beer on the wall.
+
+36 bottles of beer on the wall, 36 bottles of beer.
+Take one down and pass it around, 35 bottles of beer on the wall.
+
+35 bottles of beer on the wall, 35 bottles of beer.
+Take one down and pass it around, 34 bottles of beer on the wall.
+
+34 bottles of beer on the wall, 34 bottles of beer.
+Take one down and pass it around, 33 bottles of beer on the wall.
+
+33 bottles of beer on the wall, 33 bottles of beer.
+Take one down and pass it around, 32 bottles of beer on the wall.
+
+32 bottles of beer on the wall, 32 bottles of beer.
+Take one down and pass it around, 31 bottles of beer on the wall.
+
+31 bottles of beer on the wall, 31 bottles of beer.
+Take one down and pass it around, 30 bottles of beer on the wall.
+
+30 bottles of beer on the wall, 30 bottles of beer.
+Take one down and pass it around, 29 bottles of beer on the wall.
+
+29 bottles of beer on the wall, 29 bottles of beer.
+Take one down and pass it around, 28 bottles of beer on the wall.
+
+28 bottles of beer on the wall, 28 bottles of beer.
+Take one down and pass it around, 27 bottles of beer on the wall.
+
+27 bottles of beer on the wall, 27 bottles of beer.
+Take one down and pass it around, 26 bottles of beer on the wall.
+
+26 bottles of beer on the wall, 26 bottles of beer.
+Take one down and pass it around, 25 bottles of beer on the wall.
+
+25 bottles of beer on the wall, 25 bottles of beer.
+Take one down and pass it around, 24 bottles of beer on the wall.
+
+24 bottles of beer on the wall, 24 bottles of beer.
+Take one down and pass it around, 23 bottles of beer on the wall.
+
+23 bottles of beer on the wall, 23 bottles of beer.
+Take one down and pass it around, 22 bottles of beer on the wall.
+
+22 bottles of beer on the wall, 22 bottles of beer.
+Take one down and pass it around, 21 bottles of beer on the wall.
+
+21 bottles of beer on the wall, 21 bottles of beer.
+Take one down and pass it around, 20 bottles of beer on the wall.
+
+20 bottles of beer on the wall, 20 bottles of beer.
+Take one down and pass it around, 19 bottles of beer on the wall.
+
+19 bottles of beer on the wall, 19 bottles of beer.
+Take one down and pass it around, 18 bottles of beer on the wall.
+
+18 bottles of beer on the wall, 18 bottles of beer.
+Take one down and pass it around, 17 bottles of beer on the wall.
+
+17 bottles of beer on the wall, 17 bottles of beer.
+Take one down and pass it around, 16 bottles of beer on the wall.
+
+16 bottles of beer on the wall, 16 bottles of beer.
+Take one down and pass it around, 15 bottles of beer on the wall.
+
+15 bottles of beer on the wall, 15 bottles of beer.
+Take one down and pass it around, 14 bottles of beer on the wall.
+
+14 bottles of beer on the wall, 14 bottles of beer.
+Take one down and pass it around, 13 bottles of beer on the wall.
+
+13 bottles of beer on the wall, 13 bottles of beer.
+Take one down and pass it around, 12 bottles of beer on the wall.
+
+12 bottles of beer on the wall, 12 bottles of beer.
+Take one down and pass it around, 11 bottles of beer on the wall.
+
+11 bottles of beer on the wall, 11 bottles of beer.
+Take one down and pass it around, 10 bottles of beer on the wall.
+
+10 bottles of beer on the wall, 10 bottles of beer.
+Take one down and pass it around, 9 bottles of beer on the wall.
+
+9 bottles of beer on the wall, 9 bottles of beer.
+Take one down and pass it around, 8 bottles of beer on the wall.
+
+8 bottles of beer on the wall, 8 bottles of beer.
+Take one down and pass it around, 7 bottles of beer on the wall.
+
+7 bottles of beer on the wall, 7 bottles of beer.
+Take one down and pass it around, 6 bottles of beer on the wall.
+
+6 bottles of beer on the wall, 6 bottles of beer.
+Take one down and pass it around, 5 bottles of beer on the wall.
+
+5 bottles of beer on the wall, 5 bottles of beer.
+Take one down and pass it around, 4 bottles of beer on the wall.
+
+4 bottles of beer on the wall, 4 bottles of beer.
+Take one down and pass it around, 3 bottles of beer on the wall.
+
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 99 bottles of beer on the wall.
+```
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+* Remove as much duplication as you possibly can.
+* Optimize for readability, even if it means introducing duplication.
+* If you've removed all the duplication, do you have a lot of
+  conditionals? Try replacing the conditionals with polymorphism, if it
+  applies in this language. How readable is it?
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Hints
+- Try to capture the structure of the song in your code, where you build up the song by composing its parts.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Learn to Program by Chris Pine [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -1,0 +1,66 @@
+# Binary Search Tree
+
+Insert and search for numbers in a binary tree.
+
+When we need to represent sorted data, an array does not make a good
+data structure.
+
+Say we have the array `[1, 3, 4, 5]`, and we add 2 to it so it becomes
+`[1, 3, 4, 5, 2]` now we must sort the entire array again! We can
+improve on this by realizing that we only need to make space for the new
+item `[1, nil, 3, 4, 5]`, and then adding the item in the space we
+added. But this still requires us to shift many elements down by one.
+
+Binary Search Trees, however, can operate on sorted data much more
+efficiently.
+
+A binary search tree consists of a series of connected nodes. Each node
+contains a piece of data (e.g. the number 3), a variable named `left`,
+and a variable named `right`. The `left` and `right` variables point at
+`nil`, or other nodes. Since these other nodes in turn have other nodes
+beneath them, we say that the left and right variables are pointing at
+subtrees. All data in the left subtree is less than or equal to the
+current node's data, and all data in the right subtree is greater than
+the current node's data.
+
+For example, if we had a node containing the data 4, and we added the
+data 2, our tree would look like this:
+
+      4
+     /
+    2
+
+If we then added 6, it would look like this:
+
+      4
+     / \
+    2   6
+
+If we then added 3, it would look like this
+
+       4
+     /   \
+    2     6
+     \
+      3
+
+And if we then added 1, 5, and 7, it would look like this
+
+          4
+        /   \
+       /     \
+      2       6
+     / \     / \
+    1   3   5   7
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Josh Cheek [https://twitter.com/josh_cheek](https://twitter.com/josh_cheek)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -1,0 +1,47 @@
+# Binary Search
+
+Implement a binary search algorithm.
+
+Searching a sorted collection is a common task. A dictionary is a sorted
+list of word definitions. Given a word, one can find its definition. A
+telephone book is a sorted list of people's names, addresses, and
+telephone numbers. Knowing someone's name allows one to quickly find
+their telephone number and address.
+
+If the list to be searched contains more than a few items (a dozen, say)
+a binary search will require far fewer comparisons than a linear search,
+but it imposes the requirement that the list be sorted.
+
+In computer science, a binary search or half-interval search algorithm
+finds the position of a specified input value (the search "key") within
+an array sorted by key value.
+
+In each step, the algorithm compares the search key value with the key
+value of the middle element of the array.
+
+If the keys match, then a matching element has been found and its index,
+or position, is returned.
+
+Otherwise, if the search key is less than the middle element's key, then
+the algorithm repeats its action on the sub-array to the left of the
+middle element or, if the search key is greater, on the sub-array to the
+right.
+
+If the remaining array to be searched is empty, then the key cannot be
+found in the array and a special "not found" indication is returned.
+
+A binary search halves the number of items to check with each iteration,
+so locating an item (or determining its absence) takes logarithmic time.
+A binary search is a dichotomic divide and conquer search algorithm.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Binary_search_algorithm](http://en.wikipedia.org/wiki/Binary_search_algorithm)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -1,0 +1,24 @@
+# Bob
+
+Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+
+Bob answers 'Sure.' if you ask him a question.
+
+He answers 'Whoa, chill out!' if you yell at him.
+
+He says 'Fine. Be that way!' if you address him without actually saying
+anything.
+
+He answers 'Whatever.' to anything else.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -1,0 +1,80 @@
+# Book Store
+
+To try and encourage more sales of different books from a popular 5 book
+series, a bookshop has decided to offer discounts on multiple book purchases.
+
+One copy of any of the five books costs $8. 
+
+If, however, you buy two different books, you get a 5%
+discount on those two books.
+
+If you buy 3 different books, you get a 10% discount. 
+
+If you buy 4 different books, you get a 20% discount.
+
+If you buy all 5, you get a 25% discount. 
+
+Note: that if you buy four books, of which 3 are
+different titles, you get a 10% discount on the 3 that
+form part of a set, but the fourth book still costs $8. 
+
+Your mission is to write a piece of code to calculate the
+price of any conceivable shopping basket (containing only
+books of the same series), giving as big a discount as
+possible.
+
+For example, how much does this basket of books cost?
+
+- 2 copies of the first book
+- 2 copies of the second book
+- 2 copies of the third book
+- 1 copy of the fourth book
+- 1 copy of the fifth book
+ 
+One way of grouping these 8 books is:
+
+- 1 group of 5 --> 25% discount (1st,2nd,3rd,4th,5th)
+- +1 group of 3 --> 10% discount (1st,2nd,3rd)
+
+This would give a total of:
+
+- 5 books at a 25% discount
+- +3 books at a 10% discount
+
+Resulting in:
+
+- 5 x (8 - 2.00) == 5 x 6.00 == $30.00
+- +3 x (8 - 0.80) == 3 x 7.20 == $21.60
+
+For a total of $51.60
+
+However, a different way to group these 8 books is:
+
+- 1 group of 4 books --> 20% discount  (1st,2nd,3rd,4th)
+- +1 group of 4 books --> 20% discount  (1st,2nd,3rd,5th)
+
+This would give a total of:
+
+- 4 books at a 20% discount
+- +4 books at a 20% discount
+
+Resulting in:
+
+- 4 x (8 - 1.60) == 4 x 6.40 == $25.60
+- +4 x (8 - 1.60) == 4 x 6.40 == $25.60
+
+For a total of $51.20
+
+And $51.20 is the price with the biggest discount.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by the harry potter kata from Cyber-Dojo. [http://cyber-dojo.org](http://cyber-dojo.org)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -1,0 +1,59 @@
+# Bowling
+
+Score a bowling game.
+
+Bowling is game where players roll a heavy ball to knock down pins
+arranged in a triangle. Write code to keep track of the score
+of a game of bowling.
+
+## Scoring Bowling
+
+The game consists of 10 frames. A frame is composed of one or two ball throws with 10 pins standing at frame initialization. There are three cases for the tabulation of a frame.
+
+* An open frame is where a score of less than 10 is recorded for the frame. In this case the score for the frame is the number of pins knocked down.
+
+* A spare is where all ten pins are knocked down after the second throw. The total value of a spare is 10 plus the number of pins knocked down in their next throw.
+
+* A strike is where all ten pins are knocked down after the first throw. The total value of a strike is 10 plus the number of pins knocked down in their next two throws. If a strike is immediately followed by a second strike, then we can not total the value of first strike until they throw the ball one more time.
+
+Here is a three frame example:
+
+| Frame 1         | Frame 2       | Frame 3                |
+| :-------------: |:-------------:| :---------------------:|
+| X (strike)      | 5/ (spare)    | 9 0 (open frame)       |
+
+Frame 1 is (10 + 5 + 5) = 20
+
+Frame 2 is (5 + 5 + 9) = 19
+
+Frame 3 is (9 + 0) = 9
+
+This means the current running total is 48.
+
+The tenth frame in the game is a special case. If someone throws a strike or a spare then they get a fill ball. Fill balls exist to calculate the total of the 10th frame. Scoring a strike or spare on the fill ball does not give the player more fill balls. The total value of the 10th frame is the total number of pins knocked down.
+
+For a tenth frame of X1/ (strike and a spare), the total value is 20.
+
+For a tenth frame of XXX (three strikes), the total value is 30.
+
+## Requirements
+
+Write code to keep track of the score of a game of bowling. It should
+support two operations:
+
+* `roll(pins : int)` is called each time the player rolls a ball.  The
+  argument is the number of pins knocked down.
+* `score() : int` is called only at the very end of the game.  It
+  returns the total score for that game.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Bowling Game Kata at but UncleBob [http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata](http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -1,0 +1,16 @@
+# Bracket Push
+
+Given a string containing brackets `[]`, braces `{}` and parentheses `()`,
+verify that all the pairs are matched and nested correctly.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Ginna Baker
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -1,0 +1,29 @@
+# Change
+
+Correctly determine the fewest number of coins to be given to a customer such
+that the sum of the coins' value would equal the correct amount of change.
+
+## For example
+
+- An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5)
+  and one dime (10) or [0, 1, 1, 0, 0]
+- An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5)
+  and one dime (10) and one quarter (25) or [0, 1, 1, 1, 0]
+
+## Edge cases
+
+- Does your algorithm work for any given set of coins?
+- Can you ask for negative change?
+- Can you ask for a change value smaller than the smallest coin value?
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Software Craftsmanship - Kata-logue [http://craftsmanship.sv.cmu.edu/exercises/coin-change-kata](http://craftsmanship.sv.cmu.edu/exercises/coin-change-kata)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -1,0 +1,56 @@
+# Circular Buffer
+
+A circular buffer, cyclic buffer or ring buffer is a data structure that
+uses a single, fixed-size buffer as if it were connected end-to-end.
+
+A circular buffer first starts empty and of some predefined length. For
+example, this is a 7-element buffer:
+
+    [ ][ ][ ][ ][ ][ ][ ]
+
+Assume that a 1 is written into the middle of the buffer (exact starting
+location does not matter in a circular buffer):
+
+    [ ][ ][ ][1][ ][ ][ ]
+
+Then assume that two more elements are added — 2 & 3 — which get
+appended after the 1:
+
+    [ ][ ][ ][1][2][3][ ]
+
+If two elements are then removed from the buffer, the oldest values
+inside the buffer are removed. The two elements removed, in this case,
+are 1 & 2, leaving the buffer with just a 3:
+
+    [ ][ ][ ][ ][ ][3][ ]
+
+If the buffer has 7 elements then it is completely full:
+
+    [6][7][8][9][3][4][5]
+
+When the buffer is full an error will be raised, alerting the client
+that further writes are blocked until a slot becomes free.
+
+The client can opt to overwrite the oldest data with a forced write. In
+this case, two more elements — A & B — are added and they overwrite the
+3 & 4:
+
+    [6][7][8][9][A][B][5]
+
+Finally, if two elements are now removed then what would be returned is
+not 3 & 4 but 5 & 6 because A & B overwrote the 3 & the 4 yielding the
+buffer with:
+
+    [ ][7][8][9][A][B][ ]
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Circular_buffer](http://en.wikipedia.org/wiki/Circular_buffer)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -1,0 +1,25 @@
+# Clock
+
+Implement a clock that handles times without dates.
+
+You should be able to add and subtract minutes to it.
+
+Two clocks that represent the same time should be equal to each other.
+
+## Hints
+This exercise requires you to implements a type-specific method for determining equality of instances.
+For more information, see [this page]
+(https://docs.microsoft.com/en-us/dotnet/core/api/System.IEquatable-1) .
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Pairing session with Erin Drummond [https://twitter.com/ebdrummond](https://twitter.com/ebdrummond)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -1,0 +1,40 @@
+# Connect
+
+Compute the result for a game of Hex / Polygon.
+
+The abstract boardgame known as
+[Hex](https://en.wikipedia.org/wiki/Hex_%28board_game%29) / Polygon /
+CON-TAC-TIX is quite simple in rules, though complex in practice. Two players
+place stones on a rhombus with hexagonal fields. The player to connect his/her
+stones to the opposite side first wins. The four sides of the rhombus are
+divided between the two players (i.e. one player gets assigned a side and the
+side directly opposite it and the other player gets assigned the two other
+sides).
+
+Your goal is to build a program that given a simple representation of a board
+computes the winner (or lack thereof). Note that all games need not be "fair".
+(For example, players may have mismatched piece counts.)
+
+The boards look like this (with spaces added for readability, which won't be in
+the representation passed to your code):
+
+```        
+. O . X .
+ . X X O .
+  O O O X .
+   . X O X O
+    X O O O X
+```
+
+"Player `O`" plays from top to bottom, "Player `X`" plays from left to right. In
+the above example `O` has made a connection from left to right but nobody has
+won since `O` didn't connect top and bottom.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -1,0 +1,80 @@
+# Crypto Square
+
+Implement the classic method for composing secret messages called a square code.
+
+Given an English text, output the encoded version of that text.
+
+First, the input is normalized: the spaces and punctuation are removed
+from the English text and the message is downcased.
+
+Then, the normalized characters are broken into rows.  These rows can be
+regarded as forming a rectangle when printed with intervening newlines.
+
+For example, the sentence
+
+> If man was meant to stay on the ground, god would have given us roots.
+
+is normalized to:
+
+> ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots
+
+The plaintext should be organized in to a rectangle.  The size of the
+rectangle (`r x c`) should be decided by the length of the message,
+such that `c >= r` and `c - r <= 1`, where `c` is the number of columns
+and `r` is the number of rows.
+
+Our normalized text is 54 characters long, dictating a rectangle with
+`c = 8` and `r = 7`:
+
+```plain
+ifmanwas
+meanttos
+tayonthe
+groundgo
+dwouldha
+vegivenu
+sroots
+```
+
+The coded message is obtained by reading down the columns going left to
+right.
+
+The message above is coded as:
+
+```plain
+imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
+```
+
+Output the encoded text in chunks.  Phrases that fill perfect squares
+`(r X r)` should be output in `r`-length chunks separated by spaces.
+Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
+
+```plain
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau
+```
+
+Notice that were we to stack these, we could visually decode the
+cyphertext back in to the original message:
+
+```plain
+imtgdvs
+fearwer
+mayoogo
+anouuio
+ntnnlvt
+wttddes
+aohghn
+sseoau
+```
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -1,0 +1,23 @@
+# Custom Set
+
+Create a custom set type.
+
+Sometimes it is necessary to define a custom data structure of some
+type, like a set. In this exercise you will define your own set. How it
+works internally doesn't matter, as long as it behaves like a set of
+unique elements.
+
+## Hints
+This exercise requires you to implements a type-specific method for determining equality of instances.
+For more information, see [this page]
+(https://docs.microsoft.com/en-us/dotnet/core/api/System.IEquatable-1) .
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -1,0 +1,75 @@
+# Diamond
+
+The diamond kata takes as its input a letter, and outputs it in a diamond 
+shape. Given a letter, it prints a diamond starting with 'A', with the 
+supplied letter at the widest point.
+
+## Requirements
+
+* The first row contains one 'A'.
+* The last row contains one 'A'.
+* All rows, except the first and last, have exactly two identical letters.
+* All rows have as many trailing spaces as leading spaces. (This might be 0).
+* The diamond is horizontally symmetric.
+* The diamond is vertically symmetric.
+* The diamond has a square shape (width equals height).
+* The letters form a diamond shape.
+* The top half has the letters in ascending order.
+* The bottom half has the letters in descending order. 
+* The four corners (containing the spaces) are triangles.
+
+## Examples
+
+In the following examples, spaces are indicated by `·` characters.
+
+Diamond for letter 'A':
+
+```plain
+A
+```
+
+Diamond for letter 'C':
+
+```plain
+··A··
+·B·B·
+C···C
+·B·B·
+··A··
+```
+
+Diamond for letter 'E':
+
+```plain
+····A····
+···B·B···
+··C···C··
+·D·····D·
+E·······E
+·D·····D·
+··C···C··
+···B·B···
+····A····
+```
+
+## Hints
+The tests in this exercise are different from your usual tests. Normally, a test checks if for a given input, the output matches the expected value. This is called *value-based testing*. However, this exercise uses *property-based testing*, where the tests check if for a range of inputs, the output has a specific property. The two key differences that differentiate property-based testing from value-based testing are:
+
+1. A property-based test works not with a single input value, but with many.
+1. A property-based test verifies properties, not concrete values.
+
+For this exercise, the tests all verify a property of the diamond shape your code should be producing. Furthermore, all tests check if the property they test holds for all valid input letters ('A' to 'Z').
+
+For more information on property-based testing, see [this article](http://www.erikschierboom.com/2016/02/22/property-based-testing/).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Seb Rose [http://claysnow.co.uk/recycling-tests-in-tdd/](http://claysnow.co.uk/recycling-tests-in-tdd/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -1,0 +1,30 @@
+# Difference Of Squares
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first
+ten natural numbers and the sum of the squares of the first ten
+natural numbers is 3025 - 385 = 2640.
+
+## Hints
+This exercise requires you to process a collection of data. You can simplify your code by using LINQ (Language Integrated Query).
+For more information, see [this page]
+(https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -1,0 +1,55 @@
+# Diffie Hellman
+
+Diffie-Hellman key exchange.
+
+Alice and Bob use Diffie-Hellman key exchange to share secrets.  They
+start with prime numbers, pick private keys, generate and share public
+keys, and then generate a shared secret key.
+
+## Step 0
+
+The test program supplies prime numbers p and g.
+
+## Step 1
+
+Alice picks a private key, a, greater than 1 and less than p.  Bob does
+the same to pick a private key b.
+
+## Step 2
+
+Alice calculates a public key A.
+
+    A = g**a mod p
+
+Using the same p and g, Bob similarly calculates a public key B from his
+private key b.
+
+## Step 3
+
+Alice and Bob exchange public keys.  Alice calculates secret key s.
+
+    s = B**a mod p
+
+Bob calculates
+
+    s = A**b mod p
+
+The calculations produce the same result!  Alice and Bob now share
+secret s.
+
+## Hints
+This exercise requires you to perform calculations on large numbers. To correctly represent large numbers, the
+[BigInteger](https://msdn.microsoft.com/en-us/library/system.numerics.biginteger(v=vs.110).aspx) struct is used.
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia, 1024 bit key from www.cryptopp.com/wiki. [http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange](http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -1,0 +1,24 @@
+# Dominoes
+
+Make a chain of dominoes.
+
+Compute a way to order a given set of dominoes in such a way that they form a
+correct domino chain (the dots on one half of a stone match the dots on the
+neighbouring half of an adjacent stone) and that dots on the halfs of the stones
+which don't have a neighbour (the first and last stone) match each other.
+
+For example given the stones `21`, `23` and `13` you should compute something
+like `12 23 31` or `32 21 13` or `13 32 21` etc, where the first and last numbers are the same.
+
+For stones 12, 41 and 23 the resulting chain is not valid: 41 12 23's first and last numbers are not the same. 4 != 3
+
+Some test cases may use duplicate stones in a chain solution, assume that multiple Domino sets are being used.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -1,0 +1,37 @@
+# Dot Dsl
+
+Write a Domain Specific Language similar to the Graphviz dot language.
+
+A [Domain Specific Language
+(DSL)](https://en.wikipedia.org/wiki/Domain-specific_language) is a
+small language optimized for a specific domain.
+
+For example the dot language of [Graphviz](http://graphviz.org) allows
+you to write a textual description of a graph which is then transformed
+into a picture by one of the graphviz tools (such as `dot`). A simple
+graph looks like this:
+
+    graph {
+        graph [bgcolor="yellow"]
+        a [color="red"]
+        b [color="blue"]
+        a -- b [color="green"]
+    }
+
+Putting this in a file `example.dot` and running `dot example.dot -T png
+-o example.png` creates an image `example.png` with red and blue circle
+connected by a green line on a yellow background.
+
+Create a DSL similar to the dot language.
+
+## Hints
+This exercise requires you to implement classes with a custom equality check. For more information, see [this page](https://msdn.microsoft.com/en-us/library/bsc2ak47(v=vs.110).aspx).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -1,0 +1,19 @@
+# Error Handling
+
+Implement various kinds of error handling and resource management.
+
+An important point of programming is how to handle errors and close
+resources even if errors occur.
+
+This exercise requires you to handle various errors. Because error handling
+is rather programming language specific you'll have to refer to the tests
+for your track to see what's exactly required.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,0 +1,57 @@
+# Etl
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+### ETL
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
+
+### The goal
+We're going to extract some scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data
+format to the shiny new format.
+
+### Notes
+
+A final note about scoring, Scrabble is played around the world in a
+variety of languages, each with its own unique scoring table. For
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -1,0 +1,24 @@
+# Flatten Array
+
+Take a nested list and return a single flattened list with all values except nil/null.
+
+The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+ 
+For Example
+
+input: [1,[2,3,null,4],[null],5]
+
+output: [1,2,3,4,5]
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Interview Question [https://reference.wolfram.com/language/ref/Flatten.html](https://reference.wolfram.com/language/ref/Flatten.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -1,0 +1,80 @@
+# Food Chain
+
+Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'.
+
+While you could copy/paste the lyrics,
+or read them from a file, this problem is much more
+interesting if you approach it algorithmically.
+
+This is a [cumulative song](http://en.wikipedia.org/wiki/Cumulative_song) of unknown origin.
+
+This is one of many common variants.
+
+```plain
+I know an old lady who swallowed a fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a spider.
+It wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a bird.
+How absurd to swallow a bird!
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a cat.
+Imagine that, to swallow a cat!
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a dog.
+What a hog, to swallow a dog!
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a goat.
+Just opened her throat and swallowed a goat!
+She swallowed the goat to catch the dog.
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a cow.
+I don't know how she swallowed a cow!
+She swallowed the cow to catch the goat.
+She swallowed the goat to catch the dog.
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a horse.
+She's dead, of course!
+```
+
+## Hints
+- Try to capture the structure of the song in your code, where you build up the song by composing its parts.
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly](http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -1,0 +1,39 @@
+# Forth
+
+Implement an evaluator for a very simple subset of Forth.
+
+[Forth](https://en.wikipedia.org/wiki/Forth_%28programming_language%29)
+is a stack-based programming language. Implement a very basic evaluator
+for a small subset of Forth.
+
+Your evaluator has to support the following words:
+
+- `+`, `-`, `*`, `/` (integer arithmetic)
+- `DUP`, `DROP`, `SWAP`, `OVER` (stack manipulation)
+
+Your evaluator also has to support defining new words using the
+customary syntax: `: word-name definition ;`.
+
+To keep things simple the only data type you need to support is signed
+integers of at least 16 bits size.
+
+You should use the following rules for the syntax: a number is a
+sequence of one or more (ASCII) digits, a word is a sequence of one or
+more letters, digits, symbols or punctuation that is not a number.
+(Forth probably uses slightly different rules, but this is close
+enough.)
+
+Words are case-insensitive.
+
+## Hints
+- To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/).
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -1,0 +1,17 @@
+# Gigasecond
+
+Calculate the moment when someone has lived for 10^9 seconds.
+
+A gigasecond is 10^9 (1,000,000,000) seconds.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/go-counting/README.md
+++ b/exercises/go-counting/README.md
@@ -1,0 +1,43 @@
+# Go Counting
+
+Count the scored points on a Go board.
+
+In the game of go (also known as baduk, igo, cờ vây and wéiqí) points
+are gained by completely encircling empty intersections with your
+stones. The encircled intersections of a player are known as its
+territory.
+
+Write a function that determines the territory of each player. You may
+assume that any stones that have been stranded in enemy territory have
+already been taken off the board.
+
+Multiple empty intersections may be encircled at once and for encircling
+only horizontal and vertical neighbours count. In the following diagram
+the stones which matter are marked "O" and the stones that don't are
+marked "I" (ignored).  Empty spaces represent empty intersections.
+
+```
++----+
+|IOOI|
+|O  O|
+|O OI|
+|IOI |
++----+
+```
+
+To be more precise an empty intersection is part of a player's territory
+if all of its neighbours are either stones of that player or empty
+intersections that are part of that player's territory.
+
+For more information see
+[wikipedia](https://en.wikipedia.org/wiki/Go_%28game%29) or [Sensei's
+Library](http://senseis.xmp.net/).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -1,0 +1,48 @@
+# Grade School
+
+Given students' names along with the grade that they are in, create a roster
+for the school.
+
+In the end, you should be able to:
+
+- Add a student's name to the roster for a grade
+  - "Add Jim to grade 2."
+  - "OK."
+- Get a list of all students enrolled in a grade
+  - "Which students are in grade 2?"
+  - "We've only got Jim just now."
+- Get a sorted list of all students in all grades.  Grades should sort
+  as 1, 2, 3, etc., and students within a grade should be sorted
+  alphabetically by name.
+  - "Who all is enrolled in school right now?"
+  - "Grade 1: Anna, Barb, and Charlie. Grade 2: Alex, Peter, and Zoe.
+    Grade 3…"
+
+Note that all our students only have one name.  (It's a small town, what
+do you want?)
+
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- If you're working in a language with mutable data structures and your
+  implementation allows outside code to mutate the school's internal DB
+  directly, see if you can prevent this. Feel free to introduce additional
+  tests.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A pairing session with Phil Battos at gSchool [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -1,0 +1,40 @@
+# Grains
+
+Calculate the number of grains of wheat on a chessboard given that the number
+on each square doubles.
+
+There once was a wise servant who saved the life of a prince. The king
+promised to pay whatever the servant could dream up. Knowing that the
+king loved chess, the servant told the king he would like to have grains
+of wheat. One grain on the first square of a chess board. Two grains on
+the next. Four on the third, and so on.
+
+There are 64 squares on a chessboard.
+
+Write code that shows:
+- how many grains were on each square, and
+- the total number of grains
+
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- Optimize for speed.
+- Optimize for readability.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+JavaRanch Cattle Drive, exercise 6 [http://www.javaranch.com/grains.jsp](http://www.javaranch.com/grains.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -1,0 +1,77 @@
+# Grep
+
+Search a file for lines matching a regular expression pattern. Return the line
+number and contents of each matching line.
+
+The Unix [`grep`](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html) command can be used to search for lines in one or more files 
+that match a user-provided search query (known as the *pattern*).
+
+The `grep` command takes three arguments:
+
+1. The pattern used to match lines in a file. 
+2. Zero or more flags to customize the matching behavior.
+3. One or more files in which to search for matching lines. 
+
+Your task is to implement the `grep` function, which should read the contents
+of the specified files, find the lines that match the specified pattern
+and then output those lines as a single string. Note that the lines should
+be output in the order in which they were found, with the first matching line
+in the first file being output first.
+
+As an example, suppose there is a file named "input.txt" with the following contents:
+
+<pre>
+hello
+world
+hello again
+</pre>
+
+If we were to call `grep "hello" input.txt`, the returned string should be:
+
+<pre>
+hello
+hello again
+</pre>
+
+### Flags
+
+As said earlier, the `grep` command should also support the following flags:
+
+- `-n` Print the line numbers of each matching line.
+- `-l` Print only the names of files that contain at least one matching line.
+- `-i` Match line using a case-insensitive comparison.
+- `-v` Invert the program -- collect all lines that fail to match the pattern.
+- `-x` Only match entire lines, instead of lines that contain a match.
+
+If we run `grep -n "hello" input.txt`, the `-n` flag will require the matching
+lines to be prefixed with its line number:
+
+<pre>
+1:hello
+3:hello again
+</pre>
+
+And if we run `grep -i "HELLO" input.txt`, we'll do a case-insensitive match, 
+and the output will be:
+
+<pre>
+hello
+hello again
+</pre>
+
+The `grep` command should support multiple flags at once.
+
+For example, running `grep -l -v "hello" file1.txt file2.txt` should
+print the names of files that do not contain the string "hello".
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Conversation with Nate Foster. [http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf](http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -1,0 +1,48 @@
+# Hamming
+
+Calculate the Hamming difference between two DNA strands.
+
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
+
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
+
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
+
+This is called the 'Hamming distance'.
+
+It is found by comparing two DNA strands and counting how many of the
+nucleotides are different from their equivalent in the other string.
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+The Hamming distance between these two DNA strands is 7.
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length. This means
+that based on the definition, each language could deal with getting sequences
+of equal length differently.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hangman/README.md
+++ b/exercises/hangman/README.md
@@ -1,0 +1,32 @@
+# Hangman
+
+Implement the logic of the hangman game using functional reactive programming.
+
+[Hangman][] is a simple word guessing game.
+
+[Functional Reactive Programming][frp] is a way to write interactive
+programs. It differs from the usual perspective in that instead of
+saying "when the button is pressed increment the counter", you write
+"the value of the counter is the sum of the number of times the button
+is pressed."
+
+Implement the basic logic behind hangman using functional reactive
+programming.  You'll need to install an FRP library for this, this will
+be described in the language/track specific files of the exercise.
+
+[Hangman]: https://en.wikipedia.org/wiki/Hangman_%28game%29
+[frp]: https://en.wikipedia.org/wiki/Functional_reactive_programming
+
+## Hints
+This exercise requires you to work with events. For more information, see [this page]
+(https://docs.microsoft.com/en-us/dotnet/articles/csharp/programming-guide/events/) .
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,0 +1,27 @@
+# Hello World
+
+The classical introductory exercise. Just say "Hello, World!".
+
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
+
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -1,0 +1,123 @@
+# House
+
+Output the nursery rhyme 'This is the House that Jack Built'.
+
+> [The] process of placing a phrase of clause within another phrase of
+> clause is called embedding. It is through the processes of recursion
+> and embedding that we are able to take a finite number of forms (words
+> and phrases) and construct an infinite number of expressions.
+> Furthermore, embedding also allows us to construct an infinitely long
+> structure, in theory anyway.
+
+- [papyr.com](http://papyr.com/hypertextbooks/grammar/ph_noun.htm)
+
+
+The nursery rhyme reads as follows:
+
+```plain
+This is the house that Jack built.
+
+This is the malt
+that lay in the house that Jack built.
+
+This is the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the farmer sowing his corn
+that kept the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the horse and the hound and the horn
+that belonged to the farmer sowing his corn
+that kept the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+```
+
+## Hints
+
+Try to capture the structure of the song in your code, where you build up the song by composing its parts.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+British nursery rhyme [http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built](http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -1,0 +1,25 @@
+# Isogram
+
+Determine if a word or phrase is an isogram.
+
+An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter.
+
+Examples of isograms:
+
+- lumberjacks
+- background
+- downstream
+
+The word *isograms*, however, is not an isogram, because the s repeats.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Isogram](https://en.wikipedia.org/wiki/Isogram)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -1,0 +1,72 @@
+# Kindergarten Garden
+
+Given a diagram, determine which plants each child in the kindergarten class is
+responsible for.
+
+The kindergarten class is learning about growing plants. The teachers
+thought it would be a good idea to give them actual seeds, plant them in
+actual dirt, and grow actual plants.
+
+They've chosen to grow grass, clover, radishes, and violets.
+
+To this end, they've put little styrofoam cups along the window sills,
+and planted one type of plant in each cup, choosing randomly from the
+available types of seeds.
+
+```plain
+[window][window][window]
+........................ # each dot represents a styrofoam cup
+........................
+```
+
+There are 12 children in the class:
+
+- Alice, Bob, Charlie, David,
+- Eve, Fred, Ginny, Harriet,
+- Ileana, Joseph, Kincaid, and Larry.
+
+Each child gets 4 cups, two on each row. The children are assigned to
+cups in alphabetical order.
+
+The following diagram represents Alice's plants:
+
+```plain
+[window][window][window]
+VR......................
+RG......................
+```
+
+So in the row nearest the window, she has a violet and a radish; in the
+row behind that, she has a radish and some grass.
+
+Your program will be given the plants from left-to-right starting with
+the row nearest the windows. From this, it should be able to determine
+which plants belong to which students.
+
+For example, if it's told that the garden looks like so:
+
+```plain
+[window][window][window]
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+```
+
+Then if asked for Alice's plants, it should provide:
+
+- Violets, radishes, violets, radishes
+
+While asking for Bob's plants would yield:
+
+- Clover, grass, clover, clover
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Random musings during airplane trip. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -1,0 +1,26 @@
+# Largest Series Product
+
+Given a string of digits, calculate the largest product for a contiguous
+substring of digits of length n.
+
+For example, for the input `'1027839564'`, the largest product for a
+series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
+series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+For the input `'73167176531330624919225119674426574742355349194934'`,
+the largest product for a series of 6 digits is 23520.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -1,0 +1,39 @@
+# Leap
+
+Given a year, report if it is a leap year.
+
+The tricky thing here is that a leap year in the Gregorian calendar occurs:
+
+```plain
+on every year that is evenly divisible by 4
+  except every year that is evenly divisible by 100
+    unless the year is also evenly divisible by 400
+```
+
+For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
+year, but 2000 is.
+
+If your language provides a method in the standard library that does
+this look-up, pretend it doesn't exist and implement it yourself.
+
+## Notes
+
+Though our exercise adopts some very simple rules, there is more to
+learn!
+
+For a delightful, four minute explanation of the whole leap year
+phenomenon, go watch [this youtube video][video].
+
+[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/ledger/README.md
+++ b/exercises/ledger/README.md
@@ -1,0 +1,24 @@
+# Ledger
+
+Refactor a ledger printer.
+
+The ledger exercise is a refactoring exercise. There is code that prints a
+nicely formatted ledger, given a locale (American or Dutch) and a currency (US
+dollar or euro). The code however is rather badly written, though (somewhat
+surprisingly) it consistently passes the test suite.
+
+Rewrite this code. Remember that in refactoring the trick is to make small steps
+that keep the tests passing. That way you can always quickly go back to a
+working version.  Version control tools like git can help here as well.
+
+Please keep a log of what changes you've made and make a comment on the exercise
+containing that log, this will help reviewers.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -1,0 +1,40 @@
+# Linked List
+
+Implement a doubly linked list.
+
+Like an array, a linked list is a simple linear data structure. Several 
+common data types can be implemented using linked lists, like queues, 
+stacks, and associative arrays.
+
+A linked list is a collection of data elements called *nodes*. In a 
+*singly linked list* each node holds a value and a link to the next node. 
+In a *doubly linked list* each node also holds a link to the previous 
+node.
+
+You will write an implementation of a doubly linked list. Implement a 
+Node to hold a value and pointers to the next and previous nodes. Then 
+implement a List which holds references to the first and last node and 
+offers an array-like interface for adding and removing items:
+
+* `push` (*insert value at back*);
+* `pop` (*remove value at back*);
+* `shift` (*remove value at front*).
+* `unshift` (*insert value at front*);
+
+To keep your implementation simple, the tests will not cover error 
+conditions. Specifically: `pop` or `shift` will never be called on an 
+empty list.
+
+If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Classic computer science topic
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -1,0 +1,19 @@
+# List Ops
+
+Implement basic list operations.
+
+In functional languages list operations like `length`, `map`, and
+`reduce` are very common. Implement a series of basic list operations,
+without using existing functions.
+
+## Hints
+The `Foldl` and `Foldr` methods are "fold" functions, which is a concept well-known in the functional programming world, but less so in the object-oriented one. If you'd like more background information, check out this [fold](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) page.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -1,0 +1,77 @@
+# Luhn
+
+Given a number determine whether or not it is valid per the Luhn formula.
+
+The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is
+a simple checksum formula used to validate a variety of identification
+numbers, such as credit card numbers and Canadian Social Insurance
+Numbers.
+
+The task is to check if a given string is valid.
+
+Validating a Number
+------
+
+Strings of length 1 or less are not valid. Spaces are allowed in the input,
+but they should be stripped before checking. All other non-digit characters
+are disallowed.
+
+## Example 1: valid credit card number
+
+```
+4539 1488 0343 6467
+```
+
+The first step of the Luhn algorithm is to double every second digit,
+starting from the right. We will be doubling
+
+```
+4_3_ 1_8_ 0_4_ 6_6_
+```
+
+If doubling the number results in a number greater than 9 then subtract 9
+from the product. The results of our doubling:
+
+```
+8569 2478 0383 3437
+```
+
+Then sum all of the digits:
+
+```
+8+5+6+9+2+4+7+8+0+3+8+3+3+4+3+7 = 80
+```
+
+If the sum is evenly divisible by 10, then the number is valid. This number is valid!
+
+## Example 2: invalid credit card number
+
+```
+8273 1232 7352 0569
+```
+
+Double the second digits, starting from the right
+
+```
+7253 2262 5312 0539
+```
+
+Sum the digits
+
+```
+7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
+```
+
+57 is not evenly divisible by 10, so this number is not valid.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Luhn Algorithm on Wikipedia [http://en.wikipedia.org/wiki/Luhn_algorithm](http://en.wikipedia.org/wiki/Luhn_algorithm)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -1,0 +1,28 @@
+# Markdown
+
+Refactor a Markdown parser.
+
+The markdown exercise is a refactoring exercise. There is code that parses a
+given string with [Markdown
+syntax](https://guides.github.com/features/mastering-markdown/) and returns the
+associated HTML for that string. Even though this code is confusingly written
+and hard to follow, somehow it works and all the tests are passing! Your
+challenge is to re-write this code to make it easier to read and maintain
+while still making sure that all the tests keep passing.
+
+It would be helpful if you made notes of what you did in your refactoring in
+comments so reviewers can see that, but it isn't strictly necessary. The most
+important thing is to make the code better!
+
+## Hints
+For this exercise the following C# feature comes in handy:
+- [String Interpolation](https://msdn.microsoft.com/en-us/library/dn961160.aspx) (C# 6 and up).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -1,0 +1,51 @@
+# Matrix
+
+Given a string representing a matrix of numbers, return the rows and columns of
+that matrix.
+
+So given a string with embedded newlines like:
+
+> 9 8 7  
+> 5 3 2  
+> 6 6 7  
+
+representing this matrix:
+
+```plain
+    0  1  2
+  |---------
+0 | 9  8  7
+1 | 5  3  2
+2 | 6  6  7
+```
+
+your code should be able to spit out:
+
+- A list of the rows, reading each row left-to-right while moving
+  top-to-bottom across the rows,
+- A list of the columns, reading each column top-to-bottom while moving
+  from left-to-right.
+
+The rows for our example matrix:
+
+- 9, 8, 7
+- 5, 3, 2
+- 6, 6, 7
+
+And its columns:
+
+- 9, 5, 6
+- 8, 3, 6
+- 7, 2, 7
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Warmup to the `saddle-points` warmup. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -1,0 +1,36 @@
+# Meetup
+
+Calculate the date of meetups.
+
+Typically meetups happen on the same day of the week.  In this exercise, you will take
+a description of a meetup date, and return the actual meetup date.
+
+Examples of general descriptions are:
+
+- the first Monday of January 2017
+- the third Tuesday of January 2017
+- the Wednesteenth of January 2017
+- the last Thursday of January 2017
+
+Note that "Monteenth", "Tuesteenth", etc are all made up words. There
+was a meetup whose members realized that there are exactly 7 numbered days in a month that
+end in '-teenth'. Therefore, one is guaranteed that each day of the week
+(Monday, Tuesday, ...) will have exactly one date that is named with '-teenth'
+in every month.
+
+Given examples of a meetup dates, each containing a month, day, year, and descriptor 
+(first, second, teenth, etc), calculate the date of the actual meetup.
+For example, if given "First Monday of January 2017", the correct meetup date is 2017/1/2
+ 
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month [https://twitter.com/copiousfreetime](https://twitter.com/copiousfreetime)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -1,0 +1,36 @@
+# Minesweeper
+
+Add the numbers to a minesweeper board.
+
+Minesweeper is a popular game where the user has to find the mines using
+numeric hints that indicate how many mines are directly adjacent
+(horizontally, vertically, diagonally) to a square.
+
+In this exercise you have to create some code that counts the number of
+mines adjacent to a square and transforms boards like this (where `*`
+indicates a mine):
+
+    +-----+
+    | * * |
+    |  *  |
+    |  *  |
+    |     |
+    +-----+
+
+into this:
+
+    +-----+
+    |1*3*1|
+    |13*31|
+    | 2*2 |
+    | 111 |
+    +-----+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -1,0 +1,29 @@
+# Nth Prime
+
+Given a number n, determine what the nth prime is.
+
+By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that
+the 6th prime is 13.
+
+If your language provides methods in the standard library to deal with prime
+numbers, pretend they don't exist and implement them yourself.
+
+## Hints
+
+For this exercise the following C# feature comes in handy: 
+Enumerables are evaluated lazily.    They allow you to work with an infinite sequence of values.
+See [this article](https://blogs.msdn.microsoft.com/pedram/2007/06/02/lazy-evaluation-in-c/).
+
+Note: to help speedup calculation, you should not check numbers which you know beforehand will never be prime. For more information, see the [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A variation on Problem 7 at Project Euler [http://projecteuler.net/problem=7](http://projecteuler.net/problem=7)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,0 +1,43 @@
+# Nucleotide Count
+
+Given a DNA string, compute how many times each nucleotide occurs in the string.
+
+DNA is represented by an alphabet of the following symbols: 'A', 'C',
+'G', and 'T'.
+
+Each symbol represents a nucleotide, which is a fancy name for the
+particular molecules that happen to make up a large part of DNA.
+
+Shortest intro to biochemistry EVAR:
+
+- twigs are to birds nests as
+- nucleotides are to DNA and RNA as
+- amino acids are to proteins as
+- sugar is to starch as
+- oh crap lipids
+
+I'm not going to talk about lipids because they're crazy complex.
+
+So back to nucleotides.
+
+DNA contains four types of them: adenine (`A`), cytosine (`C`), guanine
+(`G`), and thymine (`T`).
+
+RNA contains a slightly different set of nucleotides, but we don't care
+about that for now.
+
+## Hints
+This exercise requires the use of a Dictionary. For more information see 
+[this page.](https://msdn.microsoft.com/en-us/library/s4ys34ea(v=vs.110).aspx)
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -1,0 +1,91 @@
+# Ocr Numbers
+
+Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is
+represented, or whether it is garbled.
+
+# Step One
+
+To begin with, convert a simple binary font to a string containing 0 or 1.
+
+The binary font uses pipes and underscores, four rows high and three columns wide.
+
+```
+     _   #
+    | |  # zero.
+    |_|  #
+         # the fourth row is always blank
+```
+
+Is converted to "0"
+
+```
+         #
+      |  # one.
+      |  #
+         # (blank fourth row)
+```
+
+Is converted to "1"
+
+If the input is the correct size, but not recognizable, your program should return '?'
+
+If the input is the incorrect size, your program should return an error.
+
+# Step Two
+
+Update your program to recognize multi-character binary strings, replacing garbled numbers with ?
+
+# Step Three
+
+Update your program to recognize all numbers 0 through 9, both individually and as part of a larger string.
+
+```
+ _ 
+ _|
+|_ 
+   
+```
+
+Is converted to "2"
+
+```
+      _  _     _  _  _  _  _  _  #
+    | _| _||_||_ |_   ||_||_|| | # decimal numbers.
+    ||_  _|  | _||_|  ||_| _||_| #
+                                 # fourth line is always blank
+```
+
+Is converted to "1234567890"
+
+# Step Four
+
+Update your program to handle multiple numbers, one per line. When converting several lines, join the lines with commas.
+
+```
+    _  _ 
+  | _| _|
+  ||_  _|
+         
+    _  _ 
+|_||_ |_ 
+  | _||_|
+         
+ _  _  _ 
+  ||_||_|
+  ||_| _|
+         
+```
+
+Is converted to "123,456,789"
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by the Bank OCR kata [http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR](http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -1,0 +1,51 @@
+# Palindrome Products
+
+Detect palindrome products in a given range.
+
+A palindromic number is a number that remains the same when its digits are
+reversed. For example, `121` is a palindromic number but `112` is not.
+
+Given the definition of a palindromic number, we define a palindrome _product_
+to be the product `c`, such that `a * b = c`, where `c` is a palindromic number and
+ `a` and `b` are integers (possibly, but _not_ necessarily palindromic numbers).
+
+For example, the palindromic number 9009 can be written as the palindrome
+product: `91 * 99 = 9009`.
+
+It's possible (and indeed common) for a palindrome product to be the product
+of multiple combinations of numbers. For example, the palindrome product `9` has
+the factors `(1, 9)`, `(3, 3)`, and `(9, 1)`.
+
+Write a program that given a range of integers, returns the smallest and largest
+palindromic product within that range, along with all of it's factors.
+
+## Example 1
+
+Given the range `[1, 9]` (both inclusive)...
+
+The smallest product is `1`. It's factors are `(1, 1)`.
+The largest product is `9`. It's factors are `(1, 9)`, `(3, 3)`, and `(9, 1)`.
+
+## Example 2
+
+Given the range `[10, 99]` (both inclusive)...
+
+The smallest palindrome product is `121`. It's factors are `(11, 11)`.
+The largest palindrome product is `9009`. It's factors are `(91, 99)` and `(99, 91)`.
+
+## Hints
+
+For this exercise, you will need to create a set of factors using tuples.
+For more information on tuples, see [this link](https://msdn.microsoft.com/en-us/library/system.tuple(v=vs.110).aspx).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Problem 4 at Project Euler [http://projecteuler.net/problem=4](http://projecteuler.net/problem=4)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -1,0 +1,21 @@
+# Pangram
+
+Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
+"every letter") is a sentence using every letter of the alphabet at least once.
+The best known English pangram is: 
+> The quick brown fox jumps over the lazy dog.
+
+The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
+insensitive. Input will not contain non-ASCII symbols.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Pangram](https://en.wikipedia.org/wiki/Pangram)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -1,0 +1,17 @@
+# Parallel Letter Frequency
+
+Count the frequency of letters in texts using parallel computation.
+
+Parallelism is about doing things in parallel that can also be done
+sequentially. A common example is counting the frequency of letters.
+Create a function that returns the total frequency of each letter in a
+list of texts and that employs parallelism.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -1,0 +1,27 @@
+# Pascals Triangle
+
+Compute Pascal's triangle up to a given number of rows.
+
+In Pascal's Triangle each number is computed by adding the numbers to
+the right and left of the current position in the previous row.
+
+```plain
+    1
+   1 1
+  1 2 1
+ 1 3 3 1
+1 4 6 4 1
+# ... etc
+```
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Pascal's Triangle at Wolfram Math World [http://mathworld.wolfram.com/PascalsTriangle.html](http://mathworld.wolfram.com/PascalsTriangle.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -1,0 +1,30 @@
+# Perfect Numbers
+
+Determine if a number is perfect, abundant, or deficient based on
+Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
+
+The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
+
+- **Perfect**: aliquot sum = number 
+  - 6 is a perfect number because (1 + 2 + 3) = 6
+  - 28 is a perfect number because (1 + 2 + 4 + 7 + 14) = 28
+- **Abundant**: aliquot sum > number
+  - 12 is an abundant number because (1 + 2 + 3 + 4 + 6) = 16
+  - 24 is an abundant number because (1 + 2 + 3 + 4 + 6 + 8 + 12) = 36
+- **Deficient**: aliquot sum < number
+  - 8 is a deficient number because (1 + 2 + 4) = 7
+  - Prime numbers are deficient
+  
+Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Taken from Chapter 2 of Functional Thinking by Neal Ford. [http://shop.oreilly.com/product/0636920029687.do](http://shop.oreilly.com/product/0636920029687.do)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -1,0 +1,40 @@
+# Phone Number
+
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+
+
+The format is usually represented as
+```
+(NXX)-NXX-XXXX
+```
+where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
+
+Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.
+
+For example, the inputs
+- `+1 (613)-995-0253`
+- `613-995-0253`
+- `1 613 995 0253`
+- `613.995.0253`
+
+should all produce the output
+
+`6139950253`
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -1,0 +1,30 @@
+# Pig Latin
+
+Implement a program that translates from English to Pig Latin.
+
+Pig Latin is a made-up children's language that's intended to be
+confusing. It obeys a few simple rules (below), but when it's spoken
+quickly it's really difficult for non-children (and non-native speakers)
+to understand.
+
+- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to
+  the end of the word.
+- **Rule 2**: If a word begins with a consonant sound, move it to the
+  end of the word, and then add an "ay" sound to the end of the word.
+
+There are a few more rules for edge cases, and there are regional
+variants too.
+
+See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Pig Latin exercise at Test First Teaching by Ultrasaurus [https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/](https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -1,0 +1,18 @@
+# Poker
+
+Pick the best hand(s) from a list of poker hands.
+
+See [wikipedia](https://en.wikipedia.org/wiki/List_of_poker_hands) for an
+overview of poker hands.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by the training course from Udacity. [https://www.udacity.com/course/viewer#!/c-cs212/](https://www.udacity.com/course/viewer#!/c-cs212/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pov/README.md
+++ b/exercises/pov/README.md
@@ -1,0 +1,52 @@
+# Pov
+
+Reparent a graph on a selected node.
+
+# Tree Reparenting
+
+This exercise is all about re-orientating a graph to see things from a different
+point of view. For example family trees are usually presented from the
+ancestor's perspective:
+
+```
+    +------0------+
+    |      |      |
+  +-1-+  +-2-+  +-3-+
+  |   |  |   |  |   |
+  4   5  6   7  8   9
+```
+
+But the same information can be presented from the perspective of any other node
+in the graph, by pulling it up to the root and dragging its relationships along
+with it. So the same graph from 6's perspective would look like:
+
+```
+        6
+        |
+  +-----2-----+
+  |           |
+  7     +-----0-----+
+        |           |
+      +-1-+       +-3-+
+      |   |       |   |
+      4   5       8   9
+```
+
+This lets us more simply describe the paths between two nodes. So for example
+the path from 6-9 (which in the first graph goes up to the root and then down to
+a different leaf node) can be seen to follow the path 6-2-0-3-9
+
+This exercise involves taking an input graph and re-orientating it from the point
+of view of one of the nodes.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Adaptation of exercise from 4clojure [https://www.4clojure.com/](https://www.4clojure.com/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -1,0 +1,42 @@
+# Prime Factors
+
+Compute the prime factors of a given natural number.
+
+A prime number is only evenly divisible by itself and 1.
+
+Note that 1 is not a prime number.
+
+## Example
+
+What are the prime factors of 60?
+
+- Our first divisor is 2. 2 goes into 60, leaving 30.
+- 2 goes into 30, leaving 15.
+  - 2 doesn't go cleanly into 15. So let's move on to our next divisor, 3.
+- 3 goes cleanly into 15, leaving 5.
+  - 3 does not go cleanly into 5. The next possible factor is 4.
+  - 4 does not go cleanly into 5. The next possible factor is 5.
+- 5 does go cleanly into 5.
+- We're left only with 1, so now, we're done.
+
+Our successful divisors in that computation represent the list of prime
+factors of 60: 2, 2, 3, and 5.
+
+You can check this yourself:
+
+- 2 * 2 * 3 * 5
+- = 4 * 15
+- = 60
+- Success!
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Prime Factors Kata by Uncle Bob [http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata](http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -1,0 +1,55 @@
+# Protein Translation
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a polypeptide with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+ 
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.  
+
+There are also four terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAG", "AUG"` => 
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting Amino Acids needed for the exercise.
+
+Codon                 | Protein
+:---                  | :---
+AUG                   | Methionine
+UUU, UUC              | Phenylalanine
+UUA, UUG              | Leucine
+UCU, UCC, UCA, UCG    | Serine
+UAU, UAC              | Tyrosine
+UGU, UGC              | Cysteine
+UGG                   | Tryptophan
+UAA, UAG, UGA         | STOP
+
+
+Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki/Translation_(biology))
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Tyler Long
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -1,0 +1,28 @@
+# Proverb
+
+For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output
+the full text of this proverbial rhyme:
+
+> For want of a nail the shoe was lost.  
+> For want of a shoe the horse was lost.  
+> For want of a horse the rider was lost.  
+> For want of a rider the message was lost.  
+> For want of a message the battle was lost.  
+> For want of a battle the kingdom was lost.  
+> And all for the want of a horseshoe nail.
+
+## HINTS
+
+Try to capture the structure of the song in your code, where you build up the song by composing its parts.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/For_Want_of_a_Nail](http://en.wikipedia.org/wiki/For_Want_of_a_Nail)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -1,0 +1,30 @@
+# Pythagorean Triplet
+
+A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
+which,
+
+```
+a**2 + b**2 = c**2
+```
+
+For example, 
+
+```
+3**2 + 4**2 = 9 + 16 = 25 = 5**2.
+```
+
+There exists exactly one Pythagorean triplet for which a + b + c = 1000.
+
+Find the product a * b * c.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Problem 9 at Project Euler [http://projecteuler.net/problem=9](http://projecteuler.net/problem=9)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -1,0 +1,39 @@
+# Queen Attack
+
+Given the position of two queens on a chess board, indicate whether or not they
+are positioned so that they can attack each other.
+
+In the game of chess, a queen can attack pieces which are on the same
+row, column, or diagonal.
+
+A chessboard can be represented by an 8 by 8 array.
+
+So if you're told the white queen is at (2, 3) and the black queen at
+(5, 6), then you'd know you've got a set-up like so:
+
+```plain
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ W _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ B _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+```
+
+You'd also be able to answer whether the queens can attack each other.
+In this case, that answer would be yes, they can, because both pieces
+share a diagonal.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -1,0 +1,66 @@
+# Rail Fence Cipher
+
+Implement encoding and decoding for the rail fence cipher.
+
+The Rail Fence cipher is a form of transposition cipher that gets its name from
+the way in which it's encoded. It was already used by the ancient Greeks.
+
+In the Rail Fence cipher, the message is written downwards on successive "rails"
+of an imaginary fence, then moving up when we get to the bottom (like a zig-zag).
+Finally the message is then read off in rows.
+
+For example, using three "rails" and the message "WE ARE DISCOVERED FLEE AT ONCE",
+the cipherer writes out:
+```
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . A . . . I . . . V . . . D . . . E . . . N . .
+```
+
+Then reads off:
+```
+WECRLTEERDSOEEFEAOCAIVDEN
+```
+
+
+To decrypt a message you take the zig-zag shape and fill the ciphertext along the rows.
+```
+? . . . ? . . . ? . . . ? . . . ? . . . ? . . . ?
+. ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+The first row has seven spots that can be filled with "WECRLTE".
+```
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+Now the 2nd row takes "ERDSOEEFEAOC".
+```
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+Leaving "AIVDEN" for the last row.
+```
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . A . . . I . . . V . . . D . . . E . . . N . .
+```
+
+If you now read along the zig-zag shape you can read the original message.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher](https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -1,0 +1,30 @@
+# Raindrops
+
+Convert a number to a string, the contents of which depend on the number's factors.
+
+- If the number has 3 as a factor, output 'Pling'.
+- If the number has 5 as a factor, output 'Plang'.
+- If the number has 7 as a factor, output 'Plong'.
+- If the number does not have 3, 5, or 7 as a factor,
+  just pass the number's digits straight through.
+
+## Examples
+
+- 28's factors are 1, 2, 4, **7**, 14, 28.
+  - In raindrop-speak, this would be a simple "Plong".
+- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
+  - In raindrop-speak, this would be a "PlingPlang".
+- 34 has four factors: 1, 2, 17, and 34.
+  - In raindrop-speak, this would be "34".
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -1,0 +1,29 @@
+# React
+
+Implement a basic reactive system.
+
+Reactive programming is a programming paradigm that focuses on how values
+are computed in terms of each other to allow a change to one value to
+automatically propagate to other values, like in a spreadsheet.
+
+Implement a basic reactive system with cells with settable values ("input"
+cells) and cells with values computed in terms of other cells ("compute"
+cells). Implement updates so that when an input value is changed, values
+propagate to reach a new stable system state.
+
+In addition, compute cells should allow for registering change notification
+callbacks.  Call a cell’s callbacks when the cell’s value in a new stable
+state has changed from the previous stable state.
+
+## Hints
+In this exercise the following C# feature is used:
+- [Events](https://msdn.microsoft.com/en-us/library/9aackb16(v=vs.110).aspx).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -1,0 +1,73 @@
+# Rectangles
+
+Count the rectangles in an ASCII diagram like the one below.
+
+```
+   +--+
+  ++  |
++-++--+
+|  |  |
++--+--+
+```
+
+The above diagram contains 6 rectangles:
+
+```
+
+
++-----+
+|     |
++-----+
+```
+
+```
+   +--+
+   |  |
+   |  |
+   |  |
+   +--+
+```
+
+```
+   +--+
+   |  |
+   +--+
+
+
+```
+
+```
+       
+       
+   +--+
+   |  |
+   +--+
+```
+
+```
+       
+       
++--+
+|  |
++--+
+```
+
+```
+       
+  ++   
+  ++   
+       
+       
+```
+
+You may assume that the input is always a proper rectangle (i.e. the length of
+every line equals the length of the first line).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,0 +1,31 @@
+# Rna Transcription
+
+Given a DNA strand, return its RNA complement (per RNA transcription).
+
+Both DNA and RNA strands are a sequence of nucleotides.
+
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and thymine (**T**).
+
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and uracil (**U**).
+
+Given a DNA strand, its transcribed RNA strand is formed by replacing
+each nucleotide with its complement:
+
+* `G` -> `C`
+* `C` -> `G`
+* `T` -> `A`
+* `A` -> `U`
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -1,0 +1,28 @@
+# Robot Name
+
+Manage robot factory settings.
+
+When robots come off the factory floor, they have no name.
+
+The first time you boot them up, a random name is generated in the format
+of two uppercase letters followed by three digits, such as RX837 or BC811.
+
+Every once in a while we need to reset a robot to its factory settings,
+which means that their name gets wiped. The next time you ask, it will
+respond with a new random name.
+
+The names must be random: they should not follow a predictable sequence.
+Random names means a risk of collisions. Your solution must ensure that
+every existing robot has a unique name.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -1,0 +1,40 @@
+# Robot Simulator
+
+Write a robot simulator.
+
+A robot factory's test facility needs a program to verify robot movements.
+
+The robots have three possible movements:
+
+- turn right
+- turn left
+- advance
+
+Robots are placed on a hypothetical infinite grid, facing a particular
+direction (north, east, south, or west) at a set of {x,y} coordinates,
+e.g., {3,8}, with coordinates increasing to the north and east.
+
+The robot then receives a number of instructions, at which point the
+testing facility verifies the robot's new position, and in which
+direction it is pointing.
+
+- The letter-string "RAALAL" means:
+  - Turn right
+  - Advance twice
+  - Turn left
+  - Advance once
+  - Turn left yet again
+- Say a robot starts at {7, 3} facing north. Then running this stream
+  of instructions should leave it at {9, 4} facing west.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by an interview question at a famous company.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -1,0 +1,59 @@
+# Roman Numerals
+
+Write a function to convert from normal numbers to Roman Numerals.
+
+The Romans were a clever bunch. They conquered most of Europe and ruled
+it for hundreds of years. They invented concrete and straight roads and
+even bikinis. One thing they never discovered though was the number
+zero. This made writing and dating extensive histories of their exploits
+slightly more challenging, but the system of numbers they came up with
+is still in use today. For example the BBC uses Roman numerals to date
+their programmes.
+
+The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
+these letters have lots of straight lines and are hence easy to hack
+into stone tablets).
+
+```
+ 1  => I
+10  => X
+ 7  => VII
+```
+
+There is no need to be able to convert numbers larger than about 3000.
+(The Romans themselves didn't tend to go any higher)
+
+Wikipedia says: Modern Roman numerals ... are written by expressing each
+digit separately starting with the left most digit and skipping any
+digit with a value of zero.
+
+To see this in practice, consider the example of 1990.
+
+In Roman numerals 1990 is MCMXC:
+
+1000=M
+900=CM
+90=XC
+
+2008 is written as MMVIII:
+
+2000=MM
+8=VIII
+
+See also: http://www.novaroma.org/via_romana/numbers.html
+
+## Hints
+This exercise requires you to write an extension method. For more information, see [this page](https://msdn.microsoft.com/en-us//library/bb383977.aspx).
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -1,0 +1,42 @@
+# Rotational Cipher
+
+Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
+
+The Caesar cipher is a simple shift cipher that relies on
+transposing all the letters in the alphabet using an integer key
+between `0` and `26`. Using a key of `0` or `26` will always yield
+the same output due to modular arithmetic. The letter is shifted
+for as many values as the value of the key.
+
+The general notation for rotational ciphers is `ROT + <key>`.
+The most commonly used rotational cipher is `ROT13`.
+
+A `ROT13` on the Latin alphabet would be as follows:
+
+```plain
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: nopqrstuvwxyzabcdefghijklm
+```
+
+It is stronger than the Atbash cipher because it has 27 possible keys, and 25 usable keys.
+
+Ciphertext is written out in the same formatting as the input including spaces and punctuation.
+
+## Examples
+- ROT5  `omg` gives `trl`
+- ROT0  `c` gives `c`
+- ROT26 `Cool` gives `Cool`
+- ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
+- ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Caesar_cipher](https://en.wikipedia.org/wiki/Caesar_cipher)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -1,0 +1,36 @@
+# Run Length Encoding
+
+Implement run-length encoding and decoding.
+
+Run-length encoding (RLE) is a simple form of data compression, where runs
+(consecutive data elements) are replaced by just one data value and count.
+
+For example we can represent the original 53 characters with only 13.
+
+```
+"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"  ->  "12WB12W3B24WB"
+```
+
+RLE allows the original data to be perfectly reconstructed from
+the compressed data, which makes it a lossless data compression.
+
+```
+"AABCCCDEEEE"  ->  "2AB3CD4E"  ->  "AABCCCDEEEE"
+```
+
+For simplicity, you can assume that the unencoded string will only contain
+the letters A through Z (either lower or upper case) and whitespace. This way 
+data to be encoded will never contain any numbers and numbers inside data to 
+be decoded always represent the count for the following character.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -1,0 +1,44 @@
+# Saddle Points
+
+Detect saddle points in a matrix.
+
+So say you have a matrix like so:
+
+```plain
+    0  1  2
+  |---------
+0 | 9  8  7
+1 | 5  3  2     <--- saddle point at (1,0)
+2 | 6  6  7
+```
+
+It has a saddle point at (1, 0).
+
+It's called a "saddle point" because it is greater than or equal to
+every element in its row and the less than or equal to every element in
+its column.
+
+A matrix may have zero or more saddle points.
+
+Your code should be able to provide the (possibly empty) list of all the
+saddle points for any given matrix.
+
+Note that you may find other definitions of matrix saddle points online,
+but the tests for this exercise follow the above unambiguous definition.
+
+## Hints
+
+For this exercise, you will need to create a set of factors using tuples.
+For more information on tuples, see [this link](https://msdn.microsoft.com/en-us/library/system.tuple(v=vs.110).aspx).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -1,0 +1,75 @@
+# Say
+
+Given a number from 0 to 999,999,999,999, spell out that number in English.
+
+## Step 1
+
+Handle the basic case of 0 through 99.
+
+If the input to the program is `22`, then the output should be
+`'twenty-two'`.
+
+Your program should complain loudly if given a number outside the
+blessed range.
+
+Some good test cases for this program are:
+
+- 0
+- 14
+- 50
+- 98
+- -1
+- 100
+
+### Extension
+
+If you're on a Mac, shell out to Mac OS X's `say` program to talk out
+loud.
+
+## Step 2
+
+Implement breaking a number up into chunks of thousands.
+
+So `1234567890` should yield a list like 1, 234, 567, and 890, while the
+far simpler `1000` should yield just 1 and 0.
+
+The program must also report any values that are out of range.
+
+## Step 3
+
+Now handle inserting the appropriate scale word between those chunks.
+
+So `1234567890` should yield `'1 billion 234 million 567 thousand 890'`
+
+The program must also report any values that are out of range.  It's
+fine to stop at "trillion".
+
+## Step 4
+
+Put it all together to get nothing but plain English.
+
+`12345` should give `twelve thousand three hundred forty-five`.
+
+The program must also report any values that are out of range.
+
+### Extensions
+
+Use _and_ (correctly) when spelling out the number in English:
+
+- 14 becomes "fourteen".
+- 100 becomes "one hundred".
+- 120 becomes "one hundred and twenty".
+- 1002 becomes "one thousand and two".
+- 1323 becomes "one thousand three hundred and twenty-three".
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A variation on JavaRanch CattleDrive, exercise 4a [http://www.javaranch.com/say.jsp](http://www.javaranch.com/say.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -1,0 +1,66 @@
+# Scale Generator
+
+Given a tonic, or starting note, and a set of intervals, generate
+the musical scale starting with the tonic and following the
+specified interval pattern.
+
+Scales in Western music are based on the chromatic (12-note) scale.This
+scale can be expressed as the following group of pitches:
+
+A, A#, B, C, C#, D, D#, E, F, F#, G, G#
+
+A given sharp note (indicated by a #), can also be expressed as the flat
+of the note above it (indicated by a b), so the chromatic scale can also be
+written like this:
+
+A, Bb, B, C, Db, D, Eb, E, F, Gb, G, Ab
+
+The major and minor scale and modes are subsets of this twelve-pitch
+collection. They have seven pitches, and are called diatonic scales.
+The collection of notes in these scales is written with either sharps or
+flats, depending on the tonic. Here is a list of which are which:
+
+No Accidentals:
+C major
+A minor
+
+Use Sharps:
+G, D, A, E, B, F# major
+e, b, f#, c#, g#, d# minor
+
+Use Flats:
+F, Bb, Eb, Ab, Db, Gb major
+d, g, c, f, bb, eb minor
+
+
+The diatonic scales, and all other scales that derive from the
+chromatic scale, are built upon intervals. An interval is the space
+between two pitches.
+
+The simplest interval is between two adjacent notes, and is called a
+"half step", or "minor second" (sometimes written as a lower-case "m").
+The interval between two notes that have an interceding note is called
+a "whole step" or "major second" (written as an upper-case "M"). The
+diatonic scales are built using only these two intervals between
+adjacent notes.
+
+Non-diatonic scales can contain the same letter twice, and can contain other intervals.
+Sometimes they may be smaller than usual (diminished, written "D"), or larger
+(augmented, written "A").  Intervals larger than an augmented second have other names.
+
+Here is a table of pitches with the names of their interval distance from the tonic (A).
+
+|   A    |    A#   |    B    |    C    |    C#   |    D    |    D#   |    E    |    F    |    F#   |    G    |    G#   |    A   |
+|:------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:------:|
+| Unison | Min 2nd | Maj 2nd | Min 3rd | Maj 3rd | Per 4th | Tritone | Per 5th | Min 6th | Maj 6th | Min 7th | Maj 7th | Octave |
+|        |         | Dim 3rd | Aug 2nd | Dim 4th |         | Aug 4th | Dim 5th | Aug 5th | Dim 7th | Aug 6th | Dim 8ve |        |
+|        |         |         |         |         |         | Dim 5th |         |         |         |         |         |        |
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -1,0 +1,50 @@
+# Scrabble Score
+
+Given a word, compute the scrabble score for that word.
+
+## Letter Values
+
+You'll need these:
+
+```plain
+Letter                           Value
+A, E, I, O, U, L, N, R, S, T       1
+D, G                               2
+B, C, M, P                         3
+F, H, V, W, Y                      4
+K                                  5
+J, X                               8
+Q, Z                               10
+```
+
+## Examples
+"cabbage" should be scored as worth 14 points:
+
+- 3 points for C
+- 1 point for A, twice
+- 3 points for B, twice
+- 2 points for G
+- 1 point for E
+
+And to total:
+
+- `3 + 2*1 + 2*3 + 2 + 1`
+- = `3 + 2 + 6 + 3`
+- = `5 + 9`
+- = 14
+
+## Extensions
+- You can play a double or a triple letter.
+- You can play a double or a triple word.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -1,0 +1,41 @@
+# Secret Handshake
+
+> There are 10 types of people in the world: Those who understand
+> binary, and those who don't.
+
+You and your fellow cohort of those in the "know" when it comes to
+binary decide to come up with a secret "handshake".
+
+```
+1 = wink
+10 = double blink
+100 = close your eyes
+1000 = jump
+
+
+10000 = Reverse the order of the operations in the secret handshake.
+```
+
+Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.
+
+Here's a couple of examples:
+
+Given the input 3, the function would return the array
+["wink", "double blink"] because 3 is 11 in binary.
+
+Given the input 19, the function would return the array
+["double blink", "wink"] because 19 is 10011 in binary.
+Notice that the addition of 16 (10000 in binary)
+has caused the array to be reversed.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Bert, in Mary Poppins [http://www.imdb.com/character/ch0011238/quotes](http://www.imdb.com/character/ch0011238/quotes)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,0 +1,33 @@
+# Series
+
+Given a string of digits, output all the contiguous substrings of length `n` in
+that string.
+
+For example, the string "49142" has the following 3-digit series:
+
+- 491
+- 914
+- 142
+
+And the following 4-digit series:
+
+- 4914
+- 9142
+
+And if you ask for a 6-digit series from a 5-digit string, you deserve
+whatever you get.
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A subset of the Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sgf-parsing/README.md
+++ b/exercises/sgf-parsing/README.md
@@ -1,0 +1,78 @@
+# Sgf Parsing
+
+Parsing a Smart Game Format string.
+
+[SGF](https://en.wikipedia.org/wiki/Smart_Game_Format) is a standard format for
+storing board game files, in particular go.
+
+SGF is a fairly simple format. An SGF file usually contains a single
+tree of nodes where each node is a property list. The property list
+contains key value pairs, each key can only occur once but may have
+multiple values.
+
+An SGF file may look like this:
+
+```
+(;FF[4]C[root]SZ[19];B[aa];W[ab])
+```
+
+This is a tree with three nodes:
+
+- The top level node has two properties: FF\[4\] (key = "FF", value =
+  "4") and C\[root\](key = "C", value = "root"). (FF indicates the
+  version of SGF and C is a comment.)
+  - The top level node has a single child which has a single property:
+    B\[aa\].  (Black plays on the point encoded as "aa", which is the
+    1-1 point (which is a stupid place to play)).
+    - The B\[aa\] node has a single child which has a single property:
+      W\[ab\].
+
+As you can imagine an SGF file contains a lot of nodes with a single
+child, which is why there's a shorthand for it.
+
+SGF can encode variations of play. Go players do a lot of backtracking
+in their reviews (let's try this, doesn't work, let's try that) and SGF
+supports variations of play sequences. For example:
+
+```
+(;FF[4](;B[aa];W[ab])(;B[dd];W[ee]))
+```
+
+Here the root node has two variations. The first (which by convention
+indicates what's actually played) is where black plays on 1-1. Black was
+sent this file by his teacher who pointed out a more sensible play in
+the second child of the root node: `B[dd]` (4-4 point, a very standard
+opening to take the corner).
+
+A key can have multiple values associated with it. For example:
+
+```
+(;FF[4];AB[aa][ab][ba])
+```
+
+Here `AB` (add black) is used to add three black stones to the board.
+
+There are a few more complexities to SGF (and parsing in general), which
+you can mostly ignore. You should assume that the input is encoded in
+UTF-8, the tests won't contain a charset property, so don't worry about
+that. Furthermore you may assume that all newlines are unix style (`\n`,
+no `\r` or `\r\n` will be in the tests) and that no optional whitespace
+between properties, nodes, etc will be in the tests.
+
+The exercise will have you parse an SGF string and return a tree
+structure of properties. You do not need to encode knowledge about the
+data types of properties, just use the rules for the
+[text](http://www.red-bean.com/sgf/sgf4.html#text) type everywhere.
+
+## Hints
+- To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/).
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -1,0 +1,40 @@
+# Sieve
+
+Use the Sieve of Eratosthenes to find all the primes from 2 up to a given
+number.
+
+The Sieve of Eratosthenes is a simple, ancient algorithm for finding all
+prime numbers up to any given limit. It does so by iteratively marking as
+composite (i.e. not prime) the multiples of each prime,
+starting with the multiples of 2.
+
+Create your range, starting at two and continuing up to and including the given limit. (i.e. [2, limit])
+
+The algorithm consists of repeating the following over and over:
+
+- take the next available unmarked number in your list (it is prime)
+- mark all the multiples of that number (they are not prime)
+
+Repeat until you have processed each number in your range.
+
+When the algorithm terminates, all the numbers in the list that have not
+been marked are prime.
+
+The wikipedia article has a useful graphic that explains the algorithm:
+https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
+
+Notice that this is a very specific algorithm, and the tests don't check
+that you've implemented the algorithm, only that you've come up with the
+correct list of primes.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Sieve of Eratosthenes at Wikipedia [http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes](http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -1,0 +1,96 @@
+# Simple Cipher
+
+Implement a simple shift cipher like Caesar and a more secure substitution cipher.
+
+## Step 1
+
+"If he had anything confidential to say, he wrote it in cipher, that is,
+by so changing the order of the letters of the alphabet, that not a word
+could be made out. If anyone wishes to decipher these, and get at their
+meaning, he must substitute the fourth letter of the alphabet, namely D,
+for A, and so with the others."
+—Suetonius, Life of Julius Caesar
+
+Ciphers are very straight-forward algorithms that allow us to render
+text less readable while still allowing easy deciphering. They are
+vulnerable to many forms of cryptoanalysis, but we are lucky that
+generally our little sisters are not cryptoanalysts.
+
+The Caesar Cipher was used for some messages from Julius Caesar that
+were sent afield. Now Caesar knew that the cipher wasn't very good, but
+he had one ally in that respect: almost nobody could read well. So even
+being a couple letters off was sufficient so that people couldn't
+recognize the few words that they did know.
+
+Your task is to create a simple shift cipher like the Caesar Cipher.
+This image is a great example of the Caesar Cipher:
+
+![Caesar Cipher][1]
+
+For example:
+
+Giving "iamapandabear" as input to the encode function returns the cipher "ldpdsdqgdehdu". Obscure enough to keep our message secret in transit.
+
+When "ldpdsdqgdehdu" is put into the decode function it would return
+the original "iamapandabear" letting your friend read your original
+message.
+
+## Step 2
+
+Shift ciphers are no fun though when your kid sister figures it out. Try
+amending the code to allow us to specify a key and use that for the
+shift distance. This is called a substitution cipher.
+
+Here's an example:
+
+Given the key "aaaaaaaaaaaaaaaaaa", encoding the string "iamapandabear"
+would return the original "iamapandabear".
+
+Given the key "ddddddddddddddddd", encoding our string "iamapandabear"
+would return the obscured "lpdsdqgdehdu"
+
+In the example above, we've set a = 0 for the key value. So when the
+plaintext is added to the key, we end up with the same message coming
+out. So "aaaa" is not an ideal key. But if we set the key to "dddd", we
+would get the same thing as the Caesar Cipher.
+
+## Step 3
+
+The weakest link in any cipher is the human being. Let's make your
+substitution cipher a little more fault tolerant by providing a source
+of randomness and ensuring that the key is not composed of numbers or
+capital letters.
+
+If someone doesn't submit a key at all, generate a truly random key of
+at least 100 characters in length, accessible via Cipher#key (the #
+syntax means instance variable)
+
+If the key submitted has capital letters or numbers, throw an
+ArgumentError with a message to that effect.
+
+## Extensions
+
+Shift ciphers work by making the text slightly odd, but are vulnerable
+to frequency analysis. Substitution ciphers help that, but are still
+very vulnerable when the key is short or if spaces are preserved. Later
+on you'll see one solution to this problem in the exercise
+"crypto-square".
+
+If you want to go farther in this field, the questions begin to be about
+how we can exchange keys in a secure way. Take a look at [Diffie-Hellman
+on Wikipedia][dh] for one of the first implementations of this scheme.
+
+[1]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
+[dh]: http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Substitution Cipher at Wikipedia [http://en.wikipedia.org/wiki/Substitution_cipher](http://en.wikipedia.org/wiki/Substitution_cipher)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -1,0 +1,38 @@
+# Simple Linked List
+
+Write a simple linked list implementation that uses Elements and a List.
+
+The linked list is a fundamental data structure in computer science,
+often used in the implementation of other data structures. They're
+pervasive in functional programming languages, such as Clojure, Erlang,
+or Haskell, but far less common in imperative languages such as Ruby or
+Python.
+
+The simplest kind of linked list is a singly linked list. Each element in the
+list contains data and a "next" field pointing to the next element in the list
+of elements.
+
+This variant of linked lists is often used to represent sequences or
+push-down stacks (also called a LIFO stack; Last In, First Out).
+
+As a first take, lets create a singly linked list to contain the range (1..10),
+and provide functions to reverse a linked list and convert to and from arrays.
+
+When implementing this in a language with built-in linked lists,
+implement your own abstract data type.
+
+## Hints
+This exercise requires you to create a linked list data structure which can be iterated. This requires you to implement the IEnumerable\<T> interface. 
+For more information, see [this page](https://msdn.microsoft.com/en-us/library/9eekhta0(v=vs.110).aspx).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists. [http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000](http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -1,0 +1,30 @@
+# Space Age
+
+Given an age in seconds, calculate how old someone would be on:
+
+   - Earth: orbital period 365.25 Earth days, or 31557600 seconds
+   - Mercury: orbital period 0.2408467 Earth years
+   - Venus: orbital period 0.61519726 Earth years
+   - Mars: orbital period 1.8808158 Earth years
+   - Jupiter: orbital period 11.862615 Earth years
+   - Saturn: orbital period 29.447498 Earth years
+   - Uranus: orbital period 84.016846 Earth years
+   - Neptune: orbital period 164.79132 Earth years
+
+So if you were told someone were 1,000,000,000 seconds old, you should
+be able to say that they're 31 Earth-years old.
+
+If you're wondering why Pluto didn't make the cut, go watch [this
+youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=01](http://pine.fm/LearnToProgram/?Chapter=01)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -1,0 +1,46 @@
+# Strain
+
+Implement the `keep` and `discard` operation on collections. Given a collection
+and a predicate on the collection's elements, `keep` returns a new collection
+containing those elements where the predicate is true, while `discard` returns
+a new collection containing those elements where the predicate is false.
+
+For example, given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the predicate:
+
+- is the number even?
+
+Then your keep operation should produce:
+
+- 2, 4
+
+While your discard operation should produce:
+
+- 1, 3, 5
+
+Note that the union of keep and discard is all the elements.
+
+The functions may be called `keep` and `discard`, or they may need different
+names in order to not clash with existing functions or concepts in your
+language.
+
+## Restrictions
+
+Keep your hands off that filter/reject/whatchamacallit functionality
+provided by your standard library!  Solve this one yourself using other
+basic tools instead.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -1,0 +1,32 @@
+# Sublist
+
+Given two lists determine if the first list is contained within the second
+list, if the second list is contained within the first list, if both lists are
+contained within each other or if none of these are true.
+
+Specifically, a list A is a sublist of list B if by dropping 0 or more elements
+from the front of B and 0 or more elements from the back of B you get a list
+that's completely equal to A.
+
+Examples:
+
+ * A = [1, 2, 3], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [3, 4, 5], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [3, 4], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [1, 2, 3], B = [1, 2, 3], A is equal to B
+ * A = [1, 2, 3, 4, 5], B = [2, 3, 4], A is a superlist of B
+ * A = [1, 2, 4], B = [1, 2, 3, 4, 5], A is not a superlist of, sublist of or equal to B
+
+## Hints
+To be able to compare data, the IComparable interface is used.
+For more information, see [this page](https://msdn.microsoft.com/en-us/library/system.icomparable(v=vs.110).aspx).
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,0 +1,28 @@
+# Sum Of Multiples
+
+Given a number, find the sum of all the multiples of particular numbers up to
+but not including that number.
+
+If we list all the natural numbers up to but not including 20 that are
+multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
+
+The sum of these multiples is 78.
+
+Given a number, find the sum of the multiples of a given set of numbers,
+up to but not including that number.
+
+## Hints
+This exercise requires you to process a collection of data. You can simplify your code by using LINQ (Language Integrated Query).
+For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A variation on Problem 1 at Project Euler [http://projecteuler.net/problem=1](http://projecteuler.net/problem=1)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -1,0 +1,74 @@
+# Tournament
+
+Tally the results of a small football competition.
+
+Based on an input file containing which team played against which and what the
+outcome was, create a file with a table like this:
+
+```
+Team                           | MP |  W |  D |  L |  P
+Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+Courageous Californians        |  3 |  0 |  1 |  2 |  1
+```
+
+What do those abbreviations mean?
+
+- MP: Matches Played
+- W: Matches Won
+- D: Matches Drawn (Tied)
+- L: Matches Lost
+- P: Points
+
+A win earns a team 3 points. A draw earns 1. A loss earns 0.
+
+The outcome should be ordered by points, descending. In case of a tie, teams are ordered alphabetically.
+
+###
+
+Input
+
+Your tallying program will receive input that looks like:
+
+```
+Allegoric Alaskans;Blithering Badgers;win
+Devastating Donkeys;Courageous Californians;draw
+Devastating Donkeys;Allegoric Alaskans;win
+Courageous Californians;Blithering Badgers;loss
+Blithering Badgers;Devastating Donkeys;loss
+Allegoric Alaskans;Courageous Californians;win
+```
+
+The result of the match refers to the first team listed. So this line
+
+```
+Allegoric Alaskans;Blithering Badgers;win
+```
+
+Means that the Allegoric Alaskans beat the Blithering Badgers.
+
+This line:
+
+```
+Courageous Californians;Blithering Badgers;loss
+```
+
+Means that the Blithering Badgers beat the Courageous Californians.
+
+And this line:
+
+```
+Devastating Donkeys;Courageous Californians;draw
+```
+
+Means that the Devastating Donkeys and Courageous Californians tied.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -1,0 +1,71 @@
+# Transpose
+
+Given an input text output it transposed.
+
+Roughly explained, the transpose of a matrix:
+
+```
+ABC
+DEF
+```
+
+is given by:
+
+```
+AD
+BE
+CF
+```
+
+Rows become columns and columns become rows. See <https://en.wikipedia.org/wiki/Transpose>.
+
+If the input has rows of different lengths, this is to be solved as follows:
+
+- Pad to the left with spaces.
+- Don't pad to the right.
+
+Therefore, transposing this matrix:
+
+```
+ABC
+DE
+```
+
+results in:
+
+```
+AD
+BE
+C
+```
+
+And transposing:
+
+```
+AB
+DEF
+```
+
+results in:
+
+```
+AD
+BE
+ F
+```
+
+In general, all characters from the input should also be present in the transposed output.
+That means that if a column in the input text contains only spaces on its bottom-most row(s), 
+the corresponding output row should contain the spaces in its right-most column(s).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Reddit r/dailyprogrammer challenge #270 [Easy]. [https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text](https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/tree-building/README.md
+++ b/exercises/tree-building/README.md
@@ -1,0 +1,36 @@
+# Tree Building
+
+Refactor a tree building algorithm.
+
+Some web-forums have a tree layout, so posts are presented as a tree. However
+the posts are typically stored in a database as an unsorted set of records. Thus
+when presenting the posts to the user the tree structure has to be
+reconstructed.
+
+Your job will be to refactor a working but slow and ugly piece of code that
+implements the tree building logic for highly abstracted records. The records
+only contain an ID number and a parent ID number. The ID number is always
+between 0 (inclusive) and the length of the record list (exclusive). All records
+have a parent ID lower than their own ID, except for the root record, which has 
+a parent ID that's equal to its own ID.
+
+An example tree:
+
+<pre>
+root (ID: 0, parent ID: 0)
+|-- child1 (ID: 1, parent ID: 0)
+|    |-- grandchild1 (ID: 2, parent ID: 1)
+|    +-- grandchild2 (ID: 4, parent ID: 1)
++-- child2 (ID: 3, parent ID: 0)
+|    +-- grandchild3 (ID: 6, parent ID: 3)
++-- child3 (ID: 5, parent ID: 0)
+</pre>
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -1,0 +1,32 @@
+# Triangle
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.<br/>
+An _isosceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)<br/>
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and 
+the sum of the lengths of any two sides must be greater than or equal to the 
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+
+## Dig Deeper
+
+The case where the sum of the lengths of two sides _equals_ that of the 
+third is known as a _degenerate_ triangle - it has zero area and looks like 
+a single line. Feel free to add your own code/tests to check for degenerate triangles.
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -1,0 +1,45 @@
+# Twelve Days
+
+Output the lyrics to 'The Twelve Days of Christmas'.
+
+```
+On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.
+
+On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the fourth day of Christmas my true love gave to me, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the fifth day of Christmas my true love gave to me, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the sixth day of Christmas my true love gave to me, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the seventh day of Christmas my true love gave to me, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the eighth day of Christmas my true love gave to me, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the ninth day of Christmas my true love gave to me, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the tenth day of Christmas my true love gave to me, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+```
+
+## Hints
+- Try to capture the structure of the song in your code, where you build up the song by composing its parts.
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)](http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song))
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -1,0 +1,42 @@
+# Two Bucket
+
+Given two buckets of different size, demonstrate how to measure an exact number of liters by strategically transferring liters of fluid between the buckets.
+
+Since this mathematical problem is fairly subject to interpretation / individual approach, the tests have been written specifically to expect one overarching solution.
+
+To help, the tests provide you with which bucket to fill first. That means, when starting with the larger bucket full, you are NOT allowed at any point to have the smaller bucket full and the larger bucket empty (aka, the opposite starting point); that would defeat the purpose of comparing both approaches! 
+
+Your program will take as input:
+- the size of bucket one, passed as a numeric value
+- the size of bucket two, passed as a numeric value
+- the desired number of liters to reach, passed as a numeric value
+- which bucket to fill first, passed as a String (either 'one' or 'two')
+
+Your program should determine:
+- the total number of "moves" it should take to reach the desired number of liters, including the first fill - expects a numeric value
+- which bucket should end up with the desired number of liters (let's say this is bucket A) - expects a String (either 'one' or 'two')
+- how many liters are left in the other bucket (bucket B) - expects a numeric value
+
+Note: any time a change is made to either or both buckets counts as one (1) move. 
+
+Example: 
+Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters. Let's say bucket one, at a given step, is holding 7 liters, and bucket two is holding 8 liters (7,8). If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one "move". Instead, if you had poured from bucket one into bucket two until bucket two was full, leaving you with 4 liters in bucket one and 11 liters in bucket two (4,11), that would count as only one "move" as well.
+
+To conclude, the only valid moves are:
+- pouring from one bucket to another
+- emptying one bucket and doing nothing to the other
+- filling one bucket and doing nothing to the other
+
+Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by [Lindsay](http://lindsaylevine.com).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Water Pouring Problem [http://demonstrations.wolfram.com/WaterPouringProblem/](http://demonstrations.wolfram.com/WaterPouringProblem/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -1,0 +1,50 @@
+# Variable Length Quantity
+
+Implement variable length quantity encoding and decoding.
+
+The goal of this exercise is to implement [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity) encoding/decoding.
+
+In short, the goal of this encoding is to encode integer values in a way that would save bytes.
+Only the first 7 bits of each byte is significant (right-justified; sort of like an ASCII byte). 
+So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes. 
+Of course, you will have a variable number of bytes depending upon your integer. 
+To indicate which is the last byte of the series, you leave bit #7 clear.
+In all of the preceding bytes, you set bit #7. 
+
+So, if an integer is between `0-127`, it can be represented as one byte. 
+Although VLQ can deal with numbers of arbitrary sizes, for this exercise we will restrict ourselves to only numbers that fit in a 32-bit unsigned integer.
+Here are examples of integers as 32-bit values, and the variable length quantities that they translate to:
+
+
+```
+ NUMBER        VARIABLE QUANTITY
+00000000              00
+00000040              40
+0000007F              7F
+00000080             81 00
+00002000             C0 00
+00003FFF             FF 7F
+00004000           81 80 00
+00100000           C0 80 00
+001FFFFF           FF FF 7F
+00200000          81 80 80 00
+08000000          C0 80 80 00
+0FFFFFFF          FF FF FF 7F
+```
+
+## Hints
+This exercise requires you to use bitwise operations. For more information, see [this page]
+(https://msdn.microsoft.com/en-us/library/6a71f45d.aspx). 
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+A poor Splice developer having to implement MIDI encoding/decoding. [https://splice.com](https://splice.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,0 +1,25 @@
+# Word Count
+
+Given a phrase, count the occurrences of each word in that phrase.
+
+For example for the input `"olly olly in come free"`
+
+```plain
+olly: 2
+in: 1
+come: 1
+free: 1
+```
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -1,0 +1,43 @@
+# Word Search
+
+In word search puzzles you get a square of letters and have to find specific
+words in them.
+
+For example:
+
+```
+jefblpepre
+camdcimgtc
+oivokprjsm
+pbwasqroua
+rixilelhrs
+wolcqlirpc
+screeaumgr
+alxhpburyi
+jalaycalmp
+clojurermt
+```
+
+There are several programming languages hidden in the above square.
+
+Words can be hidden in all kinds of directions: left-to-right, right-to-left,
+vertical and diagonal.
+
+Given a puzzle and a list of words return the location of the first and last
+letter of each word.
+
+## HINTS
+
+One of the uses of Tuples is returning multiple values from a function.   In this exercise, write
+a function that returns a Tuple (the x- and y- part of a coordinate).
+
+For more information on Tuples, see [this link](https://msdn.microsoft.com/en-us/library/system.tuple(v=vs.110).aspx).
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -1,0 +1,73 @@
+# Wordy
+
+Parse and evaluate simple math word problems returning the answer as an integer.
+
+
+## Iteration 1 — Addition
+
+Add two numbers together.
+
+> What is 5 plus 13?
+
+Evaluates to 18.
+
+Handle large numbers and negative numbers.
+
+
+## Iteration 2 — Subtraction, Multiplication and Division
+
+Now, perform the other three operations.
+
+> What is 7 minus 5?
+
+2
+
+> What is 6 multiplied by 4?
+
+24
+
+> What is 25 divided by 5?
+
+5
+
+
+## Iteration 3 — Multiple Operations
+
+Handle a set of operations, in sequence.
+
+Since these are verbal word problems, evaluate the expression from
+left-to-right, _ignoring the typical order of operations._
+
+> What is 5 plus 13 plus 6?
+
+24
+
+> What is 3 plus 2 multiplied by 3?
+
+15  (i.e. not 9)
+
+
+## Bonus — Exponentials
+
+If you'd like, handle exponentials.
+
+> What is 2 raised to the 5th power?
+
+32
+
+
+## Hints
+- To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/).
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Inspired by one of the generated questions in the Extreme Startup game. [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/zebra-puzzle/README.md
+++ b/exercises/zebra-puzzle/README.md
@@ -1,0 +1,43 @@
+# Zebra Puzzle
+
+Solve the zebra puzzle.
+
+1. There are five houses.
+2. The Englishman lives in the red house.
+3. The Spaniard owns the dog.
+4. Coffee is drunk in the green house.
+5. The Ukrainian drinks tea.
+6. The green house is immediately to the right of the ivory house.
+7. The Old Gold smoker owns snails.
+8. Kools are smoked in the yellow house.
+9. Milk is drunk in the middle house.
+10. The Norwegian lives in the first house.
+11. The man who smokes Chesterfields lives in the house next to the man with the fox.
+12. Kools are smoked in the house next to the house where the horse is kept.
+13. The Lucky Strike smoker drinks orange juice.
+14. The Japanese smokes Parliaments.
+15. The Norwegian lives next to the blue house.
+
+Each of the five houses is painted a different color, and their
+inhabitants are of different national extractions, own different pets,
+drink different beverages and smoke different brands of cigarettes.
+
+Which of the residents drinks water?
+Who owns the zebra?
+
+## Hints
+This exercise requires you to process a collection of data. You can simplify your code by using lazy sequences to improve performance.
+For more information, see [this page](https://xosfaere.wordpress.com/2010/03/21/lazy-evaluation-in-csharp/).
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Zebra_Puzzle](https://en.wikipedia.org/wiki/Zebra_Puzzle)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -1,0 +1,41 @@
+# Zipper
+
+Creating a zipper for a binary tree.
+
+[Zippers](https://en.wikipedia.org/wiki/Zipper_%28data_structure%29) are
+a way purely functional of navigating within a data structure and
+manipulating it.  They essentially contain a data structure and a
+pointer into that data structure (called the focus).
+
+For example given a rose tree (where each node contains a value and a
+list of child nodes) a zipper might support these operations:
+
+- `from_tree` (get a zipper out of a rose tree, the focus is on the root node)
+- `to_tree` (get the rose tree out of the zipper)
+- `value` (get the value of the focus node)
+- `prev` (move the focus to the previous child of the same parent,
+  returns a new zipper)
+- `next` (move the focus to the next child of the same parent, returns a
+  new zipper)
+- `up` (move the focus to the parent, returns a new zipper)
+- `set_value` (set the value of the focus node, returns a new zipper)
+- `insert_before` (insert a new subtree before the focus node, it
+  becomes the `prev` of the focus node, returns a new zipper)
+- `insert_after` (insert a new subtree after the focus node, it becomes
+  the `next` of the focus node, returns a new zipper)
+- `delete` (removes the focus node and all subtrees, focus moves to the
+  `next` node if possible otherwise to the `prev` node if possible,
+  otherwise to the parent node, returns a new zipper)
+
+## Hints
+This exercise deals with custom equality. For more information see [this page.](http://www.loganfranken.com/blog/687/overriding-equals-in-c-part-1/)
+
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
We are working towards making exercises stand-alone.
That is to say: no more generating READMEs on the fly.

This will give maintainers more control over each individual exercise
README, and it will also make some of the backend logic for delivering
exercises simpler.

This does not mean, however, hand-crafting READMEs from scratch.

I wrote some tooling to make it possible to generate the READMEs from
a customizable template.

The template uses the Go text/template package, and the default template
will generate the same READMEs as we have been generating on the fly.

See the documentation in [regenerating exercise readmes][regenerate-docs] for
details.

The READMEs can be generated at any time using a new 'generate' command in configlet. This command has not yet landed in master or been released, but can be built from source in the generate-readmes branch on [configlet][].

Tracking progress of all tracks in: https://github.com/exercism/meta/issues/15

[configlet]: https://github.com/exercism/configlet
[regenerate-docs]: https://github.com/exercism/docs/blob/master/maintaining-a-track/regenerating-exercise-readmes.md