### PR TITLE
Added FlattenArray generator

### DIFF
--- a/exercises/flatten-array/Example.cs
+++ b/exercises/flatten-array/Example.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections;
 
-public static class Flattener
+public static class FlattenArray
 {
     public static IEnumerable Flatten(IEnumerable input)
     {

--- a/exercises/flatten-array/FlattenArray.cs
+++ b/exercises/flatten-array/FlattenArray.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections;
 
-public static class Flattener
+public static class FlattenArray
 {
     public static IEnumerable Flatten(IEnumerable input)
     {

--- a/exercises/flatten-array/FlattenArrayTest.cs
+++ b/exercises/flatten-array/FlattenArrayTest.cs
@@ -7,36 +7,140 @@ public class FlattenArrayTest
     [Fact]
     public void No_nesting()
     {
-        Assert.Equal(new[] { 0, 1, 2 }, FlattenArray.Flatten(new[] { 0, 1, 2 }));
+        var input = new[] { 0, 1, 2 };
+        var expected = new[] { 0, 1, 2 };
+        Assert.Equal(expected, FlattenArray.Flatten(input));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Flattens_array_with_just_integers_present()
     {
-        Assert.Equal(new[] { 1, 2, 3, 4, 5, 6, 7, 8 }, FlattenArray.Flatten(new[] { 1, new[] { 2, 3, 4, 5, 6, 7 }, 8 }));
+        var input = new object[] {
+          1,
+          new object[] {
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          },
+          8
+        };
+        var expected = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        Assert.Equal(expected, FlattenArray.Flatten(input));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Number_5_level_nesting()
     {
-        Assert.Equal(new[] { 0, 2, 2, 3, 8, 100, 4, 50, -2 }, FlattenArray.Flatten(new[] { 0, 2, new[] { new[] { 2, 3 }, 8, 100, 4, new[] { new[] { new[] { 50 } } } }, -2 }));
+        var input = new object[] {
+          0,
+          2,
+          new object[] {
+            new object[] {
+              2,
+              3
+            },
+            8,
+            100,
+            4,
+            new object[] {
+              new object[] {
+                new object[] {
+                  50
+                }
+              }
+            }
+          },
+          -2
+        };
+        var expected = new[] { 0, 2, 2, 3, 8, 100, 4, 50, -2 };
+        Assert.Equal(expected, FlattenArray.Flatten(input));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Number_6_level_nesting()
     {
-        Assert.Equal(new[] { 1, 2, 3, 4, 5, 6, 7, 8 }, FlattenArray.Flatten(new[] { 1, new[] { 2, new[] { new[] { 3 } }, new[] { 4, new[] { new[] { 5 } } }, 6, 7 }, 8 }));
+        var input = new object[] {
+          1,
+          new object[] {
+            2,
+            new object[] {
+              new object[] {
+                3
+              }
+            },
+            new object[] {
+              4,
+              new object[] {
+                new object[] {
+                  5
+                }
+              }
+            },
+            6,
+            7
+          },
+          8
+        };
+        var expected = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        Assert.Equal(expected, FlattenArray.Flatten(input));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Number_6_level_nest_list_with_null_values()
     {
-        Assert.Equal(new[] { 0, 2, 2, 3, 8, 100, -2 }, FlattenArray.Flatten(new[] { 0, 2, new[] { new[] { 2, 3 }, 8, new[] { new[] { 100 } }, , new[] { new[] {  } } }, -2 }));
+        var input = new object[] {
+          0,
+          2,
+          new object[] {
+            new object[] {
+              2,
+              3
+            },
+            8,
+            new object[] {
+              new object[] {
+                100
+              }
+            },
+            null,
+            new object[] {
+              new object[] {
+                null
+              }
+            }
+          },
+          -2
+        };
+        var expected = new[] { 0, 2, 2, 3, 8, 100, -2 };
+        Assert.Equal(expected, FlattenArray.Flatten(input));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void All_values_in_nested_list_are_null()
     {
-        Assert.Empty(FlattenArray.Flatten(new[] { , new[] { new[] { new[] {  } } }, , , new[] { new[] { ,  },  },  }));
+        var input = new object[] {
+          null,
+          new object[] {
+            new object[] {
+              new object[] {
+                null
+              }
+            }
+          },
+          null,
+          null,
+          new object[] {
+            new object[] {
+              null,
+              null
+            },
+            null
+          },
+          null
+        };
+        Assert.Empty(FlattenArray.Flatten(input));
     }
 }

--- a/exercises/flatten-array/FlattenArrayTest.cs
+++ b/exercises/flatten-array/FlattenArrayTest.cs
@@ -1,112 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+// This file was auto-generated based on version 1.1.0 of the canonical data.
+
 using Xunit;
 
 public class FlattenArrayTest
 {
     [Fact]
-    public void Flattens_A_Nested_List()
+    public void No_nesting()
     {
-        var nestedList = new List<object> { new List<object>() };
-        Assert.Empty(Flattener.Flatten(nestedList));
+        Assert.Equal(new[] { 0, 1, 2 }, FlattenArray.Flatten(new[] { 0, 1, 2 }));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Flattens_2_Level_Nested_List()
+    public void Flattens_array_with_just_integers_present()
     {
-        var nestedList = new List<object> { 1, new List<object> { 2, 3, 4 }, 5 };
-        Assert.Equal(new List<int> { 1, 2, 3, 4, 5 }, Flattener.Flatten(nestedList).Cast<int>());
+        Assert.Equal(new[] { 1, 2, 3, 4, 5, 6, 7, 8 }, FlattenArray.Flatten(new[] { 1, new[] { 2, 3, 4, 5, 6, 7 }, 8 }));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Flattens_3_Level_Nested_List()
+    public void Number_5_level_nesting()
     {
-        var nestedList = new List<object>
-        {
-            1,
-            new List<object> { 2, 3, 4 },
-            5,
-            new List<object> { 6, new List<object> { 7, 8 } }
-        };
-        Assert.Equal(new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 }, Flattener.Flatten(nestedList).Cast<int>());
+        Assert.Equal(new[] { 0, 2, 2, 3, 8, 100, 4, 50, -2 }, FlattenArray.Flatten(new[] { 0, 2, new[] { new[] { 2, 3 }, 8, 100, 4, new[] { new[] { new[] { 50 } } } }, -2 }));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Flattens_5_Level_Nested_List()
+    public void Number_6_level_nesting()
     {
-        var nestedList = new List<object>
-        {
-            0,
-            2,
-            new List<object>
-            {
-                new List<object> { 2, 3 },
-                8,
-                100,
-                4,
-                new List<object> { new List<object> { new List<object> { 50 } } },
-                -2
-            }
-        };
-        Assert.Equal(new List<int> { 0, 2, 2, 3, 8, 100, 4, 50, -2 }, Flattener.Flatten(nestedList).Cast<int>());
+        Assert.Equal(new[] { 1, 2, 3, 4, 5, 6, 7, 8 }, FlattenArray.Flatten(new[] { 1, new[] { 2, new[] { new[] { 3 } }, new[] { 4, new[] { new[] { 5 } } }, 6, 7 }, 8 }));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Flattens_6_Level_Nested_List()
+    public void Number_6_level_nest_list_with_null_values()
     {
-        var nestedList = new List<object>
-        {
-            1,
-            new List<object>
-            {
-                2,
-                new List<object> { new List<object> { 3 } },
-                new List<object> { 4, new List<object> { new List<object> { 5 } } },
-                6,
-                7
-            },
-            8
-        };
-        Assert.Equal(new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 }, Flattener.Flatten(nestedList).Cast<int>());
+        Assert.Equal(new[] { 0, 2, 2, 3, 8, 100, -2 }, FlattenArray.Flatten(new[] { 0, 2, new[] { new[] { 2, 3 }, 8, new[] { new[] { 100 } }, , new[] { new[] {  } } }, -2 }));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Flattens_6_Level_Nested_List_With_Nulls()
+    public void All_values_in_nested_list_are_null()
     {
-        var nestedList = new List<object>
-        {
-            1,
-            new List<object>
-            {
-                2,
-                null,
-                new List<object> { new List<object> { 3 }, null },
-                new List<object> { 4, new List<object> { new List<object> { 5 } } },
-                6,
-                7,
-                new List<object> { new List<object> { null } }
-            },
-            8,
-            null
-        };
-        Assert.Equal(new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 }, Flattener.Flatten(nestedList).Cast<int>());
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void All_Null_Nested_List_Returns_Empty_List()
-    {
-        var nestedList = new List<object>
-        {
-            null,
-            new List<object>
-            {
-                null,
-                new List<object> { null },
-                new List<object> { new List<object> { new List<object> { null } } }
-            },
-            null
-        };
-        Assert.Empty(Flattener.Flatten(nestedList));
+        Assert.Empty(FlattenArray.Flatten(new[] { , new[] { new[] { new[] {  } } }, , , new[] { new[] { ,  },  },  }));
     }
 }

--- a/generators/Exercises/FlattenArray.cs
+++ b/generators/Exercises/FlattenArray.cs
@@ -1,0 +1,11 @@
+using Generators.Input;
+
+namespace Generators.Exercises
+{
+    public class FlattenArray : Exercise
+    {
+    	protected override void UpdateCanonicalData(CanonicalData canonicalData)
+        {
+        }
+    }
+}

--- a/generators/Exercises/FlattenArray.cs
+++ b/generators/Exercises/FlattenArray.cs
@@ -1,4 +1,6 @@
 using Generators.Input;
+using Generators.Output;
+using System.Collections;
 
 namespace Generators.Exercises
 {
@@ -6,6 +8,29 @@ namespace Generators.Exercises
     {
     	protected override void UpdateCanonicalData(CanonicalData canonicalData)
         {
+            foreach (var canonicalDataCase in canonicalData.Cases)
+            {
+                canonicalDataCase.UseVariablesForInput = true;
+                canonicalDataCase.UseVariableForExpected = true;
+
+                string stringInput = canonicalDataCase.Properties["input"].ToString();
+
+                // We skip reformatting of pure int arrays.
+                if(stringInput.Contains("System.Int32"))
+                    continue;
+
+                string properInput = ToProperObjArray(stringInput);
+
+                canonicalDataCase.Properties["input"] = new UnescapedValue(properInput);
+            }
+        }
+
+        private string ToProperObjArray(string input) 
+        {
+            string res = input.Replace("System.Int32", "");
+            res = res.Replace("]", "}");
+            res = res.Replace("[", "new object[] {");
+            return res;
         }
     }
 }


### PR DESCRIPTION
I have a problem here. The `null` values in the [Canonical Data](https://github.com/exercism/problem-specifications/blob/master/exercises/flatten-array/canonical-data.json) file for this exercise aren't rendered correctly at the moment of generating the test. In fact, they are ommited:

```json
{
      "description": "all values in nested list are null",
      "property": "flatten",
      "input": [null, [[[null]]], null, null, [[null, null], null], null],
      "expected": []
}
```
gets rendered as:

```csharp
public void All_values_in_nested_list_are_null()
{
        Assert.Empty(FlattenArray.Flatten(new[] { , new[] { new[] { new[] {  } } }, , , new[] { new[] { ,  },  },  }));
}
```

Is there a way to `UpdateCanonicalData` the nulls into this one?

Assuming there isn't, I digged around in the code base and the only thing I could find that might be amiss is the `ValueFormatter` class. That's the one in charge of rendering, but that's as far as I can go today.

Pls halp.