### PR TITLE
Added Largest Series Product Generator

### DIFF
--- a/exercises/largest-series-product/LargestSeriesProductTest.cs
+++ b/exercises/largest-series-product/LargestSeriesProductTest.cs
@@ -1,171 +1,97 @@
-using System;
+// This file was auto-generated based on version 1.0.0 of the canonical data.
+
 using Xunit;
+using System;
 
 public class LargestSeriesProductTest
 {
     [Fact]
+    public void Finds_the_largest_product_if_span_equals_length()
+    {
+        Assert.Equal(18, LargestSeriesProduct.GetLargestProduct("29", 2));
+    }
+
+    [Fact(Skip = "Remove to run test")]
     public void Can_find_the_largest_product_of_2_with_numbers_in_order()
     {
-        const string digits = "0123456789";
-        const int span = 2;
-        const int expected = 72;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Equal(72, LargestSeriesProduct.GetLargestProduct("0123456789", 2));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Can_find_the_largest_product_of_2()
     {
-        const string digits = "576802143";
-        const int span = 2;
-        const int expected = 48;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Finds_the_largest_product_if_span_equals_length()
-    {
-        const string digits = "29";
-        const int span = 2;
-        const int expected = 18;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Equal(48, LargestSeriesProduct.GetLargestProduct("576802143", 2));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Can_find_the_largest_product_of_3_with_numbers_in_order()
     {
-        const string digits = "0123456789";
-        const int span = 3;
-        const int expected = 504;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Equal(504, LargestSeriesProduct.GetLargestProduct("0123456789", 3));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Can_find_the_largest_product_of_3()
     {
-        const string digits = "1027839564";
-        const int span = 3;
-        const int expected = 270;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Equal(270, LargestSeriesProduct.GetLargestProduct("1027839564", 3));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Can_find_the_largest_product_of_5_with_numbers_in_order()
     {
-        const string digits = "0123456789";
-        const int span = 5;
-        const int expected = 15120;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Equal(15120, LargestSeriesProduct.GetLargestProduct("0123456789", 5));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Can_get_the_largest_product_of_a_big_number()
     {
-        const string digits = "73167176531330624919225119674426574742355349194934";
-        const int span = 6;
-        const int expected = 23520;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Can_get_the_largest_product_of_a_big_number_II()
-    {
-        const string digits = "52677741234314237566414902593461595376319419139427";
-        const int span = 6;
-        const int expected = 28350;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Can_get_the_largest_product_of_a_big_number_III()
-    {
-        const string digits = "7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450";
-        const int span = 13;
-        const long expected = 23514624000;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Equal(23520, LargestSeriesProduct.GetLargestProduct("73167176531330624919225119674426574742355349194934", 6));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Reports_zero_if_the_only_digits_are_zero()
     {
-        const string digits = "0000";
-        const int span = 2;
-        const int expected = 0;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Equal(0, LargestSeriesProduct.GetLargestProduct("0000", 2));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Reports_zero_if_all_spans_include_zero()
     {
-        const string digits = "99099";
-        const int span = 3;
-        const int expected = 0;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Reports_1_for_empty_string_and_empty_product_0_span()
-    {
-        const string digits = "";
-        const int span = 0;
-        const int expected = 1;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
-    }
-
-    [Fact(Skip = "Remove to run test")]
-    public void Reports_1_for_nonempty_string_and_empty_product_0_span()
-    {
-        const string digits = "123";
-        const int span = 0;
-        const int expected = 1;
-
-        Assert.Equal(expected, LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Equal(0, LargestSeriesProduct.GetLargestProduct("99099", 3));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Rejects_span_longer_than_string_length()
     {
-        const string digits = "123";
-        const int span = 4;
+        Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct("123", 4));
+    }
 
-        Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct(digits, span));
+    [Fact(Skip = "Remove to run test")]
+    public void Reports_1_for_empty_string_and_empty_product_0_span_()
+    {
+        Assert.Equal(1, LargestSeriesProduct.GetLargestProduct("", 0));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Reports_1_for_nonempty_string_and_empty_product_0_span_()
+    {
+        Assert.Equal(1, LargestSeriesProduct.GetLargestProduct("123", 0));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Rejects_empty_string_and_nonzero_span()
     {
-        const string digits = "";
-        const int span = 1;
-
-        Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct("", 1));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Rejects_invalid_character_in_digits()
     {
-        const string digits = "1234a5";
-        const int span = 2;
-
-        Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct("1234a5", 2));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Rejects_negative_span()
     {
-        const string digits = "12345";
-        const int span = -1;
-
-        Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct(digits, span));
+        Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct("12345", -1));
     }
 }

--- a/generators/Exercises/LargestSeriesProduct.cs
+++ b/generators/Exercises/LargestSeriesProduct.cs
@@ -1,0 +1,18 @@
+using Generators.Input;
+
+namespace Generators.Exercises
+{
+    public class LargestSeriesProduct : Exercise
+    {
+        protected override void UpdateCanonicalData(CanonicalData canonicalData)
+        {
+            foreach (var canonicalDataCase in canonicalData.Cases)
+            {
+                canonicalDataCase.Property = "GetLargestProduct";
+                
+                var caseInputLessThanZero = (long)canonicalDataCase.Expected == -1;
+                canonicalDataCase.ExceptionThrown = caseInputLessThanZero ? typeof(System.ArgumentException) : null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Changed name of Property to `GetLargestProduct`, to fit with example and stub implementation
- Fixed issues in example implementation, that didn't handle the newest tests' requirements. In particular, erroneous input crashed the example, while the testing suite **expected it to return -1**. Now the example behaves properly.
- Updated `eol` to canonical (unintended, but the generator created it).