### PR TITLE
Use exceptions everywhere instead of null

### DIFF
--- a/exercises/phone-number/Example.cs
+++ b/exercises/phone-number/Example.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -17,7 +18,7 @@ public class PhoneNumber
         }
         else
         {
-            return null;
+            throw new ArgumentException("invalid phone number");
         }
     }
 }

--- a/exercises/phone-number/PhoneNumberTest.cs
+++ b/exercises/phone-number/PhoneNumberTest.cs
@@ -1,6 +1,7 @@
 // This file was auto-generated based on version 1.2.0 of the canonical data.
 
 using Xunit;
+using System;
 
 public class PhoneNumberTest
 {
@@ -29,14 +30,14 @@ public class PhoneNumberTest
     public void Invalid_when_9_digits()
     {
         var phrase = "123456789";
-        Assert.Null(PhoneNumber.Clean(phrase));
+        Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Invalid_when_11_digits_does_not_start_with_a_1()
     {
         var phrase = "22234567890";
-        Assert.Null(PhoneNumber.Clean(phrase));
+        Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -57,34 +58,34 @@ public class PhoneNumberTest
     public void Invalid_when_more_than_11_digits()
     {
         var phrase = "321234567890";
-        Assert.Null(PhoneNumber.Clean(phrase));
+        Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Invalid_with_letters()
     {
         var phrase = "123-abc-7890";
-        Assert.Null(PhoneNumber.Clean(phrase));
+        Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Invalid_with_punctuations()
     {
         var phrase = "123-@:!-7890";
-        Assert.Null(PhoneNumber.Clean(phrase));
+        Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Invalid_if_area_code_does_not_start_with_2_9()
     {
         var phrase = "(123) 456-7890";
-        Assert.Null(PhoneNumber.Clean(phrase));
+        Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Invalid_if_exchange_code_does_not_start_with_2_9()
     {
         var phrase = "(223) 056-7890";
-        Assert.Null(PhoneNumber.Clean(phrase));
+        Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 }

--- a/exercises/rna-transcription/Example.cs
+++ b/exercises/rna-transcription/Example.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,7 +13,7 @@ public static class RnaTranscription
     {
         if (nucleotide.Any(x => !DnaToRna.ContainsKey(x)))
         {
-            return null;
+            throw new ArgumentException("invalid nucleotide");
         }
 
         return string.Concat(nucleotide.Select(x => DnaToRna[x]));

--- a/exercises/rna-transcription/RnaTranscriptionTest.cs
+++ b/exercises/rna-transcription/RnaTranscriptionTest.cs
@@ -1,6 +1,7 @@
 // This file was auto-generated based on version 1.0.1 of the canonical data.
 
 using Xunit;
+using System;
 
 public class RnaTranscriptionTest
 {
@@ -37,18 +38,18 @@ public class RnaTranscriptionTest
     [Fact(Skip = "Remove to run test")]
     public void Correctly_handles_invalid_input_rna_instead_of_dna_()
     {
-        Assert.Null(RnaTranscription.ToRna("U"));
+        Assert.Throws<ArgumentException>(() => RnaTranscription.ToRna("U"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Correctly_handles_completely_invalid_dna_input()
     {
-        Assert.Null(RnaTranscription.ToRna("XXX"));
+        Assert.Throws<ArgumentException>(() => RnaTranscription.ToRna("XXX"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Correctly_handles_partially_invalid_dna_input()
     {
-        Assert.Null(RnaTranscription.ToRna("ACGTXXXCTTAA"));
+        Assert.Throws<ArgumentException>(() => RnaTranscription.ToRna("ACGTXXXCTTAA"));
     }
 }

--- a/generators/Exercises/PhoneNumber.cs
+++ b/generators/Exercises/PhoneNumber.cs
@@ -1,4 +1,5 @@
-﻿using Generators.Input;
+﻿using System;
+using Generators.Input;
 
 namespace Generators.Exercises
 {
@@ -9,6 +10,7 @@ namespace Generators.Exercises
             foreach (var canonicalDataCase in CanonicalData.Cases)
             {
                 canonicalDataCase.UseVariablesForInput = true;
+                canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is null ? typeof(ArgumentException) : null;
             }
         }
     }

--- a/generators/Exercises/RnaTranscription.cs
+++ b/generators/Exercises/RnaTranscription.cs
@@ -1,6 +1,16 @@
-﻿namespace Generators.Exercises
+﻿using System;
+using Generators.Input;
+
+namespace Generators.Exercises
 {
     public class RnaTranscription : Exercise
     {
+        protected override void UpdateCanonicalData(CanonicalData canonicalData)
+        {
+            foreach (var canonicalDataCase in CanonicalData.Cases)
+            {
+                canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is null ? typeof(ArgumentException) : null;
+            }
+        }
     }
 }


### PR DESCRIPTION
After our discussion in #366 I've migrated what I think are the remaining test generated exercises to throw exceptions.

I didn't remove the `Assert.Null` method @jpreese added because we may want to use it at some point.