### PR TITLE
two-fer: "unlock_by": null

### DIFF
--- a/config.json
+++ b/config.json
@@ -64,7 +64,7 @@
         "optional_values",
         "strings"
       ],
-      "unlocked_by": "null",
+      "unlocked_by": null,
       "uuid": "57f02d0e-7b75-473b-892d-26a7d980c4ce"
     },
     {


### PR DESCRIPTION
Not "unlock_by": "null"  This crashes `configlet tree .`.  See exercism/configlet#102