### PR TITLE
Fix queen-attack generator after canonical-data change

### DIFF
--- a/generators/Exercises/QueenAttack.cs
+++ b/generators/Exercises/QueenAttack.cs
@@ -48,10 +48,10 @@ Assert.{% if Expected %}True{% else %}False{% endif %}(QueenAttack.CanAttack(whi
 
         private static Tuple<int, int> GetCoordinatesFromPosition(dynamic expected)
         {
-            var coordinates = expected["position"].Split(',');
+            var coordinates = expected["position"];
 
-            var positionX = int.Parse(coordinates[0].TrimStart('('));
-            var positionY = int.Parse(coordinates[1].TrimEnd(')'));
+            var positionX = (int)coordinates["row"];
+            var positionY = (int)coordinates["column"];
 
             return Tuple.Create(positionX, positionY);
         }


### PR DESCRIPTION
A recent change to the queen-attack canonical data broke the test generator. This fixes it.

As a note, we might want to consider transitioning from `x` and `y` to `row` and `column`, as this is what the canonical data converged to.