### PR TITLE
Add back deleted, deprecated exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -1240,6 +1240,30 @@
       ],
       "unlocked_by": "markdown",
       "uuid": "a5794706-58d2-48f7-8aab-78639d7bce77"
+    },
+    {
+      "core": false,
+      "deprecated": true,
+      "slug": "binary",
+      "uuid": "cef7deef-54ce-4201-b263-7cd2098533f8"
+    },
+    {
+      "core": false,
+      "deprecated": true,
+      "slug": "trinary",
+      "uuid": "c7dd8467-87e2-4997-a96e-a04cb8b891e8"
+    },
+    {
+      "core": false,
+      "deprecated": true,
+      "slug": "octal",
+      "uuid": "c8555f37-9976-4f52-a5db-6a680ec8d53b"
+    },
+    {
+      "core": false,
+      "deprecated": true,
+      "slug": "hexadecimal",
+      "uuid": "5d30c5a0-0f69-4b79-8c7e-3b1fe6a5707f"
     }
   ],
   "foregone": [

--- a/exercises/binary/Binary.cs
+++ b/exercises/binary/Binary.cs
@@ -1,0 +1,9 @@
+using System;
+
+public class Binary
+{
+    public static int ToDecimal(string binary)
+    {
+        throw new NotImplementedException("You need to implement this function.");
+    }
+}

--- a/exercises/binary/Binary.csproj
+++ b/exercises/binary/Binary.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Example.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/binary/BinaryTest.cs
+++ b/exercises/binary/BinaryTest.cs
@@ -1,0 +1,94 @@
+using Xunit;
+
+public class BinaryTest
+{
+    [Fact]
+    public void Binary_0_is_decimal_0()
+    {
+        Assert.Equal(0, Binary.ToDecimal("0"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Binary_1_is_decimal_1()
+    {
+        Assert.Equal(1, Binary.ToDecimal("1"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Binary_10_is_decimal_2()
+    {
+        Assert.Equal(2, Binary.ToDecimal("10"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Binary_11_is_decimal_3()
+    {
+        Assert.Equal(3, Binary.ToDecimal("11"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Binary_100_is_decimal_4()
+    {
+        Assert.Equal(4, Binary.ToDecimal("100"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Binary_1001_is_decimal_9()
+    {
+        Assert.Equal(9, Binary.ToDecimal("1001"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Binary_11010_is_decimal_26()
+    {
+        Assert.Equal(26, Binary.ToDecimal("11010"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Binary_10001101000_is_decimal_1128()
+    {
+        Assert.Equal(1128, Binary.ToDecimal("10001101000"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Binary_ignores_leading_zeros()
+    {
+        Assert.Equal(31, Binary.ToDecimal("000011111"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Invalid_binary_2_converts_to_decimal_0()
+    {
+        Assert.Equal(0, Binary.ToDecimal("2"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void A_number_containing_a_non_binary_digit_is_invalid()
+    {
+        Assert.Equal(0, Binary.ToDecimal("01201"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void A_number_with_trailing_non_binary_characters_is_invalid()
+    {
+        Assert.Equal(0, Binary.ToDecimal("10nope"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void A_number_with_leading_non_binary_characters_is_invalid()
+    {
+        Assert.Equal(0, Binary.ToDecimal("nope10"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void A_number_with_internal_non_binary_characters_is_invalid()
+    {
+        Assert.Equal(0, Binary.ToDecimal("10nope10"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void A_number_and_a_word_whitespace_separated_is_invalid()
+    {
+        Assert.Equal(0, Binary.ToDecimal("001 nope"));
+    }
+}

--- a/exercises/binary/Example.cs
+++ b/exercises/binary/Example.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+
+public class Binary
+{
+    public static int ToDecimal(string binary)
+    {
+        if (IsNotValidBinary(binary)) return 0;
+
+        return binary
+            .Select((c, i) => int.Parse(c.ToString()) * TwoToThePowerOf(binary.Length - i - 1))
+            .Sum();
+    }
+
+    private static bool IsNotValidBinary(string binary)
+    {
+        return !binary.All(x => char.IsDigit(x) && int.Parse(x.ToString()) < 2);
+    }
+
+    private static int TwoToThePowerOf(int power)
+    {
+        return (int)Math.Pow(2, power);
+    }
+}

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -1,0 +1,41 @@
+# Binary
+
+Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
+
+Implement binary to decimal conversion. Given a binary input
+string, your program should produce a decimal output. The
+program should handle invalid inputs.
+
+## Note
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
+## About Binary (Base-2)
+Decimal is a base-10 system.
+
+A number 23 in base 10 notation can be understood
+as a linear combination of powers of 10:
+
+- The rightmost digit gets multiplied by 10^0 = 1
+- The next number gets multiplied by 10^1 = 10
+- ...
+- The *n*th number gets multiplied by 10^*(n-1)*.
+- All these values are summed.
+
+So: `23 => 2*10^1 + 3*10^0 => 2*10 + 3*1 = 23 base 10`
+
+Binary is similar, but uses powers of 2 rather than powers of 10.
+
+So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the exercise file that you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hexadecimal/Example.cs
+++ b/exercises/hexadecimal/Example.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+public class Hexadecimal
+{
+    private static readonly Dictionary<char, int> AlphaValues = new Dictionary<char, int>
+        {
+            { 'a', 10 },
+            { 'b', 11 },
+            { 'c', 12 },
+            { 'd', 13 },
+            { 'e', 14 },
+            { 'f', 15 }
+        };
+
+    public static int ToDecimal(string value)
+    {
+        if (IsNotValidHexadecimal(value)) return 0;
+
+        return value.Select((c, i) => GetNumericValue(c) * SixteenToThePowerOf(value.Length - i - 1)).Sum();
+    }
+
+    private static bool IsNotValidHexadecimal(string value)
+    {
+        return Regex.IsMatch(value, "[^0-9abcdef]", RegexOptions.IgnoreCase);
+    }
+
+    private static int GetNumericValue(char value)
+    {
+        if (char.IsNumber(value))
+            return (int)char.GetNumericValue(value);
+        return AlphaValues[value];
+    }
+
+    private static int SixteenToThePowerOf(int power)
+    {
+        return (int)Math.Pow(16, power);
+    }
+}

--- a/exercises/hexadecimal/Hexadecimal.cs
+++ b/exercises/hexadecimal/Hexadecimal.cs
@@ -1,0 +1,9 @@
+using System;
+
+public class Hexadecimal
+{
+    public static int ToDecimal(string value)
+    {
+        throw new NotImplementedException("You need to implement this function.");
+    }
+}

--- a/exercises/hexadecimal/Hexadecimal.csproj
+++ b/exercises/hexadecimal/Hexadecimal.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Example.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/hexadecimal/HexadecimalTest.cs
+++ b/exercises/hexadecimal/HexadecimalTest.cs
@@ -1,0 +1,65 @@
+using Xunit;
+
+public class HexadecimalTest
+{
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_1_is_decimal_1()
+    {
+        Assert.Equal(1, Hexadecimal.ToDecimal("1"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_c_is_decimal_12()
+    {
+        Assert.Equal(12, Hexadecimal.ToDecimal("c"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_10_is_decimal_16()
+    {
+        Assert.Equal(16, Hexadecimal.ToDecimal("10"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_af_is_decimal_175()
+    {
+        Assert.Equal(175, Hexadecimal.ToDecimal("af"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_100_is_decimal_256()
+    {
+        Assert.Equal(256, Hexadecimal.ToDecimal("100"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_19ace_is_decimal_105166()
+    {
+        Assert.Equal(105166, Hexadecimal.ToDecimal("19ace"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_carrot_is_decimal_0()
+    {
+        Assert.Equal(0, Hexadecimal.ToDecimal("carrot"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_000000_is_decimal_0()
+    {
+        Assert.Equal(0, Hexadecimal.ToDecimal("000000"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_ffffff_is_decimal_16777215()
+    {
+        Assert.Equal(16777215, Hexadecimal.ToDecimal("ffffff"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Hexadecimal_ffff00_is_decimal_16776960()
+    {
+        Assert.Equal(16776960, Hexadecimal.ToDecimal("ffff00"));
+    }
+
+}

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -1,0 +1,20 @@
+# Hexadecimal
+
+Convert a hexadecimal number, represented as a string (e.g. "10af8c"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).
+
+On the web we use hexadecimal to represent colors, e.g. green: 008000,
+teal: 008080, navy: 000080).
+
+The program should handle invalid hexadecimal strings.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the exercise file that you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/examples/NumberBases.html](http://www.wolframalpha.com/examples/NumberBases.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/octal/Example.cs
+++ b/exercises/octal/Example.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+
+public class Octal
+{
+    public static int ToDecimal(string octal)
+    {
+        if (IsNotValidOctal(octal)) return 0;
+
+        return octal
+            .Select((c, i) => int.Parse(c.ToString()) * EightToThePowerOf(octal.Length - i - 1))
+            .Sum();
+    }
+
+    private static bool IsNotValidOctal(string octal)
+    {
+        return !octal.All(x => char.IsDigit(x) && int.Parse(x.ToString()) < 8);
+    }
+
+    private static int EightToThePowerOf(int power)
+    {
+        return (int)Math.Pow(8, power);
+    }
+}

--- a/exercises/octal/Octal.cs
+++ b/exercises/octal/Octal.cs
@@ -1,0 +1,9 @@
+using System;
+
+public class Octal
+{
+    public static int ToDecimal(string octal)
+    {
+        throw new NotImplementedException("You need to implement this function.");
+    }
+}

--- a/exercises/octal/Octal.csproj
+++ b/exercises/octal/Octal.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Example.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/octal/OctalTest.cs
+++ b/exercises/octal/OctalTest.cs
@@ -1,0 +1,88 @@
+using Xunit;
+
+public class OctalTest
+{
+    [Fact]
+    public void Octal_1_is_decimal_1()
+    {
+        Assert.Equal(1, Octal.ToDecimal("1"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_10_is_decimal_8()
+    {
+        Assert.Equal(8, Octal.ToDecimal("10"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_17_is_decimal_15()
+    {
+        Assert.Equal(15, Octal.ToDecimal("17"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_11_is_decimal_9()
+    {
+        Assert.Equal(9, Octal.ToDecimal("11"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_130_is_decimal_88()
+    {
+        Assert.Equal(88, Octal.ToDecimal("130"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_2047_is_decimal_1063()
+    {
+        Assert.Equal(1063, Octal.ToDecimal("2047"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_7777_is_decimal_4095()
+    {
+        Assert.Equal(4095, Octal.ToDecimal("7777"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_1234567_is_decimal_342391()
+    {
+        Assert.Equal(342391, Octal.ToDecimal("1234567"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_011_is_decimal_9()
+    {
+        Assert.Equal(9, Octal.ToDecimal("011"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_carrot_is_decimal_0()
+    {
+        Assert.Equal(0, Octal.ToDecimal("carrot"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_8_is_decimal_0()
+    {
+        Assert.Equal(0, Octal.ToDecimal("8"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_9_is_decimal_0()
+    {
+        Assert.Equal(0, Octal.ToDecimal("9"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_6789_is_decimal_0()
+    {
+        Assert.Equal(0, Octal.ToDecimal("6789"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Octal_abc1z_is_decimal_0()
+    {
+        Assert.Equal(0, Octal.ToDecimal("abc1z"));
+    }
+}

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -1,0 +1,55 @@
+# Octal
+
+Convert an octal number, represented as a string (e.g. '1735263'), to its
+decimal equivalent using first principles (i.e. no, you may not use built-in or
+external libraries to accomplish the conversion).
+
+Implement octal to decimal conversion.  Given an octal input
+string, your program should produce a decimal output.
+
+## Note
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+- Treat invalid input as octal 0.
+
+## About Octal (Base-8)
+Decimal is a base-10 system.
+
+A number 233 in base 10 notation can be understood
+as a linear combination of powers of 10:
+
+- The rightmost digit gets multiplied by 10^0 = 1
+- The next number gets multiplied by 10^1 = 10
+- ...
+- The *n*th number gets multiplied by 10^*(n-1)*.
+- All these values are summed.
+
+So:
+```
+   233 # decimal
+ = 2*10^2 + 3*10^1 + 3*10^0
+ = 2*100  + 3*10   + 3*1
+```
+
+Octal is similar, but uses powers of 8 rather than powers of 10.
+
+So:
+```
+   233 # octal
+ = 2*8^2 + 3*8^1 + 3*8^0
+ = 2*64  + 3*8   + 3*1
+ = 128   + 24    + 3
+ = 155
+```
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the exercise file that you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=base+8](http://www.wolframalpha.com/input/?i=base+8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/trinary/Example.cs
+++ b/exercises/trinary/Example.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+
+public class Trinary
+{
+    public static int ToDecimal(string trinary)
+    {
+        if (IsNotValidTrinary(trinary)) return 0;
+
+        return trinary
+            .Select((c, i) => int.Parse(c.ToString()) * ThreeToThePowerOf(trinary.Length - i - 1))
+            .Sum();
+    }
+
+    private static bool IsNotValidTrinary(string trinary)
+    {
+        return !trinary.All(x => char.IsDigit(x) && int.Parse(x.ToString()) < 3);
+    }
+
+    private static int ThreeToThePowerOf(int power)
+    {
+        return (int)Math.Pow(3, power);
+    }
+}

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -1,0 +1,34 @@
+# Trinary
+
+Convert a trinary number, represented as a string (e.g. '102012'), to its
+decimal equivalent using first principles.
+
+The program should consider strings specifying an invalid trinary as the
+value 0.
+
+Trinary numbers contain three symbols: 0, 1, and 2.
+
+The last place in a trinary number is the 1's place. The second to last
+is the 3's place, the third to last is the 9's place, etc.
+
+```bash
+# "102012"
+    1       0       2       0       1       2    # the number
+1*3^5 + 0*3^4 + 2*3^3 + 0*3^2 + 1*3^1 + 2*3^0    # the value
+  243 +     0 +    54 +     0 +     3 +     2 =  302
+```
+
+If your language provides a method in the standard library to perform the
+conversion, pretend it doesn't exist and implement it yourself.
+
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the exercise file that you're submitting is in the `exercism/csharp/<exerciseName>` directory.
+
+For example, if you're submitting `bob.cs` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/csharp/bob/bob.cs`.
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/trinary/Trinary.cs
+++ b/exercises/trinary/Trinary.cs
@@ -1,0 +1,9 @@
+using System;
+
+public class Trinary
+{
+    public static int ToDecimal(string trinary)
+    {
+        throw new NotImplementedException("You need to implement this function.");
+    }
+}

--- a/exercises/trinary/Trinary.csproj
+++ b/exercises/trinary/Trinary.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Example.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/trinary/TrinaryTest.cs
+++ b/exercises/trinary/TrinaryTest.cs
@@ -1,0 +1,70 @@
+using Xunit;
+
+public class TrinaryTest
+{
+    [Fact]
+    public void Trinary_1_is_decimal_1()
+    {
+        Assert.Equal(1, Trinary.ToDecimal("1"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Trinary_2_is_decimal_2()
+    {
+        Assert.Equal(2, Trinary.ToDecimal("2"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Trinary_10_is_decimal_3()
+    {
+        Assert.Equal(3, Trinary.ToDecimal("10"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Trinary_11_is_decimal_4()
+    {
+        Assert.Equal(4, Trinary.ToDecimal("11"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Trinary_100_is_decimal_9()
+    {
+        Assert.Equal(9, Trinary.ToDecimal("100"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Trinary_112_is_decimal_14()
+    {
+        Assert.Equal(14, Trinary.ToDecimal("112"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Trinary_222_is_decimal_26()
+    {
+        Assert.Equal(26, Trinary.ToDecimal("222"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Trinary_1122000120_is_decimal_32091()
+    {
+        Assert.Equal(32091, Trinary.ToDecimal("1122000120"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Invalid_trinary_digits_returns_0()
+    {
+        Assert.Equal(0, Trinary.ToDecimal("1234"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Invalid_word_as_input_returns_0()
+    {
+        Assert.Equal(0, Trinary.ToDecimal("carrot"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Invalid_numbers_with_letters_as_input_returns_0()
+    {
+        Assert.Equal(0, Trinary.ToDecimal("0a1b2c"));
+    }
+}


### PR DESCRIPTION
When migrating the data from v1 to v2, we will lose all the solutions submitted to
deprecated exercises, unless they exist in the track configuration.

This adds the deprecated binary, trinary, octal, and hexadecimal exercises back,
leaving them deprecated so that they don't actively show up as part of the track.

We can delete them from the track again after we launch v2, if we want to.