### PR TITLE
Fix installation instructions

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 ### Installing .NET Core
 
-The F# track is built on top of the [.NET Core](https://www.microsoft.com/net/core/platform) platform, which runs on Windows, Linux and macOS. To build .NET Core projects, you can use the .NET Core Command Line Interface (CLI). This CLI is part of the .NET Core SDK, which you can install by following the [installation instructions](https://www.microsoft.com/net/download/core). Note: the F# track requires SDK version 2.1 or greater.
+The C# track is built on top of the [.NET Core](https://www.microsoft.com/net/core/platform) platform, which runs on Windows, Linux and macOS. To build .NET Core projects, you can use the .NET Core Command Line Interface (CLI). This CLI is part of the .NET Core SDK, which you can install by following the [installation instructions](https://www.microsoft.com/net/download/core). Note: the C# track requires SDK version 2.1 or greater.
 
 After completing the installation, you can verify if the CLI was installed succesfully by running this command in a terminal:
 
@@ -15,7 +15,7 @@ It the output is a version greater than or equal to `2.1.0`, the .NET Core SDK h
 If you want a more full-featured editing experience, you probably want to to use an IDE. These are the most popular IDE's that support building .NET Core projects:
 
 - [Visual Studio 2017](https://www.visualstudio.com/downloads/) (version 15.3.1 and higher)
-- [Visual Studio Code](https://code.visualstudio.com/download) with the [Ionide-fsharp extension](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp)
+- [Visual Studio Code](https://code.visualstudio.com/download) with the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
 - [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/) (still in beta)
 - [Project Rider](https://www.jetbrains.com/rider/download/)
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@ After completing the installation, you can verify if the CLI was installed succe
 dotnet --version
 ```
 
-It the output is a version greater than or equal to `2.1.0`, the .NET Core SDK has been installed succesfully.
+If the output is a version greater than or equal to `2.1.0`, the .NET Core SDK has been installed succesfully.
 
 ### Using an IDE
 


### PR DESCRIPTION
The installation instructions are changed in Pull Request #617. That PR caused the instructions to have references to F# in the C# track. Also 1 spelling mistake was introduced. This PR fixes this.