### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,10 @@
   "active": true,
   "exercises": [
     {
+      "uuid": "6c88f46b-5acb-4fae-a6ec-b48ae3f8168f",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Text formatting",
@@ -13,7 +16,10 @@
       ]
     },
     {
+      "uuid": "da00f894-dbc8-485e-adba-a79d5ebee3ad",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -21,28 +27,40 @@
       ]
     },
     {
+      "uuid": "8ba15933-29a2-49b1-a9ce-70474bad3007",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Integers"
       ]
     },
     {
+      "uuid": "b7116dfb-1107-4546-9f95-f15acdb6f6a4",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Dates"
       ]
     },
     {
+      "uuid": "5554c048-0de3-4a85-b043-7577f429cba4",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Integers"
       ]
     },
     {
+      "uuid": "440b0b23-220d-4706-98f0-9a89fce85acb",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -50,7 +68,10 @@
       ]
     },
     {
+      "uuid": "d985d4a9-1a2b-4bb1-ad08-961b8d36ee2e",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Arrays",
@@ -58,14 +79,20 @@
       ]
     },
     {
+      "uuid": "612f058b-c6d9-4c97-913a-eeeb59ef61e1",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Floating-point numbers"
       ]
     },
     {
+      "uuid": "05162ee0-38ac-40ad-a591-d70a74b6963a",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Strings",
@@ -73,21 +100,30 @@
       ]
     },
     {
+      "uuid": "372c71b6-6256-4fe2-bddc-55667e3861af",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Integers"
       ]
     },
     {
+      "uuid": "a595d7a1-81d3-48f2-9921-e53b9b22e072",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Strings"
       ]
     },
     {
+      "uuid": "29ae7f8e-a009-4175-9350-a8c684c89730",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Text formatting",
@@ -95,7 +131,10 @@
       ]
     },
     {
+      "uuid": "caca1c6a-b998-431e-b6af-ca2d47b7708f",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Dictionaries",
@@ -103,7 +142,10 @@
       ]
     },
     {
+      "uuid": "3c0563dc-665a-45b4-9b29-f133e235efd0",
       "slug": "accumulate",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Extension methods",
@@ -112,14 +154,20 @@
       ]
     },
     {
+      "uuid": "96c641c8-4c3c-47ff-9e32-9722b5ca2c37",
       "slug": "bank-account",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Classes"
       ]
     },
     {
+      "uuid": "ec1cc254-8e66-40d0-87bf-971d54c541c4",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Lists",
@@ -127,7 +175,10 @@
       ]
     },
     {
+      "uuid": "36b7602c-44e2-4589-a97d-127a0277b2a2",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Dictionaries",
@@ -136,7 +187,10 @@
       ]
     },
     {
+      "uuid": "5675771e-1a46-40bd-8923-f6e09642cc0c",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Parsing",
@@ -144,7 +198,10 @@
       ]
     },
     {
+      "uuid": "fdb19da7-28df-429b-83e5-d024abe97870",
       "slug": "strain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Sequences",
@@ -152,14 +209,20 @@
       ]
     },
     {
+      "uuid": "89c42da3-72a6-423d-a9c7-7caccbd9b1e6",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Transforming"
       ]
     },
     {
+      "uuid": "b0a978a6-9c3f-427e-8ada-0a3951ca14fd",
       "slug": "proverb",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Text formatting",
@@ -167,7 +230,10 @@
       ]
     },
     {
+      "uuid": "46b8aea8-1528-43cb-a754-495ec2790ce2",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Randomness",
@@ -176,14 +242,20 @@
       ]
     },
     {
+      "uuid": "77e46f6b-1070-4267-a1b5-a2aac931975a",
       "slug": "error-handling",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Exception handling"
       ]
     },
     {
+      "uuid": "b7458404-2534-4ed8-8350-7060fa4b5786",
       "slug": "kindergarten-garden",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Parsing",
@@ -191,7 +263,10 @@
       ]
     },
     {
+      "uuid": "75a2d5f0-5f5e-46a3-9dd2-3da415690e18",
       "slug": "protein-translation",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Strings",
@@ -200,14 +275,20 @@
       ]
     },
     {
+      "uuid": "142c97b6-ae31-4b5f-944c-3eb789d9e051",
       "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Integers"
       ]
     },
     {
+      "uuid": "83e4cb1e-456f-4c74-ae82-6895f0bd73ae",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Time",
@@ -215,7 +296,10 @@
       ]
     },
     {
+      "uuid": "5b1713c7-1597-4e67-ac97-f305b207bc38",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Integers",
@@ -223,7 +307,10 @@
       ]
     },
     {
+      "uuid": "4ae402a7-5345-429a-a6af-e95ec5b95e13",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Text formatting",
@@ -231,7 +318,10 @@
       ]
     },
     {
+      "uuid": "1897605a-afd4-49fe-b6ee-cd822f0d8acc",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Filtering",
@@ -239,14 +329,20 @@
       ]
     },
     {
+      "uuid": "5c56211a-ae1e-4836-80b5-f22f5801b7a2",
       "slug": "queen-attack",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Classes"
       ]
     },
     {
+      "uuid": "f92ff94a-73e6-41cb-a376-835c2368b358",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Searching",
@@ -254,7 +350,10 @@
       ]
     },
     {
+      "uuid": "babd38cc-cf21-42ca-9d33-f2ad75c82871",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Classes",
@@ -262,7 +361,10 @@
       ]
     },
     {
+      "uuid": "4b7b65be-f777-4f64-94a0-4f9832f17a52",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Strings",
@@ -270,7 +372,10 @@
       ]
     },
     {
+      "uuid": "1ad236a9-7035-42e6-90ec-f6a4b94ad495",
       "slug": "secret-handshake",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Bitwise operations",
@@ -278,7 +383,10 @@
       ]
     },
     {
+      "uuid": "2ac228d8-7bf0-4946-8352-6541df02c0a2",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Bitwise operations",
@@ -286,7 +394,10 @@
       ]
     },
     {
+      "uuid": "2d68e971-d717-4196-a348-d4675a47283a",
       "slug": "simple-linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Classes",
@@ -294,7 +405,10 @@
       ]
     },
     {
+      "uuid": "ddfb0a0e-8c58-4b9e-ad62-57d06ef10f5f",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -302,7 +416,10 @@
       ]
     },
     {
+      "uuid": "73509caa-9b3e-4d09-933f-364c1a7e5519",
       "slug": "matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Matrices",
@@ -310,7 +427,10 @@
       ]
     },
     {
+      "uuid": "8a0a291d-8330-4901-bdbe-f974e163158e",
       "slug": "rotational-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -319,7 +439,10 @@
       ]
     },
     {
+      "uuid": "4a6621bb-e55a-4ae2-89e3-3aa7e37a8656",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -328,7 +451,10 @@
       ]
     },
     {
+      "uuid": "97aa0e82-2fc3-49e2-ad27-faef2873b328",
       "slug": "house",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Text formatting",
@@ -336,7 +462,10 @@
       ]
     },
     {
+      "uuid": "cb755a7d-e01d-4758-92ab-9d2e6518a3eb",
       "slug": "saddle-points",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Matrices",
@@ -345,7 +474,10 @@
       ]
     },
     {
+      "uuid": "4d5a53df-3d6b-46cb-a964-71c676f3cd93",
       "slug": "pythagorean-triplet",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Overloading",
@@ -354,7 +486,10 @@
       ]
     },
     {
+      "uuid": "9ca46617-4995-45cc-a2dd-b8630eaa288b",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -363,7 +498,10 @@
       ]
     },
     {
+      "uuid": "2627fb4f-7884-4494-8f49-5888107643f1",
       "slug": "twelve-days",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Text formatting",
@@ -371,7 +509,10 @@
       ]
     },
     {
+      "uuid": "790216d1-4fd9-4a9b-94f8-e1e07a18c2b7",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -379,7 +520,10 @@
       ]
     },
     {
+      "uuid": "6e8717a7-6888-474a-96ad-0760c6d3ff92",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -388,7 +532,10 @@
       ]
     },
     {
+      "uuid": "456ffe2c-e241-4373-8bea-d4d328f815e9",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Integers",
@@ -396,14 +543,20 @@
       ]
     },
     {
+      "uuid": "064096c1-89b0-4656-bd3e-08ca833aa0b1",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Dates"
       ]
     },
     {
+      "uuid": "de5e2eff-2b80-4996-a322-dc59ebe25edd",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Integers",
@@ -411,7 +564,10 @@
       ]
     },
     {
+      "uuid": "d5d48857-5325-45d2-9969-95a0d7bba370",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Control-flow (loops)",
@@ -420,7 +576,10 @@
       ]
     },
     {
+      "uuid": "3b5b11b0-9476-4d9b-a4c5-c5c48d3d32a8",
       "slug": "list-ops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Lists",
@@ -428,7 +587,10 @@
       ]
     },
     {
+      "uuid": "54649fb0-6b14-44df-85af-ae1f7a62449d",
       "slug": "simple-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -437,7 +599,10 @@
       ]
     },
     {
+      "uuid": "d3702b93-7bb3-4e0a-8cd7-974ad93b0d3d",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Control-flow (loops)",
@@ -445,7 +610,10 @@
       ]
     },
     {
+      "uuid": "9ad05373-a049-47f9-a06a-80ad0a7b38fd",
       "slug": "flatten-array",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Lists",
@@ -453,7 +621,10 @@
       ]
     },
     {
+      "uuid": "d40541a8-d7d6-4dab-8560-27c5055adbd0",
       "slug": "binary-search-tree",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Searching",
@@ -462,7 +633,10 @@
       ]
     },
     {
+      "uuid": "466f17d4-13d0-4d6e-8564-c8bdfede35d1",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Parsing",
@@ -470,7 +644,10 @@
       ]
     },
     {
+      "uuid": "0c5918d5-15cc-401f-b038-5fb2cd515ec7",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -479,7 +656,10 @@
       ]
     },
     {
+      "uuid": "3a09736e-4002-41aa-acf9-ff10a9392b24",
       "slug": "food-chain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Text formatting",
@@ -487,7 +667,10 @@
       ]
     },
     {
+      "uuid": "a9909a03-ce2e-45d9-85f8-a77f44fb2466",
       "slug": "grep",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Text formatting",
@@ -496,14 +679,20 @@
       ]
     },
     {
+      "uuid": "89d3b074-190f-4520-8f87-cde6368fc58e",
       "slug": "sublist",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Lists"
       ]
     },
     {
+      "uuid": "b31bff08-a609-40ec-a1ee-46ba24e671f2",
       "slug": "tree-building",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Trees",
@@ -511,7 +700,10 @@
       ]
     },
     {
+      "uuid": "c7d5acc6-68a6-4cd8-a28b-359dceb1e56f",
       "slug": "scale-generator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Parsing",
@@ -519,7 +711,10 @@
       ]
     },
     {
+      "uuid": "a2070019-e56d-4d48-994b-300411598707",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Parsing",
@@ -527,7 +722,10 @@
       ]
     },
     {
+      "uuid": "5863c898-2072-4543-9ab5-045fd6691de4",
       "slug": "parallel-letter-frequency",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Parallellism",
@@ -536,7 +734,10 @@
       ]
     },
     {
+      "uuid": "49b557ad-0bf0-451b-9a12-6dd9eb0291a2",
       "slug": "linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Classes",
@@ -544,7 +745,10 @@
       ]
     },
     {
+      "uuid": "dd95f3d8-6da4-4bb4-b5c1-bf00c818d586",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -553,7 +757,10 @@
       ]
     },
     {
+      "uuid": "c1cc752e-99a2-4da3-8d0c-82e08f1c6110",
       "slug": "ledger",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Globalization",
@@ -562,14 +769,20 @@
       ]
     },
     {
+      "uuid": "a6dff389-07ea-42cb-98ec-271ce7cfeda3",
       "slug": "custom-set",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Sets"
       ]
     },
     {
+      "uuid": "d128ec4b-190f-4726-b3e7-870be09531aa",
       "slug": "dot-dsl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Domain-specific languages",
@@ -578,7 +791,10 @@
       ]
     },
     {
+      "uuid": "2a5ddf5e-e677-4eef-b759-087d71e15986",
       "slug": "ocr-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Parsing",
@@ -586,7 +802,10 @@
       ]
     },
     {
+      "uuid": "657ac368-9b17-4f87-b815-decfe2bc0b5d",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Queues",
@@ -594,7 +813,10 @@
       ]
     },
     {
+      "uuid": "20fe4853-0eee-4171-b3c1-8ef871b99d13",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -603,7 +825,10 @@
       ]
     },
     {
+      "uuid": "dee4abe1-c75f-4cb8-b5f3-5b5b77e1c7aa",
       "slug": "markdown",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Parsing",
@@ -612,7 +837,10 @@
       ]
     },
     {
+      "uuid": "4ad0d49a-e10b-4f8b-b454-623b9396d559",
       "slug": "run-length-encoding",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Algorithms",
@@ -620,14 +848,20 @@
       ]
     },
     {
+      "uuid": "8288d3e0-75a4-4a18-94c7-2fab3228dc58",
       "slug": "book-store",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Recursion"
       ]
     },
     {
+      "uuid": "d9359f25-dc94-496c-adc3-57fe541857fe",
       "slug": "tournament",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Text formatting",
@@ -635,7 +869,10 @@
       ]
     },
     {
+      "uuid": "2b05d7dd-0f0b-4fa4-a2bf-9d7fa28a7543",
       "slug": "word-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Searching",
@@ -643,7 +880,10 @@
       ]
     },
     {
+      "uuid": "64eff1cb-990d-45bc-a9e7-8f574e114ece",
       "slug": "bowling",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Algorithms",
@@ -651,7 +891,10 @@
       ]
     },
     {
+      "uuid": "2634c53c-ba4d-4729-b936-a7ec387f4789",
       "slug": "transpose",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Strings",
@@ -659,14 +902,20 @@
       ]
     },
     {
+      "uuid": "60ef0713-70e2-4ee7-9207-86910e616ec1",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Mathematics"
       ]
     },
     {
+      "uuid": "63bdd2d4-b395-41ca-8c58-b3d94bf1e696",
       "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Strings",
@@ -674,7 +923,10 @@
       ]
     },
     {
+      "uuid": "e338fed5-f850-4922-88b2-7e9ec0eb7299",
       "slug": "rail-fence-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Strings",
@@ -683,7 +935,10 @@
       ]
     },
     {
+      "uuid": "44796c6c-39b3-41c7-8ea5-ffb9738423b8",
       "slug": "change",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Integers",
@@ -691,7 +946,10 @@
       ]
     },
     {
+      "uuid": "165b8599-726d-43dd-8511-1401525810de",
       "slug": "palindrome-products",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Strings",
@@ -700,7 +958,10 @@
       ]
     },
     {
+      "uuid": "d03a9508-336a-4425-8f47-f04317d1ba15",
       "slug": "poker",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Parsing",
@@ -709,7 +970,10 @@
       ]
     },
     {
+      "uuid": "3bea029d-ccc2-48be-90f3-84bf2d5b825b",
       "slug": "diffie-hellman",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Integers",
@@ -718,7 +982,10 @@
       ]
     },
     {
+      "uuid": "0409f45f-b65e-4404-a9e7-2ef432d834b2",
       "slug": "dominoes",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Tuples",
@@ -726,7 +993,10 @@
       ]
     },
     {
+      "uuid": "817ccde1-0593-4091-85a5-616f4f8823f0",
       "slug": "rectangles",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Parsing",
@@ -734,7 +1004,10 @@
       ]
     },
     {
+      "uuid": "57ef1936-d187-4915-888b-374f09c794c7",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Parsing",
@@ -743,14 +1016,20 @@
       ]
     },
     {
+      "uuid": "e167479e-e77d-4734-b8c0-a7cd686c74a3",
       "slug": "zebra-puzzle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Logic"
       ]
     },
     {
+      "uuid": "c9b12d50-09dc-4f43-9e7e-66b277432347",
       "slug": "hangman",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Reactive programming",
@@ -758,7 +1037,10 @@
       ]
     },
     {
+      "uuid": "2f3faeb7-7cc3-42ed-9525-cd9c73922a8d",
       "slug": "diamond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Text formatting",
@@ -766,14 +1048,20 @@
       ]
     },
     {
+      "uuid": "b33c3b86-e04b-4529-bdf5-9d553ad59f87",
       "slug": "two-bucket",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Logic"
       ]
     },
     {
+      "uuid": "ca56c362-c9f5-4403-9a2d-2e31e54b35e3",
       "slug": "connect",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Parsing",
@@ -781,7 +1069,10 @@
       ]
     },
     {
+      "uuid": "34518ea7-c202-443a-b28f-e873f3207f89",
       "slug": "say",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Strings",
@@ -790,7 +1081,10 @@
       ]
     },
     {
+      "uuid": "3e86c66d-c66e-4e28-834d-09b33b2ee2d2",
       "slug": "react",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "Reactive programming",
@@ -799,7 +1093,10 @@
       ]
     },
     {
+      "uuid": "4c49ea84-8765-42b0-b4ab-5dead802eeee",
       "slug": "variable-length-quantity",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "Bitwise operations",
@@ -807,7 +1104,10 @@
       ]
     },
     {
+      "uuid": "1abbc58c-9a04-4b6f-afe1-85d3e4d202e1",
       "slug": "go-counting",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "Parsing",
@@ -816,7 +1116,10 @@
       ]
     },
     {
+      "uuid": "da255a02-8007-41e4-8a9e-7e2cfbe81be5",
       "slug": "sgf-parsing",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "Parsing",
@@ -824,7 +1127,10 @@
       ]
     },
     {
+      "uuid": "db77fbd1-29d9-40e6-a32e-9fb89acdc9fc",
       "slug": "zipper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Trees",
@@ -833,7 +1139,10 @@
       ]
     },
     {
+      "uuid": "c6961cae-5e93-470a-98ce-e7cd6b9cfcbf",
       "slug": "alphametics",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Parsing",
@@ -841,7 +1150,10 @@
       ]
     },
     {
+      "uuid": "a2ba6202-f6e0-46f4-95e4-5921656f2e1a",
       "slug": "forth",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Parsing",
@@ -849,20 +1161,37 @@
       ]
     },
     {
+      "uuid": "a5794706-58d2-48f7-8aab-78639d7bce77",
       "slug": "pov",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Graphs",
         "Recursion",
         "Searching"
       ]
+    },
+    {
+      "uuid": "0b6acd72-5f95-46f1-8c0e-4863f5a141b4",
+      "slug": "binary",
+      "deprecated": true
+    },
+    {
+      "uuid": "a2e62b5b-20f4-4b20-b146-1422359d3899",
+      "slug": "trinary",
+      "deprecated": true
+    },
+    {
+      "uuid": "3611d603-829f-4882-93af-470dcc8aa661",
+      "slug": "octal",
+      "deprecated": true
+    },
+    {
+      "uuid": "b27e1667-02a0-432b-a942-1676e77b5757",
+      "slug": "hexadecimal",
+      "deprecated": true
     }
-  ],
-  "deprecated": [
-    "binary",
-    "trinary",
-    "octal",
-    "hexadecimal"
   ],
   "foregone": [
     "lens-person",

--- a/config.json
+++ b/config.json
@@ -1171,26 +1171,6 @@
         "Recursion",
         "Searching"
       ]
-    },
-    {
-      "uuid": "0b6acd72-5f95-46f1-8c0e-4863f5a141b4",
-      "slug": "binary",
-      "deprecated": true
-    },
-    {
-      "uuid": "a2e62b5b-20f4-4b20-b146-1422359d3899",
-      "slug": "trinary",
-      "deprecated": true
-    },
-    {
-      "uuid": "3611d603-829f-4882-93af-470dcc8aa661",
-      "slug": "octal",
-      "deprecated": true
-    },
-    {
-      "uuid": "b27e1667-02a0-432b-a942-1676e77b5757",
-      "slug": "hexadecimal",
-      "deprecated": true
     }
   ],
   "foregone": [


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16