### PR TITLE
Upgrade meetup test generator to the latest canonical data

### DIFF
--- a/exercises/meetup/MeetupTest.cs
+++ b/exercises/meetup/MeetupTest.cs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.0.0 of the canonical data.
+// This file was auto-generated based on version 1.1.0 of the canonical data.
 
 using Xunit;
 using System;
@@ -9,136 +9,136 @@ public class MeetupTest
     public void Monteenth_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
-        var expected = "2013-5-13";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-05-13";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Monteenth_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
-        var expected = "2013-8-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-08-19";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Monteenth_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
-        var expected = "2013-9-16";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-09-16";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Tuesteenth_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-03-19";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Tuesteenth_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-16";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-04-16";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Tuesteenth_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
-        var expected = "2013-8-13";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-08-13";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Wednesteenth_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
-        var expected = "2013-1-16";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-01-16";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Wednesteenth_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
-        var expected = "2013-2-13";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-02-13";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Wednesteenth_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
-        var expected = "2013-6-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-06-19";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Thursteenth_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
-        var expected = "2013-5-16";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-05-16";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Thursteenth_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
-        var expected = "2013-6-13";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-06-13";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Thursteenth_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
-        var expected = "2013-9-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-09-19";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Friteenth_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-04-19";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Friteenth_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
-        var expected = "2013-8-16";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-08-16";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Friteenth_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
-        var expected = "2013-9-13";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-09-13";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Saturteenth_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
-        var expected = "2013-2-16";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-02-16";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Saturteenth_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-13";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-04-13";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -146,23 +146,23 @@ public class MeetupTest
     {
         var sut = new Meetup(10, 2013);
         var expected = "2013-10-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Sunteenth_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
-        var expected = "2013-5-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-05-19";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Sunteenth_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
-        var expected = "2013-6-16";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth).ToString("yyyy-M-d"));
+        var expected = "2013-06-16";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -170,175 +170,175 @@ public class MeetupTest
     {
         var sut = new Meetup(10, 2013);
         var expected = "2013-10-13";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-4";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-03-04";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-1";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-04-01";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
-        var expected = "2013-5-7";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-05-07";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
-        var expected = "2013-6-4";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-06-04";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
-        var expected = "2013-7-3";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-07-03";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
-        var expected = "2013-8-7";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-08-07";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
-        var expected = "2013-9-5";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-09-05";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_thursday_of_october_2013()
     {
         var sut = new Meetup(10, 2013);
-        var expected = "2013-10-3";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-10-03";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_friday_of_november_2013()
     {
         var sut = new Meetup(11, 2013);
-        var expected = "2013-11-1";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-11-01";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_friday_of_december_2013()
     {
         var sut = new Meetup(12, 2013);
-        var expected = "2013-12-6";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-12-06";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
-        var expected = "2013-1-5";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-01-05";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
-        var expected = "2013-2-2";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-02-02";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-3";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-03-03";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-7";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2013-04-07";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-11";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-03-11";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-8";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-04-08";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
-        var expected = "2013-5-14";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-05-14";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
-        var expected = "2013-6-11";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-06-11";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
-        var expected = "2013-7-10";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-07-10";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
-        var expected = "2013-8-14";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-08-14";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
-        var expected = "2013-9-12";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-09-12";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -346,15 +346,15 @@ public class MeetupTest
     {
         var sut = new Meetup(10, 2013);
         var expected = "2013-10-10";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Second).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_friday_of_november_2013()
     {
         var sut = new Meetup(11, 2013);
-        var expected = "2013-11-8";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-11-08";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -362,95 +362,95 @@ public class MeetupTest
     {
         var sut = new Meetup(12, 2013);
         var expected = "2013-12-13";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Second).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
-        var expected = "2013-1-12";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-01-12";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
-        var expected = "2013-2-9";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-02-09";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-10";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-03-10";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Second_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-14";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Second).ToString("yyyy-M-d"));
+        var expected = "2013-04-14";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Second).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-18";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-03-18";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-15";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-04-15";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
-        var expected = "2013-5-21";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-05-21";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
-        var expected = "2013-6-18";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-06-18";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
-        var expected = "2013-7-17";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-07-17";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
-        var expected = "2013-8-21";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-08-21";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
-        var expected = "2013-9-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-09-19";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -458,7 +458,7 @@ public class MeetupTest
     {
         var sut = new Meetup(10, 2013);
         var expected = "2013-10-17";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Third).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -466,7 +466,7 @@ public class MeetupTest
     {
         var sut = new Meetup(11, 2013);
         var expected = "2013-11-15";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Third).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -474,95 +474,95 @@ public class MeetupTest
     {
         var sut = new Meetup(12, 2013);
         var expected = "2013-12-20";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Third).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
-        var expected = "2013-1-19";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-01-19";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
-        var expected = "2013-2-16";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-02-16";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-17";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-03-17";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Third_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-21";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Third).ToString("yyyy-M-d"));
+        var expected = "2013-04-21";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Third).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-25";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-03-25";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-22";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-04-22";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
-        var expected = "2013-5-28";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-05-28";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
-        var expected = "2013-6-25";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-06-25";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
-        var expected = "2013-7-24";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-07-24";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
-        var expected = "2013-8-28";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-08-28";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
-        var expected = "2013-9-26";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-09-26";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -570,7 +570,7 @@ public class MeetupTest
     {
         var sut = new Meetup(10, 2013);
         var expected = "2013-10-24";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Fourth).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -578,7 +578,7 @@ public class MeetupTest
     {
         var sut = new Meetup(11, 2013);
         var expected = "2013-11-22";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Fourth).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -586,95 +586,95 @@ public class MeetupTest
     {
         var sut = new Meetup(12, 2013);
         var expected = "2013-12-27";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Fourth).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
-        var expected = "2013-1-26";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-01-26";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
-        var expected = "2013-2-23";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-02-23";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-24";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-03-24";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Fourth_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-28";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Fourth).ToString("yyyy-M-d"));
+        var expected = "2013-04-28";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Fourth).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-25";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-03-25";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-29";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-04-29";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
-        var expected = "2013-5-28";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-05-28";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
-        var expected = "2013-6-25";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-06-25";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
-        var expected = "2013-7-31";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-07-31";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
-        var expected = "2013-8-28";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-08-28";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
-        var expected = "2013-9-26";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-09-26";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -682,7 +682,7 @@ public class MeetupTest
     {
         var sut = new Meetup(10, 2013);
         var expected = "2013-10-31";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Last).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -690,7 +690,7 @@ public class MeetupTest
     {
         var sut = new Meetup(11, 2013);
         var expected = "2013-11-29";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Last).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -698,47 +698,47 @@ public class MeetupTest
     {
         var sut = new Meetup(12, 2013);
         var expected = "2013-12-27";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Last).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
-        var expected = "2013-1-26";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-01-26";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
-        var expected = "2013-2-23";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-02-23";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
-        var expected = "2013-3-31";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-03-31";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
-        var expected = "2013-4-28";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2013-04-28";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_wednesday_of_february_2012()
     {
         var sut = new Meetup(2, 2012);
-        var expected = "2012-2-29";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2012-02-29";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -746,22 +746,22 @@ public class MeetupTest
     {
         var sut = new Meetup(12, 2014);
         var expected = "2014-12-31";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last).ToString("yyyy-M-d"));
+        Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Last_sunday_of_february_2015()
     {
         var sut = new Meetup(2, 2015);
-        var expected = "2015-2-22";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last).ToString("yyyy-M-d"));
+        var expected = "2015-02-22";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last).ToString("yyyy-MM-dd"));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void First_friday_of_december_2012()
     {
         var sut = new Meetup(12, 2012);
-        var expected = "2012-12-7";
-        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.First).ToString("yyyy-M-d"));
+        var expected = "2012-12-07";
+        Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.First).ToString("yyyy-MM-dd"));
     }
 }

--- a/generators/Exercises/Meetup.cs
+++ b/generators/Exercises/Meetup.cs
@@ -10,8 +10,7 @@ namespace Generators.Exercises
     {
         private const string ParamYear = "year";
         private const string ParamMonth = "month";
-        private const string ParamDay = "dayofmonth";
-        private const string ParamSchedule = "week";
+        private const string ParamWeek = "week";
         private const string ParamDayOfWeek = "dayofweek";
 
         private const string PropertyDay = "Day";
@@ -23,20 +22,20 @@ namespace Generators.Exercises
                 canonicalDataCase.Property = PropertyDay;
                 canonicalDataCase.UseVariableForExpected = true;
                 canonicalDataCase.SetConstructorInputParameters(ParamMonth, ParamYear);
-                canonicalDataCase.SetInputParameters(ParamDayOfWeek, ParamSchedule);
+                canonicalDataCase.SetInputParameters(ParamDayOfWeek, ParamWeek);
 
-                canonicalDataCase.Properties[ParamSchedule] =
-                    new UnescapedValue($"Schedule.{((string)canonicalDataCase.Properties[ParamSchedule]).Transform(To.SentenceCase)}");
+                canonicalDataCase.Properties[ParamYear] = canonicalDataCase.Properties["input"][ParamYear];
+                canonicalDataCase.Properties[ParamMonth] = canonicalDataCase.Properties["input"][ParamMonth];
+                canonicalDataCase.Properties[ParamWeek] =
+                    new UnescapedValue($"Schedule.{((string)canonicalDataCase.Properties["input"][ParamWeek]).Transform(To.SentenceCase)}");
                 canonicalDataCase.Properties[ParamDayOfWeek] =
-                    new UnescapedValue($"DayOfWeek.{((string)canonicalDataCase.Properties[ParamDayOfWeek]).Transform(To.SentenceCase)}");
-                canonicalDataCase.Expected =
-                    $"{canonicalDataCase.Properties[ParamYear]}-{canonicalDataCase.Properties[ParamMonth]}-{canonicalDataCase.Properties[ParamDay]}";
+                    new UnescapedValue($"DayOfWeek.{((string)canonicalDataCase.Properties["input"][ParamDayOfWeek]).Transform(To.SentenceCase)}");
             }
         }
 
         protected override String RenderTestMethodBodyAssert(TestMethodBody testMethodBody)
         {
-            string template = $"Assert.Equal({{{{ ExpectedParameter }}}}, {{{{ TestedValue }}}}.ToString(\"yyyy-M-d\"));";
+            string template = $"Assert.Equal({{{{ ExpectedParameter }}}}, {{{{ TestedValue }}}}.ToString(\"yyyy-MM-dd\"));";
 
             return TemplateRenderer.RenderInline(template, testMethodBody.AssertTemplateParameters);
         }


### PR DESCRIPTION
Reference issue: #414 

I took this one because of it's still open. But I see that there is already added meetup test generator. So this changes upgrade generator to the latest canonical-data.