### PR TITLE
Refactor exercise access modifiers

### DIFF
--- a/generators/Exercises/Alphametics.cs
+++ b/generators/Exercises/Alphametics.cs
@@ -21,12 +21,12 @@ namespace Generators.Exercises
             }
         }
 
-        protected override HashSet<string> GetUsingNamespaces()
+        protected override HashSet<string> AddAdditionalNamespaces()
         {
-            var usingNamespaces = base.GetUsingNamespaces();
-            usingNamespaces.Add(typeof(Dictionary<char, int>).Namespace);
-
-            return usingNamespaces;
+            return new HashSet<string>()
+            {
+                typeof(Dictionary<char, int>).Namespace
+            };
         }
     }
 }

--- a/generators/Exercises/ComplexNumbers.cs
+++ b/generators/Exercises/ComplexNumbers.cs
@@ -62,17 +62,17 @@ namespace Generators.Exercises
 
         private static string RenderComplexNumberAssert(TestMethodBody testMethodBody)
         {
-            var tmeplate = "Assert.Equal({{ ExpectedParameter }}.Real(), {{ TestedValue }}.Real(), 15);\r\nAssert.Equal({{ ExpectedParameter }}.Imaginary(), {{ TestedValue }}.Imaginary(), 15);";
+            var template = "Assert.Equal({{ ExpectedParameter }}.Real(), {{ TestedValue }}.Real(), 15);\r\nAssert.Equal({{ ExpectedParameter }}.Imaginary(), {{ TestedValue }}.Imaginary(), 15);";
 
-            return TemplateRenderer.RenderInline(tmeplate, testMethodBody.AssertTemplateParameters);
+            return TemplateRenderer.RenderInline(template, testMethodBody.AssertTemplateParameters);
         }
 
-        protected override HashSet<string> GetUsingNamespaces()
+        protected override HashSet<string> AddAdditionalNamespaces()
         {
-            var usingNamespaces = base.GetUsingNamespaces();
-            usingNamespaces.Add(typeof(Math).Namespace);
-
-            return usingNamespaces;
+            return new HashSet<string>()
+            {
+                typeof(Math).Namespace
+            };
         }
 
         private object ConvertToType(object rawValue)

--- a/generators/Exercises/Gigasecond.cs
+++ b/generators/Exercises/Gigasecond.cs
@@ -20,12 +20,12 @@ namespace Generators.Exercises
             }
         }
 
-        protected override HashSet<string> GetUsingNamespaces()
+        protected override HashSet<string> AddAdditionalNamespaces()
         {
-            var usingNamespaces = base.GetUsingNamespaces();
-            usingNamespaces.Add(typeof(DateTime).Namespace);
-
-            return usingNamespaces;
+            return new HashSet<string>()
+            {
+                typeof(DateTime).Namespace
+            };
         }
 
         private string FormatDateTime(DateTime dateTime)

--- a/generators/Exercises/WordCount.cs
+++ b/generators/Exercises/WordCount.cs
@@ -16,12 +16,12 @@ namespace Generators.Exercises
             }
         }
 
-        protected override HashSet<string> GetUsingNamespaces()
+        protected override HashSet<string> AddAdditionalNamespaces()
         {
-            var usingNamespaces = base.GetUsingNamespaces();
-            usingNamespaces.Add(typeof(Dictionary<string, int>).Namespace);
-
-            return usingNamespaces;
+            return new HashSet<string>()
+            {
+                typeof(Dictionary<string, int>).Namespace
+            };
         }
     }
 }

--- a/generators/Output/TestClass.cs
+++ b/generators/Output/TestClass.cs
@@ -7,7 +7,7 @@ namespace Generators.Output
         public string ClassName { get; set; }
         public string CanonicalDataVersion { get; set; }
         public IList<string> Methods { get; set; }
-        public ISet<string> UsingNamespaces { get; set; } = new HashSet<string> { "Xunit" };
+        public ISet<string> UsingNamespaces { get; set; }
         public string TemplateName { get; set; } = "TestClass";
         
         public string Render() => TemplateRenderer.RenderPartial(TemplateName, new { ClassName, CanonicalDataVersion, Methods, UsingNamespaces });


### PR DESCRIPTION
A little refactoring.

1) Most of the methods that live inside of the Exercise base class are protected virtual, so that they can be overridden. However, in practice, only a select few are really ever going to be overridden. This may change in the future, but its always easy to open up accessibility modifiers, rather than restrict them later down the road.

2) Cleaned up how we can add namespaces. I personally like to avoid having to call into the base method where possible, and just keep the methods that the test generators will be using to be as simple and straight forward as possible. If you want to add more namespaces, then just go ahead and return a list of namespaces you want to be added.