### PR TITLE
Use canonical data parameter

### DIFF
--- a/generators/Exercise.cs
+++ b/generators/Exercise.cs
@@ -11,7 +11,7 @@ namespace Generators
         
         public string Name => GetType().ToExerciseName();
 
-        protected CanonicalData CanonicalData { get; private set; }
+        private CanonicalData CanonicalData { get; set; }
         
         public void Regenerate(CanonicalData canonicalData)
         {

--- a/generators/Exercise.cs
+++ b/generators/Exercise.cs
@@ -8,15 +8,14 @@ namespace Generators
     public abstract class Exercise
     {
         private static readonly ExerciseWriter ExerciseWriter = new ExerciseWriter();
-        
+        private CanonicalData _canonicalData { get; set; }
+
         public string Name => GetType().ToExerciseName();
 
-        private CanonicalData CanonicalData { get; set; }
-        
         public void Regenerate(CanonicalData canonicalData)
         {
-            CanonicalData = canonicalData;
-            UpdateCanonicalData(CanonicalData);
+            _canonicalData = canonicalData;
+            UpdateCanonicalData(canonicalData);
 
             ExerciseWriter.WriteToFile(this);
         }
@@ -31,7 +30,7 @@ namespace Generators
         {
             ClassName = Name.ToTestClassName(),
             Methods = RenderTestMethods(),
-            CanonicalDataVersion = CanonicalData.Version,
+            CanonicalDataVersion = _canonicalData.Version,
             UsingNamespaces = GetUsingNamespaces()
         };
 
@@ -39,13 +38,13 @@ namespace Generators
         {
             var usingNamespaces = new HashSet<string> { "Xunit" };
 
-            foreach (var canonicalDataCase in CanonicalData.Cases.Where(canonicalDataCase => canonicalDataCase.ExceptionThrown != null))
+            foreach (var canonicalDataCase in _canonicalData.Cases.Where(canonicalDataCase => canonicalDataCase.ExceptionThrown != null))
                 usingNamespaces.Add(canonicalDataCase.ExceptionThrown.Namespace);
 
             return usingNamespaces;
         }
 
-        protected virtual string[] RenderTestMethods() => CanonicalData.Cases.Select(RenderTestMethod).ToArray();
+        protected virtual string[] RenderTestMethods() => _canonicalData.Cases.Select(RenderTestMethod).ToArray();
 
         protected virtual string RenderTestMethod(CanonicalDataCase canonicalDataCase, int index) => CreateTestMethod(canonicalDataCase, index).Render();
 
@@ -70,20 +69,20 @@ namespace Generators
         {
             if (canonicalDataCase.ExceptionThrown != null)
             {
-                return new TestMethodBodyWithExceptionCheck(canonicalDataCase, CanonicalData);
+                return new TestMethodBodyWithExceptionCheck(canonicalDataCase, _canonicalData);
             }
 
             if (canonicalDataCase.Expected is bool)
             {
-                return new TestMethodBodyWithBooleanCheck(canonicalDataCase, CanonicalData);
+                return new TestMethodBodyWithBooleanCheck(canonicalDataCase, _canonicalData);
             }
 
             if (canonicalDataCase.Expected is null)
             {
-                return new TestMethodBodyWithNullCheck(canonicalDataCase, CanonicalData);
+                return new TestMethodBodyWithNullCheck(canonicalDataCase, _canonicalData);
             }
 
-            return new TestMethodBodyWithEqualityCheck(canonicalDataCase, CanonicalData);
+            return new TestMethodBodyWithEqualityCheck(canonicalDataCase, _canonicalData);
         }
 
         protected virtual string RenderTestMethodBodyArrange(TestMethodBody testMethodBody)

--- a/generators/Exercises/AllYourBase.cs
+++ b/generators/Exercises/AllYourBase.cs
@@ -7,13 +7,13 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.Input["input_digits"] = canonicalDataCase.Input["input_digits"].ConvertToEnumerable<int>();
 
                 canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is null ? typeof(ArgumentException) : null;
                 canonicalDataCase.UseVariablesForInput = true;
-                canonicalDataCase.UseVariableForExpected = canonicalDataCase.ExceptionThrown == null;
+                canonicalDataCase.UseVariableForExpected = true;
             }
         }
     }

--- a/generators/Exercises/Allergies.cs
+++ b/generators/Exercises/Allergies.cs
@@ -10,7 +10,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 if (canonicalDataCase.Property == "allergicTo")
                 {

--- a/generators/Exercises/Alphametics.cs
+++ b/generators/Exercises/Alphametics.cs
@@ -9,7 +9,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.UseVariableForExpected = true;
                 canonicalDataCase.UseVariableForTested = true;

--- a/generators/Exercises/Anagram.cs
+++ b/generators/Exercises/Anagram.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.ConstructorInput = new Dictionary<string, object>
                 {

--- a/generators/Exercises/BeerSong.cs
+++ b/generators/Exercises/BeerSong.cs
@@ -6,7 +6,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
                 canonicalDataCase.UseVariableForExpected = true;
         }
     }

--- a/generators/Exercises/BinarySearch.cs
+++ b/generators/Exercises/BinarySearch.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.ConstructorInput = new Dictionary<string, object>
                 {

--- a/generators/Exercises/BookStore.cs
+++ b/generators/Exercises/BookStore.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.Input = new Dictionary<string, object>
                 {

--- a/generators/Exercises/BracketPush.cs
+++ b/generators/Exercises/BracketPush.cs
@@ -6,7 +6,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.Input["input"] = ((string)canonicalDataCase.Input["input"]).Replace("\\", "\\\\");
                 canonicalDataCase.UseVariablesForInput = true;

--- a/generators/Exercises/CollatzConjecture.cs
+++ b/generators/Exercises/CollatzConjecture.cs
@@ -5,9 +5,9 @@ namespace Generators.Exercises
 {
     public class CollatzConjecture : Exercise
     {
-        protected override void UpdateCanonicalData(CanonicalData canonical)
+        protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.ExceptionThrown = (long)canonicalDataCase.Input["number"] <= 0 ? typeof(ArgumentException) : null;
             }

--- a/generators/Exercises/CryptoSquare.cs
+++ b/generators/Exercises/CryptoSquare.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.UseVariablesForInput = true;
                 canonicalDataCase.UseVariableForExpected = true;

--- a/generators/Exercises/FoodChain.cs
+++ b/generators/Exercises/FoodChain.cs
@@ -6,7 +6,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.Expected = canonicalDataCase.Expected.ConvertMultiLineString();
                 canonicalDataCase.UseVariableForExpected = true;

--- a/generators/Exercises/Gigasecond.cs
+++ b/generators/Exercises/Gigasecond.cs
@@ -9,7 +9,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 // Update input
                 var input = DateTime.Parse(canonicalDataCase.Input["input"].ToString());

--- a/generators/Exercises/Hamming.cs
+++ b/generators/Exercises/Hamming.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is long ? null : typeof(ArgumentException);
             }

--- a/generators/Exercises/House.cs
+++ b/generators/Exercises/House.cs
@@ -6,7 +6,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.UseVariableForExpected = true;
                 canonicalDataCase.Expected = canonicalDataCase.Expected.ConvertMultiLineString();

--- a/generators/Exercises/Leap.cs
+++ b/generators/Exercises/Leap.cs
@@ -6,7 +6,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
                 canonicalDataCase.Property = "IsLeapYear";
         }
     }

--- a/generators/Exercises/Luhn.cs
+++ b/generators/Exercises/Luhn.cs
@@ -6,7 +6,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
                 canonicalDataCase.Property = "IsValid";
         }
     }

--- a/generators/Exercises/NthPrime.cs
+++ b/generators/Exercises/NthPrime.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
                 canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is bool ? typeof(ArgumentOutOfRangeException) : null;
         }
     }

--- a/generators/Exercises/PerfectNumbers.cs
+++ b/generators/Exercises/PerfectNumbers.cs
@@ -10,7 +10,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is JObject ? typeof(ArgumentOutOfRangeException) : null;
 

--- a/generators/Exercises/PhoneNumber.cs
+++ b/generators/Exercises/PhoneNumber.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.UseVariablesForInput = true;
                 canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is null ? typeof(ArgumentException) : null;

--- a/generators/Exercises/RailFenceCipher.cs
+++ b/generators/Exercises/RailFenceCipher.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.ConstructorInput = new Dictionary<string, object>
                 {

--- a/generators/Exercises/RnaTranscription.cs
+++ b/generators/Exercises/RnaTranscription.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is null ? typeof(ArgumentException) : null;
             }

--- a/generators/Exercises/RomanNumerals.cs
+++ b/generators/Exercises/RomanNumerals.cs
@@ -6,7 +6,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.TestedMethodType = TestedMethodType.Extension;
                 canonicalDataCase.Property = "ToRoman";

--- a/generators/Exercises/RunLengthEncoding.cs
+++ b/generators/Exercises/RunLengthEncoding.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 // Prefix the test name with encode/decode because both functions are tested with the same cases
                 canonicalDataCase.Description = $"{canonicalDataCase.Property} {canonicalDataCase.Description}";

--- a/generators/Exercises/Say.cs
+++ b/generators/Exercises/Say.cs
@@ -7,14 +7,9 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
-                // Rename the property to avoid it being considered a constructor
-                if (canonicalDataCase.Property == "say")
-                {
-                    canonicalDataCase.Property = "in_english";
-                }
-
+                canonicalDataCase.Property = "InEnglish";
                 canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is long ? typeof(ArgumentOutOfRangeException) : null;
             }
         }

--- a/generators/Exercises/SecretHandshake.cs
+++ b/generators/Exercises/SecretHandshake.cs
@@ -6,7 +6,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.Expected = canonicalDataCase.Expected.ConvertToEnumerable<string>();
             }

--- a/generators/Exercises/Sieve.cs
+++ b/generators/Exercises/Sieve.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.UseVariableForExpected = true;
                 canonicalDataCase.ExceptionThrown = (long)canonicalDataCase.Input["limit"] < 2 ? typeof(ArgumentOutOfRangeException) : null;

--- a/generators/Exercises/SpaceAge.cs
+++ b/generators/Exercises/SpaceAge.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.TestedMethodType = TestedMethodType.Instance;
 

--- a/generators/Exercises/SumOfMultiples.cs
+++ b/generators/Exercises/SumOfMultiples.cs
@@ -8,7 +8,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 var hasFactors = canonicalDataCase.Input["factors"].ConvertToEnumerable<long>().Any();
 

--- a/generators/Exercises/Transpose.cs
+++ b/generators/Exercises/Transpose.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.Property = "String";
                 canonicalDataCase.Input = new Dictionary<string, object>

--- a/generators/Exercises/WordCount.cs
+++ b/generators/Exercises/WordCount.cs
@@ -8,7 +8,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
             {
                 canonicalDataCase.UseVariableForExpected = true;
                 canonicalDataCase.UseVariableForTested = true;

--- a/generators/Exercises/Wordy.cs
+++ b/generators/Exercises/Wordy.cs
@@ -7,7 +7,7 @@ namespace Generators.Exercises
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
-            foreach (var canonicalDataCase in CanonicalData.Cases)
+            foreach (var canonicalDataCase in canonicalData.Cases)
                 canonicalDataCase.ExceptionThrown = canonicalDataCase.Expected is bool ? typeof(ArgumentException) : null;
         }
     }


### PR DESCRIPTION
This is something that @ErikSchierboom and I briefly touched upon in #344. 

Currently CanonicalData is directly accessible to the derived classes. Our UpdateCanonicalData method passes a parameter, but most generators reference the property directly. This privatizes that property and forces the Update method to leverage the parameter.