### PR TITLE
Added Minesweeper generator

### DIFF
--- a/exercises/minesweeper/Example.cs
+++ b/exercises/minesweeper/Example.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 
 public class Minesweeper
 {
-    public static string Annotate(string input)
+    public static string[] Annotate(string[] input)
     {
         var results = new List<string>();
 
-        var board = input.Split("\n".ToCharArray());
+        var board = input;
 
         for (int i = 0; i < board.Length; i++)
         {
@@ -31,7 +31,7 @@ public class Minesweeper
             results.Add(result);
         }
 
-        return string.Join("\n", results);
+        return results.ToArray();
     }
 
     private static int GetCountForSquare(string[] board, int x, int y)

--- a/exercises/minesweeper/Minesweeper.cs
+++ b/exercises/minesweeper/Minesweeper.cs
@@ -2,7 +2,7 @@
 
 public static class Minesweeper
 {
-    public static string Annotate(string input)
+    public static string[] Annotate(string[] input)
     {
         throw new NotImplementedException("You need to implement this function.");
     }

--- a/exercises/minesweeper/MinesweeperTest.cs
+++ b/exercises/minesweeper/MinesweeperTest.cs
@@ -1,142 +1,240 @@
-﻿using Xunit;
+// This file was auto-generated based on version 1.0.0 of the canonical data.
+
+using Xunit;
 
 public class MinesweeperTest
 {
     [Fact]
-    public void Zero_sized_board()
+    public void No_rows()
     {
-        var input = "";
-        var expected = "";
-
+        var input = new string[] 
+        { 
+             
+        };
+        var expected = new string[] 
+        { 
+             
+        };
         Assert.Equal(expected, Minesweeper.Annotate(input));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Empty_board()
+    public void No_columns()
     {
-        var input = FormatInput(new[]
-        {
+        var input = new string[] 
+        { 
+            "" 
+        };
+        var expected = new string[] 
+        { 
+            "" 
+        };
+        Assert.Equal(expected, Minesweeper.Annotate(input));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void No_mines()
+    {
+        var input = new string[] 
+        { 
             "   ",
             "   ",
             "   "
-        });
-
-        var expected = FormatInput(new[]
-        {
+             
+        };
+        var expected = new string[] 
+        { 
             "   ",
             "   ",
             "   "
-        });
-
+             
+        };
         Assert.Equal(expected, Minesweeper.Annotate(input));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Board_full_of_mines()
+    public void Board_with_only_mines()
     {
-        var input = FormatInput(new[]
-        {
+        var input = new string[] 
+        { 
             "***",
             "***",
             "***"
-        });
-
-        var expected = FormatInput(new[]
-        {
+             
+        };
+        var expected = new string[] 
+        { 
             "***",
             "***",
             "***"
-        });
-
+             
+        };
         Assert.Equal(expected, Minesweeper.Annotate(input));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Surrounded()
+    public void Mine_surrounded_by_spaces()
     {
-        var input = FormatInput(new[]
-        {
+        var input = new string[] 
+        { 
+            "   ",
+            " * ",
+            "   "
+             
+        };
+        var expected = new string[] 
+        { 
+            "111",
+            "1*1",
+            "111"
+             
+        };
+        Assert.Equal(expected, Minesweeper.Annotate(input));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Space_surrounded_by_mines()
+    {
+        var input = new string[] 
+        { 
             "***",
             "* *",
             "***"
-        });
-
-        var expected = FormatInput(new[]
-        {
+             
+        };
+        var expected = new string[] 
+        { 
             "***",
             "*8*",
             "***"
-        });
-
+             
+        };
         Assert.Equal(expected, Minesweeper.Annotate(input));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Horizontal_line()
     {
-        var input = FormatInput(new[]
-        {
-            " * * "
-        });
+        var input = new string[] 
+        { 
+            " * * " 
+        };
+        var expected = new string[] 
+        { 
+            "1*2*1" 
+        };
+        Assert.Equal(expected, Minesweeper.Annotate(input));
+    }
 
-        var expected = FormatInput(new[]
-        {
-            "1*2*1"
-        });
-
+    [Fact(Skip = "Remove to run test")]
+    public void Horizontal_line_mines_at_edges()
+    {
+        var input = new string[] 
+        { 
+            "*   *" 
+        };
+        var expected = new string[] 
+        { 
+            "*1 1*" 
+        };
         Assert.Equal(expected, Minesweeper.Annotate(input));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Vertical_line()
     {
-        var input = FormatInput(new[]
-        {
+        var input = new string[] 
+        { 
             " ",
             "*",
             " ",
             "*",
             " "
-        });
-
-        var expected = FormatInput(new[]
-        {
+             
+        };
+        var expected = new string[] 
+        { 
             "1",
             "*",
             "2",
             "*",
             "1"
-        });
+             
+        };
+        Assert.Equal(expected, Minesweeper.Annotate(input));
+    }
 
+    [Fact(Skip = "Remove to run test")]
+    public void Vertical_line_mines_at_edges()
+    {
+        var input = new string[] 
+        { 
+            "*",
+            " ",
+            " ",
+            " ",
+            "*"
+             
+        };
+        var expected = new string[] 
+        { 
+            "*",
+            "1",
+            " ",
+            "1",
+            "*"
+             
+        };
         Assert.Equal(expected, Minesweeper.Annotate(input));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Cross()
     {
-        var input = FormatInput(new[]
-        {
+        var input = new string[] 
+        { 
             "  *  ",
             "  *  ",
             "*****",
             "  *  ",
             "  *  "
-        });
-
-        var expected = FormatInput(new[]
-        {
+             
+        };
+        var expected = new string[] 
+        { 
             " 2*2 ",
             "25*52",
             "*****",
             "25*52",
             " 2*2 "
-        });
-
+             
+        };
         Assert.Equal(expected, Minesweeper.Annotate(input));
     }
-    
-    private string FormatInput(string[] input)
+
+    [Fact(Skip = "Remove to run test")]
+    public void Large_board()
     {
-        return string.Join("\n", input);
+        var input = new string[] 
+        { 
+            " *  * ",
+            "  *   ",
+            "    * ",
+            "   * *",
+            " *  * ",
+            "      "
+             
+        };
+        var expected = new string[] 
+        { 
+            "1*22*1",
+            "12*322",
+            " 123*2",
+            "112*4*",
+            "1*22*2",
+            "111111"
+             
+        };
+        Assert.Equal(expected, Minesweeper.Annotate(input));
     }
 }

--- a/generators/Exercises/Minesweeper.cs
+++ b/generators/Exercises/Minesweeper.cs
@@ -1,0 +1,32 @@
+using Generators.Input;
+using Generators.Output;
+
+namespace Generators.Exercises
+{
+    public class Minesweeper : Exercise
+    {
+        protected override void UpdateCanonicalData(CanonicalData canonicalData)
+        {
+            foreach (var canonicalDataCase in canonicalData.Cases)
+            {
+                canonicalDataCase.UseVariablesForInput = true;
+                canonicalDataCase.UseVariableForExpected = true;
+
+                canonicalDataCase.Properties["input"] = ToMultiLineString(canonicalDataCase.Properties["input"]);
+                canonicalDataCase.Properties["expected"] = ToMultiLineString(canonicalDataCase.Properties["expected"]);
+            }
+        }
+
+        private UnescapedValue ToMultiLineString(string[] input)
+        {
+            const string template = 
+@"new string[] 
+{ 
+    {% if input.size > 0 %}{% for item in {{input}} %}{% if forloop.length == 1 %}""{{item}}""{% break %}{% endif %}""{{item}}""{% if forloop.last == false %},{% else %}{{string.Empty}}{% endif %}
+    {% endfor %}{% endif %} 
+}";
+
+            return new UnescapedValue(TemplateRenderer.RenderInline(template, new { input }));
+        }
+    }
+}


### PR DESCRIPTION
> - Added generator itself
> - Updated generated Test file
> - Fixed Example and Minesweeper classes to recieve and return the right type on method Annotate.
  Was: string -> string. Now it is: string[] -> string[]

@ErikSchierboom please tell me I didn't screw up by changing `Annotate` from a `string -> string` function to a `string[] -> string[]` one? I don't know how else to interpret the Canonical Data [files](https://github.com/exercism/problem-specifications/blob/master/exercises/minesweeper/canonical-data.json).

If that's allright, then this commit is pretty much cooked afaik.