### PR TITLE
Add function to check outdated exercises

### DIFF
--- a/generators/Exercises/ExerciseCollection.cs
+++ b/generators/Exercises/ExerciseCollection.cs
@@ -56,7 +56,7 @@ namespace Exercism.CSharp.Exercises
             var filePath = FilePathHelper.TestClassFilePath(exerciseName, exerciseName.ToTestClassName());
             var firsLine = File.ReadLines(filePath).First();
 
-            if(firsLine.StartsWith("//")) {
+            if (firsLine.StartsWith("//")) {
                 var testversion = Regex.Match(firsLine, @"[\d\.]{5}").Value;
                 var canonicalDataParser = new CanonicalDataParser(_canonicalDataFile);
                 var canonicalDataVersion = canonicalDataParser.Parse(exerciseName).Version;

--- a/generators/Exercises/ExerciseCollection.cs
+++ b/generators/Exercises/ExerciseCollection.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Exercism.CSharp.Helpers;
 using Exercism.CSharp.Input;
 
@@ -39,6 +41,8 @@ namespace Exercism.CSharp.Exercises
                     yield return new MissingDataExercise(exerciseName);
                 else if (IsNotImplemented(exerciseName))
                     yield return new UnimplementedExercise(exerciseName);
+                else if (IsOutdated(exerciseName))
+                    yield return new OutdatedExercise(exerciseName);
                 else
                     yield return CreateExercise(exerciseName);
             }
@@ -47,6 +51,20 @@ namespace Exercism.CSharp.Exercises
         private bool HasNoCanonicalData(string exerciseName) => !_canonicalDataFile.Exists(exerciseName);
 
         private bool IsNotImplemented(string exerciseName) => !_exerciseTypesByName.ContainsKey(exerciseName.ToExerciseName());
+
+        private bool IsOutdated(string exerciseName) {
+            var filePath = FilePathHelper.TestClassFilePath(exerciseName, exerciseName.ToTestClassName());
+            var firsLine = File.ReadLines(filePath).First();
+
+            if(firsLine.StartsWith("//")) {
+                var testversion = Regex.Match(firsLine, @"[\d\.]{5}").Value;
+                var canonicalDataParser = new CanonicalDataParser(_canonicalDataFile);
+                var canonicalDataVersion = canonicalDataParser.Parse(exerciseName).Version;
+                return testversion != canonicalDataVersion;
+            }
+
+            return false;
+        }
 
         private Exercise CreateExercise(string exerciseName)
             => (Exercise)Activator.CreateInstance(_exerciseTypesByName[exerciseName.ToExerciseName()]);

--- a/generators/Exercises/OutdatedExercise.cs
+++ b/generators/Exercises/OutdatedExercise.cs
@@ -1,0 +1,9 @@
+namespace Exercism.CSharp.Exercises
+{
+    public class OutdatedExercise : Exercise
+    {
+        public OutdatedExercise(string name) => Name = name;
+
+        public override string Name { get; }
+    }
+}

--- a/generators/GeneratorStatus.cs
+++ b/generators/GeneratorStatus.cs
@@ -2,10 +2,11 @@
 {
     public enum GeneratorStatus
     {
+        All,
         Implemented,
         Unimplemented,
         MissingData,
+        Outdated,
         Custom,
-        All
     }
 }

--- a/generators/Helpers/FilePathHelper.cs
+++ b/generators/Helpers/FilePathHelper.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace Exercism.CSharp.Helpers
+{
+    public static class FilePathHelper
+    {
+        public static string TestClassFilePath(string exerciseName, string exerciseTestClassName) => Path.Combine("..", "exercises", exerciseName, CsharpFileName(exerciseTestClassName));
+
+        private static string CsharpFileName(string fileName) => $"{fileName}.cs";
+    }
+}

--- a/generators/Output/TestClassOutput.cs
+++ b/generators/Output/TestClassOutput.cs
@@ -16,7 +16,7 @@ namespace Exercism.CSharp.Output
         
         public void WriteToFile()
         {
-            var filePath = FilePath;
+            var filePath = FilePathHelper.TestClassFilePath(_testClass.Exercise, _testClass.ClassName);
             var renderedContents = Render();
 
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
@@ -46,9 +46,5 @@ namespace Exercism.CSharp.Output
                     .Concat(_testClass.Namespaces)
                     .Append("Xunit")
                     .ToSortedSet();
-
-        private string FilePath => Path.Combine("..", "exercises", _testClass.Exercise, FileName);
-
-        private string FileName => $"{_testClass.ClassName}.cs";
     }
 }

--- a/generators/Program.cs
+++ b/generators/Program.cs
@@ -69,6 +69,9 @@ namespace Exercism.CSharp
                 case CustomExercise _:
                     Log.Information("{Exercise}: has customized tests", exercise.Name);
                     break;
+                case OutdatedExercise _:
+                    Log.Information("{Exercise}: is outdated", exercise.Name);
+                    break;
                 case MissingDataExercise _:
                     Log.Warning("{Exercise}: missing canonical data", exercise.Name);
                     break;
@@ -93,6 +96,8 @@ namespace Exercism.CSharp
                     return !(exercise is UnimplementedExercise);
                 case GeneratorStatus.MissingData:
                     return !(exercise is MissingDataExercise);
+                case GeneratorStatus.Outdated:
+                    return !(exercise is OutdatedExercise);
                 case GeneratorStatus.Custom:
                     return !(exercise is CustomExercise);
                 default:


### PR DESCRIPTION
This PR lets users run ```dotnet run -s Outdated``` to output exercises that use outdated canonical data.

See issue #631.