### PR TITLE
Fix DotNet twitter handle and blog plug grammatical error

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -2,14 +2,14 @@
 
 ### Blogs
 * The official [.NET blog](https://blogs.msdn.microsoft.com/dotnet/) has lots of interesting C# articles, ranging from beginner to expert difficulty.
-* Scott Hanselman's [blog](http://www.hanselman.com/blog/) is an active, we'll written blog on a wide variety of C# and .NET related subjects.
+* Scott Hanselman's [blog](http://www.hanselman.com/blog/) is an active, well written blog on a wide variety of C# and .NET related subjects.
 * Eric Lippert's [Fabulous adventures in coding](https://ericlippert.com/) is a brilliant C# blog, although his subjects are usually quite advanced.
 * The [C#/.NET Little Wonders & Little Pitfalls](http://geekswithblogs.net/BlackRabbitCoder/archive/2015/04/02/c.net-little-wonders-amp-little-pitfalls-the-complete-collection.aspx) posts by James Michael Hare contains some fantastic posts on less known C# features.
 
 ### Social media
 * [StackOverflow ](http://stackoverflow.com/questions/tagged/c%23) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.
 * [/r/csharp](https://www.reddit.com/r/csharp) is the C# subreddit.
-* [@dotnet](https://twitter.com/DotNet) is the official .NET Twitter account.
+* [\@dotnet](https://twitter.com/DotNet) is the official .NET Twitter account.
 * [Gitter](https://gitter.im/exercism/xcsharp) is the C# Gitter room, go here to get support and ask questions related to the C# track.
 
 ### Videos


### PR DESCRIPTION
With markdown, the '@' symbol is used for citations, so the twitter handle is throwing markdown for a loop in the resources section.