### PR TITLE
FORTH: update to generate InvalidOperationException from canonical data

### DIFF
--- a/exercises/forth/ForthTest.cs
+++ b/exercises/forth/ForthTest.cs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.6.0 of the canonical data.
+// This file was auto-generated based on version 1.7.0 of the canonical data.
 
 using System;
 using Xunit;

--- a/generators/Exercises/Generators/Forth.cs
+++ b/generators/Exercises/Generators/Forth.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Exercism.CSharp.Output;
+﻿using Exercism.CSharp.Output;
+using System;
 
 namespace Exercism.CSharp.Exercises.Generators
 {
@@ -9,7 +9,7 @@ namespace Exercism.CSharp.Exercises.Generators
         {
             testMethod.TestMethodName = testMethod.TestMethodNameWithPath;
 
-            if (testMethod.Expected == null)
+            if (testMethod.Expected == null || string.Join(" ", testMethod.Expected).StartsWith("[error"))
             {
                 testMethod.ExceptionThrown = typeof(InvalidOperationException);
             }

--- a/generators/Exercises/Generators/Forth.cs
+++ b/generators/Exercises/Generators/Forth.cs
@@ -1,5 +1,6 @@
 ﻿using Exercism.CSharp.Output;
 using System;
+using System.Collections.Generic;
 
 namespace Exercism.CSharp.Exercises.Generators
 {
@@ -9,7 +10,7 @@ namespace Exercism.CSharp.Exercises.Generators
         {
             testMethod.TestMethodName = testMethod.TestMethodNameWithPath;
 
-            if (testMethod.Expected == null || string.Join(" ", testMethod.Expected).StartsWith("[error"))
+            if (testMethod.Expected is Dictionary<string, object>)
             {
                 testMethod.ExceptionThrown = typeof(InvalidOperationException);
             }


### PR DESCRIPTION
As per instructed in #648 :

Regenerated test class.
Changed generator to generate same testfile.
Tests passed.