### PR TITLE
Fixed #654 - Updated Anagram Tests

### DIFF
--- a/exercises/anagram/Anagram.cs
+++ b/exercises/anagram/Anagram.cs
@@ -7,7 +7,7 @@ public class Anagram
         throw new NotImplementedException("You need to implement this function.");
     }
 
-    public string[] Anagrams(string[] potentialMatches)
+    public string[] FindAnagrams(string[] potentialMatches)
     {
         throw new NotImplementedException("You need to implement this function.");
     }

--- a/exercises/anagram/AnagramTest.cs
+++ b/exercises/anagram/AnagramTest.cs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.2.0 of the canonical data.
+// This file was auto-generated based on version 1.3.0 of the canonical data.
 
 using Xunit;
 
@@ -9,7 +9,7 @@ public class AnagramTest
     {
         var candidates = new[] { "hello", "world", "zombies", "pants" };
         var sut = new Anagram("diaper");
-        Assert.Empty(sut.Anagrams(candidates));
+        Assert.Empty(sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -18,7 +18,7 @@ public class AnagramTest
         var candidates = new[] { "stream", "pigeon", "maters" };
         var sut = new Anagram("master");
         var expected = new[] { "stream", "maters" };
-        Assert.Equal(expected, sut.Anagrams(candidates));
+        Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -26,7 +26,7 @@ public class AnagramTest
     {
         var candidates = new[] { "dog", "goody" };
         var sut = new Anagram("good");
-        Assert.Empty(sut.Anagrams(candidates));
+        Assert.Empty(sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -35,7 +35,7 @@ public class AnagramTest
         var candidates = new[] { "enlists", "google", "inlets", "banana" };
         var sut = new Anagram("listen");
         var expected = new[] { "inlets" };
-        Assert.Equal(expected, sut.Anagrams(candidates));
+        Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -44,7 +44,7 @@ public class AnagramTest
         var candidates = new[] { "gallery", "ballerina", "regally", "clergy", "largely", "leading" };
         var sut = new Anagram("allergy");
         var expected = new[] { "gallery", "regally", "largely" };
-        Assert.Equal(expected, sut.Anagrams(candidates));
+        Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -52,7 +52,7 @@ public class AnagramTest
     {
         var candidates = new[] { "last" };
         var sut = new Anagram("mass");
-        Assert.Empty(sut.Anagrams(candidates));
+        Assert.Empty(sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -61,7 +61,7 @@ public class AnagramTest
         var candidates = new[] { "cashregister", "Carthorse", "radishes" };
         var sut = new Anagram("Orchestra");
         var expected = new[] { "Carthorse" };
-        Assert.Equal(expected, sut.Anagrams(candidates));
+        Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -70,7 +70,7 @@ public class AnagramTest
         var candidates = new[] { "cashregister", "carthorse", "radishes" };
         var sut = new Anagram("Orchestra");
         var expected = new[] { "carthorse" };
-        Assert.Equal(expected, sut.Anagrams(candidates));
+        Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -79,7 +79,7 @@ public class AnagramTest
         var candidates = new[] { "cashregister", "Carthorse", "radishes" };
         var sut = new Anagram("orchestra");
         var expected = new[] { "Carthorse" };
-        Assert.Equal(expected, sut.Anagrams(candidates));
+        Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -87,7 +87,7 @@ public class AnagramTest
     {
         var candidates = new[] { "go Go GO" };
         var sut = new Anagram("go");
-        Assert.Empty(sut.Anagrams(candidates));
+        Assert.Empty(sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -95,7 +95,7 @@ public class AnagramTest
     {
         var candidates = new[] { "patter" };
         var sut = new Anagram("tapper");
-        Assert.Empty(sut.Anagrams(candidates));
+        Assert.Empty(sut.FindAnagrams(candidates));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -103,6 +103,6 @@ public class AnagramTest
     {
         var candidates = new[] { "Banana" };
         var sut = new Anagram("BANANA");
-        Assert.Empty(sut.Anagrams(candidates));
+        Assert.Empty(sut.FindAnagrams(candidates));
     }
 }

--- a/exercises/anagram/Example.cs
+++ b/exercises/anagram/Example.cs
@@ -11,7 +11,7 @@ public class Anagram
         this.baseWord = baseWord;
     }
 
-    public string[] Anagrams(string[] potentialMatches)
+    public string[] FindAnagrams(string[] potentialMatches)
     {
         List<string> matches = new List<string>();
 


### PR DESCRIPTION
This PR addresses https://github.com/exercism/csharp/issues/654.

I changed `anagrams` to `FindAanagrams` in both `Example.cs` and `Anagram.cs`.

This is because I noticed that the property was changed in https://github.com/exercism/problem-specifications/blob/master/exercises/anagram/canonical-data.json.

It also passed all of the tests when running `./build.sh --exercise=anagram`.

Thanks for considering this request.