### PR TITLE
Changing test generator for specific exercise (Wordy) - Fix for Issue #637

### DIFF
--- a/exercises/wordy/WordyTest.cs
+++ b/exercises/wordy/WordyTest.cs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.1.0 of the canonical data.
+// This file was auto-generated based on version 1.2.0 of the canonical data.
 
 using System;
 using Xunit;

--- a/generators/Exercises/Generators/Wordy.cs
+++ b/generators/Exercises/Generators/Wordy.cs
@@ -7,7 +7,7 @@ namespace Exercism.CSharp.Exercises.Generators
     {
         protected override void UpdateTestMethod(TestMethod testMethod)
         {
-            if (testMethod.Expected is bool)
+            if (!(testMethod.Expected is int))
                 testMethod.ExceptionThrown = typeof(ArgumentException);
         }
     }


### PR DESCRIPTION
Now if you generate the test you can run it right away. For Wordy exercise the answer must be an integer. If the answer in canonical data is not int the exercise should throw an exception. This fix Issue #637