### PR TITLE
Remove Exe OutputType from PropertyGroup

### DIFF
--- a/exercises/accumulate/Accumulate.csproj
+++ b/exercises/accumulate/Accumulate.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/accumulate/Accumulate.csproj
+++ b/exercises/accumulate/Accumulate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/acronym/Acronym.csproj
+++ b/exercises/acronym/Acronym.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/all-your-base/AllYourBase.csproj
+++ b/exercises/all-your-base/AllYourBase.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/all-your-base/AllYourBase.csproj
+++ b/exercises/all-your-base/AllYourBase.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/allergies/Allergies.csproj
+++ b/exercises/allergies/Allergies.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/allergies/Allergies.csproj
+++ b/exercises/allergies/Allergies.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/alphametics/Alphametics.csproj
+++ b/exercises/alphametics/Alphametics.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/alphametics/Alphametics.csproj
+++ b/exercises/alphametics/Alphametics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/anagram/Anagram.csproj
+++ b/exercises/anagram/Anagram.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/anagram/Anagram.csproj
+++ b/exercises/anagram/Anagram.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/atbash-cipher/AtbashCipher.csproj
+++ b/exercises/atbash-cipher/AtbashCipher.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/atbash-cipher/AtbashCipher.csproj
+++ b/exercises/atbash-cipher/AtbashCipher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/bank-account/BankAccount.csproj
+++ b/exercises/bank-account/BankAccount.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/bank-account/BankAccount.csproj
+++ b/exercises/bank-account/BankAccount.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/beer-song/BeerSong.csproj
+++ b/exercises/beer-song/BeerSong.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/beer-song/BeerSong.csproj
+++ b/exercises/beer-song/BeerSong.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/binary-search-tree/BinarySearchTree.csproj
+++ b/exercises/binary-search-tree/BinarySearchTree.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/binary-search-tree/BinarySearchTree.csproj
+++ b/exercises/binary-search-tree/BinarySearchTree.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/binary-search/BinarySearch.csproj
+++ b/exercises/binary-search/BinarySearch.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/binary-search/BinarySearch.csproj
+++ b/exercises/binary-search/BinarySearch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/bob/Bob.csproj
+++ b/exercises/bob/Bob.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/bob/Bob.csproj
+++ b/exercises/bob/Bob.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/book-store/BookStore.csproj
+++ b/exercises/book-store/BookStore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/book-store/BookStore.csproj
+++ b/exercises/book-store/BookStore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/bowling/Bowling.csproj
+++ b/exercises/bowling/Bowling.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/bowling/Bowling.csproj
+++ b/exercises/bowling/Bowling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/bracket-push/BracketPush.csproj
+++ b/exercises/bracket-push/BracketPush.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/bracket-push/BracketPush.csproj
+++ b/exercises/bracket-push/BracketPush.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/change/Change.csproj
+++ b/exercises/change/Change.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/change/Change.csproj
+++ b/exercises/change/Change.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/circular-buffer/CircularBuffer.csproj
+++ b/exercises/circular-buffer/CircularBuffer.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/circular-buffer/CircularBuffer.csproj
+++ b/exercises/circular-buffer/CircularBuffer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/clock/Clock.csproj
+++ b/exercises/clock/Clock.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/clock/Clock.csproj
+++ b/exercises/clock/Clock.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/collatz-conjecture/CollatzConjecture.csproj
+++ b/exercises/collatz-conjecture/CollatzConjecture.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/collatz-conjecture/CollatzConjecture.csproj
+++ b/exercises/collatz-conjecture/CollatzConjecture.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/complex-numbers/ComplexNumbers.csproj
+++ b/exercises/complex-numbers/ComplexNumbers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/connect/Connect.csproj
+++ b/exercises/connect/Connect.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/connect/Connect.csproj
+++ b/exercises/connect/Connect.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/crypto-square/CryptoSquare.csproj
+++ b/exercises/crypto-square/CryptoSquare.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/crypto-square/CryptoSquare.csproj
+++ b/exercises/crypto-square/CryptoSquare.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/custom-set/CustomSet.csproj
+++ b/exercises/custom-set/CustomSet.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/custom-set/CustomSet.csproj
+++ b/exercises/custom-set/CustomSet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/diamond/Diamond.csproj
+++ b/exercises/diamond/Diamond.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/diamond/Diamond.csproj
+++ b/exercises/diamond/Diamond.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/difference-of-squares/DifferenceOfSquares.csproj
+++ b/exercises/difference-of-squares/DifferenceOfSquares.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/difference-of-squares/DifferenceOfSquares.csproj
+++ b/exercises/difference-of-squares/DifferenceOfSquares.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/diffie-hellman/DiffieHellman.csproj
+++ b/exercises/diffie-hellman/DiffieHellman.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/diffie-hellman/DiffieHellman.csproj
+++ b/exercises/diffie-hellman/DiffieHellman.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/dominoes/Dominoes.csproj
+++ b/exercises/dominoes/Dominoes.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/dominoes/Dominoes.csproj
+++ b/exercises/dominoes/Dominoes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/dot-dsl/DotDsl.csproj
+++ b/exercises/dot-dsl/DotDsl.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/dot-dsl/DotDsl.csproj
+++ b/exercises/dot-dsl/DotDsl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/error-handling/ErrorHandling.csproj
+++ b/exercises/error-handling/ErrorHandling.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/error-handling/ErrorHandling.csproj
+++ b/exercises/error-handling/ErrorHandling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/etl/Etl.csproj
+++ b/exercises/etl/Etl.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/etl/Etl.csproj
+++ b/exercises/etl/Etl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/flatten-array/FlattenArray.csproj
+++ b/exercises/flatten-array/FlattenArray.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/flatten-array/FlattenArray.csproj
+++ b/exercises/flatten-array/FlattenArray.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/food-chain/FoodChain.csproj
+++ b/exercises/food-chain/FoodChain.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/food-chain/FoodChain.csproj
+++ b/exercises/food-chain/FoodChain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/forth/Forth.csproj
+++ b/exercises/forth/Forth.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/forth/Forth.csproj
+++ b/exercises/forth/Forth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/gigasecond/Gigasecond.csproj
+++ b/exercises/gigasecond/Gigasecond.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/gigasecond/Gigasecond.csproj
+++ b/exercises/gigasecond/Gigasecond.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/go-counting/GoCounting.csproj
+++ b/exercises/go-counting/GoCounting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/go-counting/GoCounting.csproj
+++ b/exercises/go-counting/GoCounting.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/grade-school/GradeSchool.csproj
+++ b/exercises/grade-school/GradeSchool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/grade-school/GradeSchool.csproj
+++ b/exercises/grade-school/GradeSchool.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/grains/Grains.csproj
+++ b/exercises/grains/Grains.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/grains/Grains.csproj
+++ b/exercises/grains/Grains.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/grep/Grep.csproj
+++ b/exercises/grep/Grep.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/grep/Grep.csproj
+++ b/exercises/grep/Grep.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/hamming/Hamming.csproj
+++ b/exercises/hamming/Hamming.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/hamming/Hamming.csproj
+++ b/exercises/hamming/Hamming.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/hangman/Hangman.csproj
+++ b/exercises/hangman/Hangman.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/hangman/Hangman.csproj
+++ b/exercises/hangman/Hangman.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/hello-world/HelloWorld.csproj
+++ b/exercises/hello-world/HelloWorld.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/hello-world/HelloWorld.csproj
+++ b/exercises/hello-world/HelloWorld.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/house/House.csproj
+++ b/exercises/house/House.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/house/House.csproj
+++ b/exercises/house/House.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/isogram/Isogram.csproj
+++ b/exercises/isogram/Isogram.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/isogram/Isogram.csproj
+++ b/exercises/isogram/Isogram.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/kindergarten-garden/KindergartenGarden.csproj
+++ b/exercises/kindergarten-garden/KindergartenGarden.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/kindergarten-garden/KindergartenGarden.csproj
+++ b/exercises/kindergarten-garden/KindergartenGarden.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/largest-series-product/LargestSeriesProduct.csproj
+++ b/exercises/largest-series-product/LargestSeriesProduct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/largest-series-product/LargestSeriesProduct.csproj
+++ b/exercises/largest-series-product/LargestSeriesProduct.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/leap/Leap.csproj
+++ b/exercises/leap/Leap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/leap/Leap.csproj
+++ b/exercises/leap/Leap.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/ledger/Ledger.csproj
+++ b/exercises/ledger/Ledger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/ledger/Ledger.csproj
+++ b/exercises/ledger/Ledger.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/linked-list/LinkedList.csproj
+++ b/exercises/linked-list/LinkedList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/linked-list/LinkedList.csproj
+++ b/exercises/linked-list/LinkedList.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/list-ops/ListOps.csproj
+++ b/exercises/list-ops/ListOps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/list-ops/ListOps.csproj
+++ b/exercises/list-ops/ListOps.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/luhn/Luhn.csproj
+++ b/exercises/luhn/Luhn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/luhn/Luhn.csproj
+++ b/exercises/luhn/Luhn.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/markdown/Markdown.csproj
+++ b/exercises/markdown/Markdown.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/markdown/Markdown.csproj
+++ b/exercises/markdown/Markdown.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/matrix/Matrix.csproj
+++ b/exercises/matrix/Matrix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/matrix/Matrix.csproj
+++ b/exercises/matrix/Matrix.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/meetup/Meetup.csproj
+++ b/exercises/meetup/Meetup.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/meetup/Meetup.csproj
+++ b/exercises/meetup/Meetup.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/minesweeper/Minesweeper.csproj
+++ b/exercises/minesweeper/Minesweeper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/minesweeper/Minesweeper.csproj
+++ b/exercises/minesweeper/Minesweeper.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/nth-prime/NthPrime.csproj
+++ b/exercises/nth-prime/NthPrime.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/nth-prime/NthPrime.csproj
+++ b/exercises/nth-prime/NthPrime.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/nucleotide-count/NucleotideCount.csproj
+++ b/exercises/nucleotide-count/NucleotideCount.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/nucleotide-count/NucleotideCount.csproj
+++ b/exercises/nucleotide-count/NucleotideCount.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/ocr-numbers/OcrNumbers.csproj
+++ b/exercises/ocr-numbers/OcrNumbers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/ocr-numbers/OcrNumbers.csproj
+++ b/exercises/ocr-numbers/OcrNumbers.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/palindrome-products/PalindromeProducts.csproj
+++ b/exercises/palindrome-products/PalindromeProducts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/palindrome-products/PalindromeProducts.csproj
+++ b/exercises/palindrome-products/PalindromeProducts.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pangram/Pangram.csproj
+++ b/exercises/pangram/Pangram.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pangram/Pangram.csproj
+++ b/exercises/pangram/Pangram.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/parallel-letter-frequency/ParallelLetterFrequency.csproj
+++ b/exercises/parallel-letter-frequency/ParallelLetterFrequency.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/parallel-letter-frequency/ParallelLetterFrequency.csproj
+++ b/exercises/parallel-letter-frequency/ParallelLetterFrequency.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pascals-triangle/PascalsTriangle.csproj
+++ b/exercises/pascals-triangle/PascalsTriangle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pascals-triangle/PascalsTriangle.csproj
+++ b/exercises/pascals-triangle/PascalsTriangle.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/perfect-numbers/PerfectNumbers.csproj
+++ b/exercises/perfect-numbers/PerfectNumbers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/perfect-numbers/PerfectNumbers.csproj
+++ b/exercises/perfect-numbers/PerfectNumbers.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/phone-number/PhoneNumber.csproj
+++ b/exercises/phone-number/PhoneNumber.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/phone-number/PhoneNumber.csproj
+++ b/exercises/phone-number/PhoneNumber.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pig-latin/PigLatin.csproj
+++ b/exercises/pig-latin/PigLatin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pig-latin/PigLatin.csproj
+++ b/exercises/pig-latin/PigLatin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/poker/Poker.csproj
+++ b/exercises/poker/Poker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/poker/Poker.csproj
+++ b/exercises/poker/Poker.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pov/Pov.csproj
+++ b/exercises/pov/Pov.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pov/Pov.csproj
+++ b/exercises/pov/Pov.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/prime-factors/PrimeFactors.csproj
+++ b/exercises/prime-factors/PrimeFactors.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/prime-factors/PrimeFactors.csproj
+++ b/exercises/prime-factors/PrimeFactors.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/protein-translation/ProteinTranslation.csproj
+++ b/exercises/protein-translation/ProteinTranslation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/protein-translation/ProteinTranslation.csproj
+++ b/exercises/protein-translation/ProteinTranslation.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/proverb/Proverb.csproj
+++ b/exercises/proverb/Proverb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/proverb/Proverb.csproj
+++ b/exercises/proverb/Proverb.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pythagorean-triplet/PythagoreanTriplet.csproj
+++ b/exercises/pythagorean-triplet/PythagoreanTriplet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/pythagorean-triplet/PythagoreanTriplet.csproj
+++ b/exercises/pythagorean-triplet/PythagoreanTriplet.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/queen-attack/QueenAttack.csproj
+++ b/exercises/queen-attack/QueenAttack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/queen-attack/QueenAttack.csproj
+++ b/exercises/queen-attack/QueenAttack.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/rail-fence-cipher/RailFenceCipher.csproj
+++ b/exercises/rail-fence-cipher/RailFenceCipher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/rail-fence-cipher/RailFenceCipher.csproj
+++ b/exercises/rail-fence-cipher/RailFenceCipher.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/raindrops/Raindrops.csproj
+++ b/exercises/raindrops/Raindrops.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/raindrops/Raindrops.csproj
+++ b/exercises/raindrops/Raindrops.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/react/React.csproj
+++ b/exercises/react/React.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/react/React.csproj
+++ b/exercises/react/React.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/rectangles/Rectangles.csproj
+++ b/exercises/rectangles/Rectangles.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/rectangles/Rectangles.csproj
+++ b/exercises/rectangles/Rectangles.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/rna-transcription/RnaTranscription.csproj
+++ b/exercises/rna-transcription/RnaTranscription.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/rna-transcription/RnaTranscription.csproj
+++ b/exercises/rna-transcription/RnaTranscription.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/robot-name/RobotName.csproj
+++ b/exercises/robot-name/RobotName.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/robot-name/RobotName.csproj
+++ b/exercises/robot-name/RobotName.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/robot-simulator/RobotSimulator.csproj
+++ b/exercises/robot-simulator/RobotSimulator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/robot-simulator/RobotSimulator.csproj
+++ b/exercises/robot-simulator/RobotSimulator.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/roman-numerals/RomanNumerals.csproj
+++ b/exercises/roman-numerals/RomanNumerals.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/roman-numerals/RomanNumerals.csproj
+++ b/exercises/roman-numerals/RomanNumerals.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/rotational-cipher/RotationalCipher.csproj
+++ b/exercises/rotational-cipher/RotationalCipher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/rotational-cipher/RotationalCipher.csproj
+++ b/exercises/rotational-cipher/RotationalCipher.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/run-length-encoding/RunLengthEncoding.csproj
+++ b/exercises/run-length-encoding/RunLengthEncoding.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/run-length-encoding/RunLengthEncoding.csproj
+++ b/exercises/run-length-encoding/RunLengthEncoding.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/saddle-points/SaddlePoints.csproj
+++ b/exercises/saddle-points/SaddlePoints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/saddle-points/SaddlePoints.csproj
+++ b/exercises/saddle-points/SaddlePoints.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/say/Say.csproj
+++ b/exercises/say/Say.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/say/Say.csproj
+++ b/exercises/say/Say.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/scale-generator/ScaleGenerator.csproj
+++ b/exercises/scale-generator/ScaleGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/scale-generator/ScaleGenerator.csproj
+++ b/exercises/scale-generator/ScaleGenerator.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/scrabble-score/ScrabbleScore.csproj
+++ b/exercises/scrabble-score/ScrabbleScore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/scrabble-score/ScrabbleScore.csproj
+++ b/exercises/scrabble-score/ScrabbleScore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/secret-handshake/SecretHandshake.csproj
+++ b/exercises/secret-handshake/SecretHandshake.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/secret-handshake/SecretHandshake.csproj
+++ b/exercises/secret-handshake/SecretHandshake.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/series/Series.csproj
+++ b/exercises/series/Series.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/series/Series.csproj
+++ b/exercises/series/Series.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/sgf-parsing/SgfParsing.csproj
+++ b/exercises/sgf-parsing/SgfParsing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/sgf-parsing/SgfParsing.csproj
+++ b/exercises/sgf-parsing/SgfParsing.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/sieve/Sieve.csproj
+++ b/exercises/sieve/Sieve.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/sieve/Sieve.csproj
+++ b/exercises/sieve/Sieve.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/simple-cipher/SimpleCipher.csproj
+++ b/exercises/simple-cipher/SimpleCipher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/simple-cipher/SimpleCipher.csproj
+++ b/exercises/simple-cipher/SimpleCipher.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/simple-linked-list/SimpleLinkedList.csproj
+++ b/exercises/simple-linked-list/SimpleLinkedList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/simple-linked-list/SimpleLinkedList.csproj
+++ b/exercises/simple-linked-list/SimpleLinkedList.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/space-age/SpaceAge.csproj
+++ b/exercises/space-age/SpaceAge.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/space-age/SpaceAge.csproj
+++ b/exercises/space-age/SpaceAge.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/spiral-matrix/SpiralMatrix.csproj
+++ b/exercises/spiral-matrix/SpiralMatrix.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/exercises/spiral-matrix/SpiralMatrix.csproj
+++ b/exercises/spiral-matrix/SpiralMatrix.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/spiral-matrix/SpiralMatrix.csproj
+++ b/exercises/spiral-matrix/SpiralMatrix.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/strain/Strain.csproj
+++ b/exercises/strain/Strain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/strain/Strain.csproj
+++ b/exercises/strain/Strain.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/sublist/Sublist.csproj
+++ b/exercises/sublist/Sublist.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/sublist/Sublist.csproj
+++ b/exercises/sublist/Sublist.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/sum-of-multiples/SumOfMultiples.csproj
+++ b/exercises/sum-of-multiples/SumOfMultiples.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/sum-of-multiples/SumOfMultiples.csproj
+++ b/exercises/sum-of-multiples/SumOfMultiples.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/tournament/Tournament.csproj
+++ b/exercises/tournament/Tournament.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/tournament/Tournament.csproj
+++ b/exercises/tournament/Tournament.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/transpose/Transpose.csproj
+++ b/exercises/transpose/Transpose.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/transpose/Transpose.csproj
+++ b/exercises/transpose/Transpose.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/tree-building/TreeBuilding.csproj
+++ b/exercises/tree-building/TreeBuilding.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/tree-building/TreeBuilding.csproj
+++ b/exercises/tree-building/TreeBuilding.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/triangle/Triangle.csproj
+++ b/exercises/triangle/Triangle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/triangle/Triangle.csproj
+++ b/exercises/triangle/Triangle.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/twelve-days/TwelveDays.csproj
+++ b/exercises/twelve-days/TwelveDays.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/twelve-days/TwelveDays.csproj
+++ b/exercises/twelve-days/TwelveDays.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/two-bucket/TwoBucket.csproj
+++ b/exercises/two-bucket/TwoBucket.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/two-bucket/TwoBucket.csproj
+++ b/exercises/two-bucket/TwoBucket.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/two-fer/TwoFer.csproj
+++ b/exercises/two-fer/TwoFer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/exercises/two-fer/TwoFer.csproj
+++ b/exercises/two-fer/TwoFer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/two-fer/TwoFer.csproj
+++ b/exercises/two-fer/TwoFer.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/variable-length-quantity/VariableLengthQuantity.csproj
+++ b/exercises/variable-length-quantity/VariableLengthQuantity.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/variable-length-quantity/VariableLengthQuantity.csproj
+++ b/exercises/variable-length-quantity/VariableLengthQuantity.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/word-count/WordCount.csproj
+++ b/exercises/word-count/WordCount.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/word-count/WordCount.csproj
+++ b/exercises/word-count/WordCount.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/word-search/WordSearch.csproj
+++ b/exercises/word-search/WordSearch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/word-search/WordSearch.csproj
+++ b/exercises/word-search/WordSearch.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/wordy/Wordy.csproj
+++ b/exercises/wordy/Wordy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/wordy/Wordy.csproj
+++ b/exercises/wordy/Wordy.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/zebra-puzzle/ZebraPuzzle.csproj
+++ b/exercises/zebra-puzzle/ZebraPuzzle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/zebra-puzzle/ZebraPuzzle.csproj
+++ b/exercises/zebra-puzzle/ZebraPuzzle.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/zipper/Zipper.csproj
+++ b/exercises/zipper/Zipper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/exercises/zipper/Zipper.csproj
+++ b/exercises/zipper/Zipper.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    
+  <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
This shouldn't really be necessary as we do not have main methods / run programs; just ensure test suites pass.

I also snuck in a couple upgrades to .NET Core 2 since we had some 1.1s that got through the find/replace.