### PR TITLE
Add Nucleotide Count Test Generator #416

### DIFF
--- a/exercises/nucleotide-count/Example.cs
+++ b/exercises/nucleotide-count/Example.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
 
-public class DNA
+public class NucleotideCount
 {
     public IDictionary<char, int> NucleotideCounts { get; private set; }
 
-    public DNA(string sequence)
+    public NucleotideCount(string sequence)
     {
         InitializeNucleotideCounts(sequence);
     }
@@ -13,16 +13,15 @@ public class DNA
     private void InitializeNucleotideCounts(string sequence)
     {
         NucleotideCounts = new Dictionary<char, int> { { 'A', 0 }, { 'T', 0 }, { 'C', 0 }, { 'G', 0 } };
-        foreach (var s in sequence)
-            NucleotideCounts[s] += 1;
-    }
-
-    public int Count(char nucleotide)
-    {
-        int count;
-        if (!NucleotideCounts.TryGetValue(nucleotide, out count))
+        try
+        {
+            foreach (var s in sequence)
+                NucleotideCounts[s] += 1;
+        }
+        catch (KeyNotFoundException)
+        {
             throw new InvalidNucleotideException();
-        return count;
+        }
     }
 }
 

--- a/exercises/nucleotide-count/NucleotideCount.cs
+++ b/exercises/nucleotide-count/NucleotideCount.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 
-public class DNA
+public class NucleotideCount
 {
-    public DNA(string sequence)
+    public NucleotideCount(string sequence)
     {
     }
 
@@ -13,11 +13,6 @@ public class DNA
         {
             throw new NotImplementedException("You need to implement this function.");
         }
-    }
-
-    public int Count(char nucleotide)
-    {
-        throw new NotImplementedException("You need to implement this function.");
     }
 }
 

--- a/exercises/nucleotide-count/NucleotideCountTest.cs
+++ b/exercises/nucleotide-count/NucleotideCountTest.cs
@@ -1,65 +1,55 @@
-using System.Collections.Generic;
-using Xunit;
+// This file was auto-generated based on version 1.0.0 of the canonical data.
 
-public class NucleoTideCountTest
+using Xunit;
+using System.Collections.Generic;
+
+public class NucleotideCountTest
 {
     [Fact]
-    public void Has_no_nucleotides()
+    public void Empty_strand()
     {
-        var dna = new DNA("");
-        var expected = new Dictionary<char, int> { { 'A', 0 }, { 'T', 0 }, { 'C', 0 }, { 'G', 0 } };
-        Assert.Equal(expected, dna.NucleotideCounts);
+        var sut = new NucleotideCount("");
+        var expected = new Dictionary<char, int>
+        {
+            ['A'] = 0,
+            ['C'] = 0,
+            ['G'] = 0,
+            ['T'] = 0
+        };
+        Assert.Equal(expected, sut.NucleotideCounts);
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Has_no_adenosine()
+    public void Strand_with_repeated_nucleotide()
     {
-        var dna = new DNA("");
-        Assert.Equal(0, dna.Count('A'));
+        var sut = new NucleotideCount("GGGGGGG");
+        var expected = new Dictionary<char, int>
+        {
+            ['A'] = 0,
+            ['C'] = 0,
+            ['G'] = 7,
+            ['T'] = 0
+        };
+        Assert.Equal(expected, sut.NucleotideCounts);
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Repetitive_cytidine_gets_counts()
+    public void Strand_with_multiple_nucleotides()
     {
-        var dna = new DNA("CCCCC");
-        Assert.Equal(5, dna.Count('C'));
+        var sut = new NucleotideCount("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
+        var expected = new Dictionary<char, int>
+        {
+            ['A'] = 20,
+            ['C'] = 12,
+            ['G'] = 17,
+            ['T'] = 21
+        };
+        Assert.Equal(expected, sut.NucleotideCounts);
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Repetitive_sequence_has_only_guanosine()
+    public void Strand_with_invalid_nucleotides()
     {
-        var dna = new DNA("GGGGGGGG");
-        var expected = new Dictionary<char, int> { { 'A', 0 }, { 'T', 0 }, { 'C', 0 }, { 'G', 8 } };
-        Assert.Equal(expected, dna.NucleotideCounts);
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Counts_only_thymidine()
-    {
-        var dna = new DNA("GGGGTAACCCGG");
-        Assert.Equal(1, dna.Count('T'));
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Counts_a_nucleotide_only_once()
-    {
-        var dna = new DNA("GGTTGG");
-        dna.Count('T');
-        Assert.Equal(2, dna.Count('T'));
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Validates_nucleotides()
-    {
-        var dna = new DNA("GGTTGG");
-        Assert.Throws<InvalidNucleotideException>(() => dna.Count('X'));
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Counts_all_nucleotides()
-    {
-        var dna = new DNA("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
-        var expected = new Dictionary<char, int> { { 'A', 20 }, { 'T', 21 }, { 'C', 12 }, { 'G', 17 } };
-        Assert.Equal(expected, dna.NucleotideCounts);
+        Assert.Throws<InvalidNucleotideException>(() => new NucleotideCount("AGXXACT"));
     }
 }

--- a/generators/Exercises/NucleotideCount.cs
+++ b/generators/Exercises/NucleotideCount.cs
@@ -1,0 +1,61 @@
+﻿using Generators.Input;
+using Generators.Output;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Generators.Exercises
+{
+    class NucleotideCount : Exercise
+    {
+        protected override void UpdateCanonicalData(CanonicalData canonicalData)
+        {
+            foreach (var canonicalDataCase in canonicalData.Cases)
+            {
+                if (!((Dictionary<string, object>)canonicalDataCase.Expected).ContainsKey("error"))
+                {
+                    canonicalDataCase.UseVariableForExpected = true;
+                    canonicalDataCase.SetConstructorInputParameters("strand");
+                    canonicalDataCase.Expected = ConvertExpected(canonicalDataCase.Expected);
+                }
+            }
+        }
+
+        private static dynamic ConvertExpected(dynamic expected)
+            => ((Dictionary<string, object>)expected).ToDictionary(kv => kv.Key[0], kv => int.Parse($"{kv.Value}"));
+
+        protected override HashSet<string> AddAdditionalNamespaces() => new HashSet<string>() { typeof(Dictionary<char, int>).Namespace };
+
+        protected override string RenderTestMethodBodyAssert(TestMethodBody testMethodBody)
+        {
+            if (testMethodBody.UseVariableForExpected)
+            {
+                return RenderEqualBodyAssert(testMethodBody);
+            }
+            return RenderThrowsBodyAssert(testMethodBody);
+        }
+
+        private string RenderEqualBodyAssert(TestMethodBody testMethodBody)
+        {
+            const string template = @"Assert.Equal(expected, sut.{{ TestedMethodName }});";
+
+            var templateParameters = new
+            {
+                TestedMethodName = NameExtensions.ToTestedMethodName(testMethodBody.CanonicalDataCase.Property)
+            }
+
+            return TemplateRenderer.RenderInline(template, templateParameters);
+        }
+
+        private string RenderThrowsBodyAssert(TestMethodBody testMethodBody)
+        {
+            const string template = @"Assert.Throws<InvalidNucleotideException>(() => new NucleotideCount(""{{ Input }}""));";
+
+            var templateParameters = new
+            {
+                Input = testMethodBody.CanonicalDataCase.Input["strand"]
+            };
+
+            return TemplateRenderer.RenderInline(template, templateParameters);
+        }
+    }
+}

--- a/generators/Exercises/NucleotideCount.cs
+++ b/generators/Exercises/NucleotideCount.cs
@@ -40,8 +40,8 @@ namespace Generators.Exercises
 
             var templateParameters = new
             {
-                TestedMethodName = NameExtensions.ToTestedMethodName(testMethodBody.CanonicalDataCase.Property)
-            }
+                TestedMethodName = testMethodBody.CanonicalDataCase.Property.ToTestedMethodName()
+            };
 
             return TemplateRenderer.RenderInline(template, templateParameters);
         }

--- a/generators/Exercises/NucleotideCount.cs
+++ b/generators/Exercises/NucleotideCount.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace Generators.Exercises
 {
-    class NucleotideCount : Exercise
+    public class NucleotideCount : Exercise
     {
         protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {


### PR DESCRIPTION
This was/is a good learning experience. I look forward to feedback and doing more work.
I tried to become as familiar as possible with the code base to come up with an elegant solution, though I didn't see a way to easily test instance properties. 

As explained further in my commit message, I took the liberty to remove the Count method from the exercise. It was previously needed in he the old unit testing but with the canonical data based unit test, it was pruned.