### PR TITLE
config.json: resolve invalid "unlocked_by"

### DIFF
--- a/config.json
+++ b/config.json
@@ -923,7 +923,7 @@
         "algorithms",
         "matrices"
       ],
-      "unlocked_by": "matrix",
+      "unlocked_by": "kindergarten-garden",
       "uuid": "bae1f3a4-b63d-4efd-921a-133b3d5e379c"
     },
     {


### PR DESCRIPTION
fixes #524
The exercise 'spiral-matrix' is being unlocked by a non-core exercise. Non-core exercises can only be unlocked by core exercises.  Kindergarten-garden seemed like the "closest" core exercise.

I am happy to change unlocked by to whatever is deemed more correct or feel free to close this PR if you want to go in an entirely different direction, you won't hurt my feelings.  :)