### PR TITLE
Rest API test bug fix

### DIFF
--- a/exercises/rest-api/Example.cs
+++ b/exercises/rest-api/Example.cs
@@ -117,8 +117,7 @@ public class RestApi
             lender.Lend(borrower, amount);
             borrower.Borrow(lender, amount);
 
-            // Replace to workaround inconsistency in specs
-            return JsonConvert.SerializeObject(new[] { lender, borrower }.OrderBy(x => x.name)).Replace("-6.0", "-6");
+            return JsonConvert.SerializeObject(new[] { lender, borrower }.OrderBy(x => x.name));
         }
 
         return String.Empty;

--- a/exercises/rest-api/RestApiTest.cs
+++ b/exercises/rest-api/RestApiTest.cs
@@ -59,7 +59,7 @@ public class RestApiTest
         var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0.0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3.0},\"owed_by\":{},\"balance\":-3.0},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3.0},\"balance\":3.0}]";
         var sut = new RestApi(database);
         var actual = sut.Post(url, payload);
-        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":3.0},\"balance\":3.0},{\"name\":\"Bob\",\"owes\":{\"Adam\":3.0,\"Chuck\":3.0},\"owed_by\":{},\"balance\":-6}]";
+        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":3.0},\"balance\":3.0},{\"name\":\"Bob\",\"owes\":{\"Adam\":3.0,\"Chuck\":3.0},\"owed_by\":{},\"balance\":-6.0}]";
         Assert.Equal(expected, actual);
     }
 


### PR DESCRIPTION
One of the tests incorrectly specifies -6 rather than -6.0 for a json number field. This inconsistent with the other tests