### PR TITLE
Run builds and tests in parallel

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -95,9 +95,13 @@ Task("TestUsingExampleImplementation")
     .IsDependentOn("ReplaceStubWithExample")
     .Does(() => {
         DotNetCoreBuild(allSln, dotNetCoreBuildSettings);
+        var parallelOptions = new ParallelOptions 
+        {
+            MaxDegreeOfParallelism = System.Environment.ProcessorCount
+        };
 
         var allProjects = GetFiles(buildDir + "/*/*.csproj");
-        Parallel.ForEach(allProjects, (project) => DotNetCoreTest(project.FullPath, dotNetCoreTestSettings));
+        Parallel.ForEach(allProjects, parallelOptions, (project) => DotNetCoreTest(project.FullPath, dotNetCoreTestSettings));
     });
 
 Task("Default")

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 var target = Argument("target", "Default");
 
@@ -10,7 +11,16 @@ var defaultSln     = buildDir + "/Exercises.Default.sln";
 var allSln         = buildDir + "/Exercises.All.sln";
 var refactoringSln = buildDir + "/Exercises.Refactoring.sln";
 
-var dotNetCoreBuildSettings = new DotNetCoreBuildSettings { NoIncremental = true };
+var dotNetCoreMSBuildSettings = new DotNetCoreMSBuildSettings
+{
+    MaxCpuCount = 0
+};
+
+var dotNetCoreBuildSettings = new DotNetCoreBuildSettings 
+{ 
+    NoIncremental = true,
+    MSBuildSettings = dotNetCoreMSBuildSettings 
+};
 
 Task("Clean")
     .Does(() => {
@@ -64,9 +74,7 @@ Task("TestRefactoringProjects")
             + GetFiles(buildDir + "/*/Ledger.csproj")
             + GetFiles(buildDir + "/*/Markdown.csproj");
 
-        foreach (var refactoringProject in refactoringProjects) {
-            DotNetCoreTest(refactoringProject.FullPath);
-        }
+        Parallel.ForEach(refactoringProjects, (project) => DotNetCoreTest(project.FullPath));
 });
 
 Task("ReplaceStubWithExample")
@@ -91,10 +99,7 @@ Task("TestUsingExampleImplementation")
         DotNetCoreBuild(allSln, dotNetCoreBuildSettings);
 
         var allProjects = GetFiles(buildDir + "/*/*.csproj");
-
-        foreach (var project in allProjects) {
-            DotNetCoreTest(project.FullPath);
-        }
+        Parallel.ForEach(allProjects, (project) => DotNetCoreTest(project.FullPath));
     });
 
 Task("Default")

--- a/build.cake
+++ b/build.cake
@@ -7,7 +7,6 @@ var target = Argument("target", "Default");
 var sourceDir = "./exercises";
 var buildDir  = "./build";
 
-var defaultSln     = buildDir + "/Exercises.Default.sln";
 var allSln         = buildDir + "/Exercises.All.sln";
 var refactoringSln = buildDir + "/Exercises.Refactoring.sln";
 
@@ -20,6 +19,11 @@ var dotNetCoreBuildSettings = new DotNetCoreBuildSettings
 { 
     NoIncremental = true,
     MSBuildSettings = dotNetCoreMSBuildSettings 
+};
+
+var dotNetCoreTestSettings = new DotNetCoreTestSettings
+{
+    NoBuild = true
 };
 
 Task("Clean")
@@ -40,14 +44,8 @@ Task("RestoreNugetPackages")
         DotNetCoreRestore(allSln);
     });
 
-Task("BuildStubImplementations")
-    .IsDependentOn("RestoreNugetPackages")
-    .Does(() => {
-        DotNetCoreBuild(defaultSln, dotNetCoreBuildSettings);
-});
-
 Task("EnableAllTests")
-    .IsDependentOn("BuildStubImplementations")
+    .IsDependentOn("RestoreNugetPackages")
     .Does(() => {
         var skipRegex = new Regex(@"Skip\s*=\s*""Remove to run test""", RegexOptions.Compiled);
         var testFiles = GetFiles(buildDir + "/*/*Test.cs");
@@ -74,7 +72,7 @@ Task("TestRefactoringProjects")
             + GetFiles(buildDir + "/*/Ledger.csproj")
             + GetFiles(buildDir + "/*/Markdown.csproj");
 
-        Parallel.ForEach(refactoringProjects, (project) => DotNetCoreTest(project.FullPath));
+        Parallel.ForEach(refactoringProjects, (project) => DotNetCoreTest(project.FullPath, dotNetCoreTestSettings));
 });
 
 Task("ReplaceStubWithExample")
@@ -99,7 +97,7 @@ Task("TestUsingExampleImplementation")
         DotNetCoreBuild(allSln, dotNetCoreBuildSettings);
 
         var allProjects = GetFiles(buildDir + "/*/*.csproj");
-        Parallel.ForEach(allProjects, (project) => DotNetCoreTest(project.FullPath));
+        Parallel.ForEach(allProjects, (project) => DotNetCoreTest(project.FullPath, dotNetCoreTestSettings));
     });
 
 Task("Default")

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-$CakeVersion = "0.20.0"
+$CakeVersion = "0.21.1"
 $DotNetVersion = "1.0.4";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
-CAKE_VERSION=0.20.0
+CAKE_VERSION=0.21.1
 CAKE_DLL=$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION/Cake.dll
 DOTNET_VERSION=1.0.4
 


### PR DESCRIPTION
For #303 

I couldn't find any native support within dotnet core or Cake for running things in parallel -- but since we're using Cake we have access to the TPL.

Our average build time was around 17-18minutes from what I could see in previous TravisCI builds, this drops it down to around 4 minutes on my machine.