### PR TITLE
Add error object to variable-length-quantity

### DIFF
--- a/exercises/variable-length-quantity/VariableLengthQuantityTest.cs
+++ b/exercises/variable-length-quantity/VariableLengthQuantityTest.cs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.1.0 of the canonical data.
+// This file was auto-generated based on version 1.2.0 of the canonical data.
 
 using System;
 using Xunit;

--- a/generators/Exercises/Generators/VariableLengthQuantity.cs
+++ b/generators/Exercises/Generators/VariableLengthQuantity.cs
@@ -14,7 +14,7 @@ namespace Exercism.CSharp.Exercises.Generators
             testMethod.UseVariablesForInput = true;
             testMethod.Input["integers"] = ConvertToUInt32Array(testMethod.Input["integers"]);
 
-            if (testMethod.Expected == null || testMethod.Expected is Dictionary<string,object> objError)
+            if (testMethod.Expected == null || testMethod.Expected is Dictionary<string,object>)
                 testMethod.ExceptionThrown = typeof(InvalidOperationException);
             else
                 testMethod.Expected = ConvertToUInt32Array(testMethod.Expected);

--- a/generators/Exercises/Generators/VariableLengthQuantity.cs
+++ b/generators/Exercises/Generators/VariableLengthQuantity.cs
@@ -14,7 +14,7 @@ namespace Exercism.CSharp.Exercises.Generators
             testMethod.UseVariablesForInput = true;
             testMethod.Input["integers"] = ConvertToUInt32Array(testMethod.Input["integers"]);
 
-            if (testMethod.Expected == null)
+            if (testMethod.Expected == null || testMethod.Expected is Dictionary<string,object> objError)
                 testMethod.ExceptionThrown = typeof(InvalidOperationException);
             else
                 testMethod.Expected = ConvertToUInt32Array(testMethod.Expected);


### PR DESCRIPTION
Fix issue #650.

Results of tests:
Task                           Duration
---------------------------------------------------
Clean                          00:00:00.2190918
CopyExercises                  00:00:00.1226173
EnableAllTests                 00:00:00.0739403
TestRefactoringProjects        00:00:00.0105540
ReplaceStubWithExample         00:00:00.0185331
TestUsingExampleImplementation 00:00:08.3845674
BuildGenerators                00:00:04.6395166
Default                        00:00:00.0051317
---------------------------------------------------
Total:                         00:00:13.4739522