### PR TITLE
Infer value of properties in canonical data case model

### DIFF
--- a/generators/Exercises/Allergies.cs
+++ b/generators/Exercises/Allergies.cs
@@ -26,8 +26,6 @@ namespace Generators.Exercises
                 {
                     ["score"] = canonicalDataCase.Properties["score"]
                 };
-                canonicalDataCase.Input.Remove("score");
-                canonicalDataCase.TestedMethodType = TestedMethodType.Instance;
             }
         }
 

--- a/generators/Exercises/Anagram.cs
+++ b/generators/Exercises/Anagram.cs
@@ -13,13 +13,11 @@ namespace Generators.Exercises
                 {
                     ["subject"] = canonicalDataCase.Input["subject"]
                 };
-                canonicalDataCase.Input.Remove("subject");
                 canonicalDataCase.Input["candidates"] = canonicalDataCase.Input["candidates"].ConvertToEnumerable<string>();
                 canonicalDataCase.Expected = canonicalDataCase.Expected.ConvertToEnumerable<string>();
 
                 canonicalDataCase.UseVariablesForInput = true;
                 canonicalDataCase.UseVariableForExpected = true;
-                canonicalDataCase.TestedMethodType = TestedMethodType.Instance;
             }
         }
     }

--- a/generators/Exercises/BinarySearch.cs
+++ b/generators/Exercises/BinarySearch.cs
@@ -13,10 +13,8 @@ namespace Generators.Exercises
                 {
                     ["array"] = canonicalDataCase.Input["array"].ConvertToEnumerable<int>()
                 };
-                canonicalDataCase.Input.Remove("array");
 
                 canonicalDataCase.UseVariablesForConstructorParameters = true;
-                canonicalDataCase.TestedMethodType = TestedMethodType.Instance;
             }
         }
     }

--- a/generators/Exercises/ComplexNumbers.cs
+++ b/generators/Exercises/ComplexNumbers.cs
@@ -18,8 +18,6 @@ namespace Generators.Exercises
 
             foreach (var canonicalDataCase in canonicalData.Cases)
             {
-                canonicalDataCase.TestedMethodType = TestedMethodType.Instance;
-
                 // Process expected
                 if (IsComplexNumber(canonicalDataCase.Expected))
                 {

--- a/generators/Exercises/RailFenceCipher.cs
+++ b/generators/Exercises/RailFenceCipher.cs
@@ -13,8 +13,7 @@ namespace Generators.Exercises
                 {
                     ["rails"] = canonicalDataCase.Properties["rails"]
                 };
-                canonicalDataCase.Input.Remove("rails");
-                canonicalDataCase.TestedMethodType = TestedMethodType.Instance;
+
                 canonicalDataCase.UseVariablesForInput = true;
                 canonicalDataCase.UseVariableForExpected = true;
             }

--- a/generators/Exercises/SpaceAge.cs
+++ b/generators/Exercises/SpaceAge.cs
@@ -9,13 +9,10 @@ namespace Generators.Exercises
         {
             foreach (var canonicalDataCase in canonicalData.Cases)
             {
-                canonicalDataCase.TestedMethodType = TestedMethodType.Instance;
-
                 canonicalDataCase.ConstructorInput = new Dictionary<string, object>
                 {
                     ["seconds"] = canonicalDataCase.Properties["seconds"]
                 };
-                canonicalDataCase.Input.Remove("seconds");
 
                 canonicalDataCase.Property = $"On_{canonicalDataCase.Input["planet"]}";
                 canonicalDataCase.Input.Remove("planet");

--- a/generators/Input/CanonicalDataCase.cs
+++ b/generators/Input/CanonicalDataCase.cs
@@ -2,12 +2,15 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Generators.Input
 {
     [JsonConverter(typeof(CanonicalDataCaseJsonConverter))]
     public class CanonicalDataCase
     {
+        private IDictionary<string, object> _constructorInput;
+
         [Required]
         public string Description { get; set; }
 
@@ -18,7 +21,20 @@ namespace Generators.Input
         public IDictionary<string, object> Input { get; set; }
 
         [JsonIgnore]
-        public IDictionary<string, object> ConstructorInput { get; set; }
+        public IDictionary<string, object> ConstructorInput
+        {
+            get
+            {
+                return _constructorInput;
+            }
+            set
+            {
+                RemoveDuplicateInputEntries(value);
+                UpdateInstanceType(value);
+
+                _constructorInput = value;
+            }
+        }
 
         public object Expected { get; set; }
 
@@ -38,9 +54,28 @@ namespace Generators.Input
         public bool UseVariableForTested { get; set; }
 
         [JsonIgnore]
-        public TestedMethodType TestedMethodType { get; set; } = TestedMethodType.Static;
+        public TestedMethodType TestedMethodType { get; set; }
 
         [JsonIgnore]
         public Type ExceptionThrown { get; set; }
+
+        private void RemoveDuplicateInputEntries(IDictionary<string, object> constructorInputDictionary)
+        {
+            foreach (var key in constructorInputDictionary.Keys)
+            {
+                if (Input.ContainsKey(key))
+                {
+                    Input.Remove(key);
+                }
+            }
+        }
+
+        private void UpdateInstanceType(IDictionary<string, object> constructorInputDictionary)
+        {
+            if (constructorInputDictionary.Keys.Any())
+            {
+                TestedMethodType = TestedMethodType.Instance;
+            }
+        }
     }
 }


### PR DESCRIPTION
This makes some assumptions that I think will always hold true and changes the CanonicalDataCase model to being purely anemic to a little richer. We have quite a few tests and this logic doesn't change any of them and reduces the amount of code needed to produce the tests.

I admittedly might be getting too clever here, but I noticed some patterns and wanted to get some feedback from you guys. I felt it was at least worth discussion.