### PR TITLE
[WIP] Use dynamic for Expected property

### DIFF
--- a/generators/Exercises/QueenAttack.cs
+++ b/generators/Exercises/QueenAttack.cs
@@ -68,7 +68,7 @@ Assert.{% if Expected %}True{% else %}False{% endif %}(QueenAttack.CanAttack(whi
 
         private static void SetCreatePropertyData(CanonicalDataCase canonicalDataCase)
         {
-            var validExpected = (long)canonicalDataCase.Expected >= 0;
+            var validExpected = canonicalDataCase.Expected >= 0;
 
             canonicalDataCase.UseVariableForTested = validExpected;
             canonicalDataCase.ExceptionThrown = validExpected ? null : typeof(ArgumentOutOfRangeException);

--- a/generators/Input/CanonicalDataCase.cs
+++ b/generators/Input/CanonicalDataCase.cs
@@ -36,7 +36,7 @@ namespace Generators.Input
             }
         }
 
-        public object Expected { get; set; }
+        public dynamic Expected { get; set; }
 
         [JsonIgnore]
         public IDictionary<string, object> Properties { get; set; }


### PR DESCRIPTION
Spawned from discussions in gitter, just so I don't forget about this. I'll pursue this a little harder when Erik wraps up his ToEnumerable() work.

Use dynamic to avoid having to cast the Expected property as a long