### PR TITLE
Sanitize canonical data properties

### DIFF
--- a/exercises/binary-search/BinarySearchTest.cs
+++ b/exercises/binary-search/BinarySearchTest.cs
@@ -61,7 +61,7 @@ public class BinarySearchTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void A_value_smaller_than_the_array_s_smallest_value_is_not_included()
+    public void A_value_smaller_than_the_arrays_smallest_value_is_not_included()
     {
         var array = new[] { 1, 3, 4, 6, 8, 9, 11 };
         var sut = new BinarySearch(array);
@@ -69,7 +69,7 @@ public class BinarySearchTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void A_value_larger_than_the_array_s_largest_value_is_not_included()
+    public void A_value_larger_than_the_arrays_largest_value_is_not_included()
     {
         var array = new[] { 1, 3, 4, 6, 8, 9, 11 };
         var sut = new BinarySearch(array);

--- a/exercises/raindrops/RaindropsTest.cs
+++ b/exercises/raindrops/RaindropsTest.cs
@@ -59,13 +59,13 @@ public class RaindropsTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void The_sound_for_15_is_pling_plang_as_it_has_factors_3_and_5()
+    public void The_sound_for_15_is_plingplang_as_it_has_factors_3_and_5()
     {
         Assert.Equal("PlingPlang", Raindrops.Convert(15));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void The_sound_for_21_is_pling_plong_as_it_has_factors_3_and_7()
+    public void The_sound_for_21_is_plingplong_as_it_has_factors_3_and_7()
     {
         Assert.Equal("PlingPlong", Raindrops.Convert(21));
     }
@@ -83,7 +83,7 @@ public class RaindropsTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void The_sound_for_35_is_plang_plong_as_it_has_factors_5_and_7()
+    public void The_sound_for_35_is_plangplong_as_it_has_factors_5_and_7()
     {
         Assert.Equal("PlangPlong", Raindrops.Convert(35));
     }
@@ -101,7 +101,7 @@ public class RaindropsTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void The_sound_for_105_is_pling_plang_plong_as_it_has_factors_3_5_and_7()
+    public void The_sound_for_105_is_plingplangplong_as_it_has_factors_3_5_and_7()
     {
         Assert.Equal("PlingPlangPlong", Raindrops.Convert(105));
     }

--- a/exercises/roman-numerals/RomanNumeralsTest.cs
+++ b/exercises/roman-numerals/RomanNumeralsTest.cs
@@ -11,13 +11,13 @@ public class RomanNumeralsTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Number_2_is_two_i_s()
+    public void Number_2_is_two_is()
     {
         Assert.Equal("II", 2.ToRoman());
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Number_3_is_three_i_s()
+    public void Number_3_is_three_is()
     {
         Assert.Equal("III", 3.ToRoman());
     }
@@ -47,7 +47,7 @@ public class RomanNumeralsTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Number_20_is_two_x_s()
+    public void Number_20_is_two_xs()
     {
         Assert.Equal("XXVII", 27.ToRoman());
     }
@@ -107,7 +107,7 @@ public class RomanNumeralsTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Number_3000_is_three_m_s()
+    public void Number_3000_is_three_ms()
     {
         Assert.Equal("MMM", 3000.ToRoman());
     }

--- a/generators/Exercises/Pangram.cs
+++ b/generators/Exercises/Pangram.cs
@@ -8,7 +8,6 @@ namespace Generators.Exercises
         {
             foreach (var canonicalDataCase in CanonicalData.Cases)
             {
-                canonicalDataCase.Description = canonicalDataCase.Description.Replace("'", string.Empty);
                 canonicalDataCase.UseVariablesForInput = true;
                 canonicalDataCase.Input["input"] = ((string)canonicalDataCase.Input["input"]).Replace("\"", "\\\"");
             }

--- a/generators/Exercises/RomanNumerals.cs
+++ b/generators/Exercises/RomanNumerals.cs
@@ -10,7 +10,6 @@ namespace Generators.Exercises
             {
                 canonicalDataCase.TestedMethodType = TestedMethodType.Extension;
                 canonicalDataCase.Property = "ToRoman";
-                canonicalDataCase.Description = "Number_" + canonicalDataCase.Description;
             }
         }
     }

--- a/generators/Output/NameExtensions.cs
+++ b/generators/Output/NameExtensions.cs
@@ -14,10 +14,12 @@ namespace Generators.Output
 
         public static string ToTestMethodName(this string input)
         {
-            var methodName = 
-                Regex.Replace(input.Replace(":", " is"), @"[^\w]+", "_", RegexOptions.Compiled)
-                    .Underscore()
-                    .Transform(To.TitleCase);
+            var methodName = input
+                .Replace(":", " is")
+                .Replace("'", "");
+
+            methodName = Regex.Replace(methodName, @"[^\w]+", "_", RegexOptions.Compiled)
+                .Transform(To.TitleCase);
 
             if (char.IsDigit(methodName[0]))
                 return "Number_" + methodName;


### PR DESCRIPTION
For #356 

I felt Underscore() wasn't really doing much, because we're already doing a replace via regex. This removal does change the RaindropsTest to be plingplang instead of pling_plang, but I think I favor it as the canonical shows PlingPlang.

