### PR TITLE
Fixes exception in AffineCipher generator

### DIFF
--- a/generators/Exercises/Generators/AffineCipher.cs
+++ b/generators/Exercises/Generators/AffineCipher.cs
@@ -13,7 +13,7 @@ namespace Exercism.CSharp.Exercises.Generators
             testMethod.Input["b"] = testMethod.Input["key"]["b"];
             testMethod.InputParameters = new[] { "phrase", "a", "b" };
 
-            if (!testMethod.Expected is string)
+            if (!(testMethod.Expected is string))
             {
                 testMethod.ExceptionThrown = typeof(ArgumentException);
             }


### PR DESCRIPTION
When executing `dotnet run` in the **generators** directory, the **AffineCipher** generator throws this exception: 

> Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Operator '!' cannot be applied to operand of type 'string'

Adding the additional parentheses corrects this issue.