### PR TITLE
updated to generate ArgumentException and regenerated tests

### DIFF
--- a/exercises/ocr-numbers/OcrNumbersTest.cs
+++ b/exercises/ocr-numbers/OcrNumbersTest.cs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.1.0 of the canonical data.
+// This file was auto-generated based on version 1.2.0 of the canonical data.
 
 using System;
 using Xunit;

--- a/generators/Exercises/Generators/OcrNumbers.cs
+++ b/generators/Exercises/Generators/OcrNumbers.cs
@@ -9,8 +9,10 @@ namespace Exercism.CSharp.Exercises.Generators
     {
         protected override void UpdateTestMethod(TestMethod testMethod)
         {
-            if (testMethod.Expected is int i && i <= 0)
+            if (!(testMethod.Expected is string))
+            {
                 testMethod.ExceptionThrown = typeof(ArgumentException);
+            }
 
             testMethod.Input["rows"] = new MultiLineString(testMethod.Input["rows"]);
             testMethod.Expected = testMethod.Expected.ToString();


### PR DESCRIPTION
Per #639 :
Regenerated test class for orc-numbers canonical data 1.2.0
Fixed generator based on [canonical-data](https://github.com/exercism/problem-specifications/blob/master/exercises/ocr-numbers/canonical-data.json)
Tests passed