### PR TITLE
Add support for Dictionary<string,int>

### DIFF
--- a/generators/Output/ValueFormatter.cs
+++ b/generators/Output/ValueFormatter.cs
@@ -16,6 +16,8 @@ namespace Generators.Output
                     return string.Join(", ", dict.Values.Select(Format));
                 case IDictionary<char, int> dict:
                     return $"new Dictionary<char, int> {{ {string.Join(", ", dict.Keys.Select(key => $"[{Format(key)}] = {Format(dict[key])}"))} }}";
+                case IDictionary<string, int> dict:
+                    return $"new Dictionary<string, int> {{ {string.Join(", ", dict.Keys.Select(key => $"[{Format(key)}] = {Format(dict[key])}"))} }}";
                 case Enum enumeration:
                     return $"{enumeration.GetType().Name}.{enumeration}";
                 case JArray jArray:
@@ -52,6 +54,8 @@ namespace Generators.Output
                     return FormatMultiLineEnumerable(strings, name);
                 case IDictionary<char, int> dict:
                     return FormatMultiLineEnumerable(dict.Keys.Select((key, i) => $"[{Format(key)}] = {Format(dict[key])}" + (i < dict.Keys.Count - 1 ? "," : "")), name, "new Dictionary<char, int>");
+                case IDictionary<string, int> dict:
+                    return FormatMultiLineEnumerable(dict.Keys.Select((key, i) => $"[{Format(key)}] = {Format(dict[key])}" + (i < dict.Keys.Count - 1 ? "," : "")), name, "new Dictionary<string, int>");
                 default:
                     return new[] {$"var {name} = {Format(val)};"};
             }


### PR DESCRIPTION
Was trying to implement the word-count generator and noticed the results looked similar to calling ToString() on the resulting Dictionary object. After some debugging I noticed we explicity check for <char,int> inside of ValueFormatter.cs -- in this case <string,int> is needed.

I'm not a huge fan of the duplication and checking specifically for types, but outside of doing a lot of reflection work I'm not sold on an alternative approach right now.