### PR TITLE
Add CollatzConjecture exercise test generator

### DIFF
--- a/exercises/collatz-conjecture/CollatzConjecture.cs
+++ b/exercises/collatz-conjecture/CollatzConjecture.cs
@@ -2,7 +2,7 @@
 
 public static class CollatzConjecture
 {
-    public static int GetSteps(int input)
+    public static int Steps(int number)
     {
         throw new NotImplementedException("You need to implement this function");
     }

--- a/exercises/collatz-conjecture/CollatzConjectureTest.cs
+++ b/exercises/collatz-conjecture/CollatzConjectureTest.cs
@@ -1,43 +1,43 @@
-﻿// This file was auto-generated based on version 1.0.0 of the canonical data.
+// This file was auto-generated based on version 1.1.1 of the canonical data.
 
-using System;
 using Xunit;
+using System;
 
 public class CollatzConjectureTest
 {
     [Fact]
     public void Zero_steps_for_one()
     {
-        Assert.Equal(0, CollatzConjecture.GetSteps(1));
+        Assert.Equal(0, CollatzConjecture.Steps(1));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Divide_if_even()
     {
-        Assert.Equal(4, CollatzConjecture.GetSteps(16));
+        Assert.Equal(4, CollatzConjecture.Steps(16));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Even_and_odd_steps()
     {
-        Assert.Equal(9, CollatzConjecture.GetSteps(12));
+        Assert.Equal(9, CollatzConjecture.Steps(12));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Large_number_of_even_and_odd_steps()
     {
-        Assert.Equal(152, CollatzConjecture.GetSteps(1000000)); 
+        Assert.Equal(152, CollatzConjecture.Steps(1000000));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Zero_is_an_error()
     {
-        Assert.Throws<ArgumentException>(() => CollatzConjecture.GetSteps(0));
+        Assert.Throws<ArgumentException>(() => CollatzConjecture.Steps(0));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Negative_value_is_an_error()
     {
-        Assert.Throws<ArgumentException>(() => CollatzConjecture.GetSteps(-15));
+        Assert.Throws<ArgumentException>(() => CollatzConjecture.Steps(-15));
     }
 }

--- a/exercises/collatz-conjecture/Example.cs
+++ b/exercises/collatz-conjecture/Example.cs
@@ -2,24 +2,24 @@
 
 public static class CollatzConjecture
 {
-    public static int GetSteps(int input)
+    public static int Steps(int number)
     {
-        if(input <= 0)
+        if(number <= 0)
         {
             throw new ArgumentException("Only positive numbers are allowed");
         }
 
         int stepCount = 0;
 
-        while(input != 1)
+        while(number != 1)
         {
-            if(input % 2 == 0)
+            if(number % 2 == 0)
             {
-                input /= 2;
+                number /= 2;
             }
             else
             {
-                input = (input * 3) + 1;
+                number = (number * 3) + 1;
             }
 
             stepCount++;

--- a/generators/Exercises/CollatzConjecture.cs
+++ b/generators/Exercises/CollatzConjecture.cs
@@ -1,0 +1,16 @@
+﻿using Generators.Input;
+using System;
+
+namespace Generators.Exercises
+{
+    public class CollatzConjecture : Exercise
+    {
+        protected override void UpdateCanonicalData(CanonicalData canonical)
+        {
+            foreach (var canonicalDataCase in CanonicalData.Cases)
+            {
+                canonicalDataCase.ExceptionThrown = (long)canonicalDataCase.Input["number"] <= 0 ? typeof(ArgumentException) : null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
One thing I did notice after using the new generator is that UpdateCanonicalData(CanonicalData canonicalData) takes a param, but it really doesn't need to since it uses the property from the Exercise abstract anyway.
