### PR TITLE
Fixes 'expected error' based on canonical data

### DIFF
--- a/exercises/largest-series-product/LargestSeriesProductTest.cs
+++ b/exercises/largest-series-product/LargestSeriesProductTest.cs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.1.0 of the canonical data.
+// This file was auto-generated based on version 1.2.0 of the canonical data.
 
 using System;
 using Xunit;

--- a/generators/Exercises/Generators/LargestSeriesProduct.cs
+++ b/generators/Exercises/Generators/LargestSeriesProduct.cs
@@ -9,7 +9,7 @@ namespace Exercism.CSharp.Exercises.Generators
         {
             testMethod.TestedMethod = "GetLargestProduct";
 
-            if (testMethod.Expected == -1)
+            if (testMethod.Expected is System.Collections.IDictionary)
                 testMethod.ExceptionThrown = typeof(ArgumentException);
         }
     }


### PR DESCRIPTION
Based on the canonical data for this exercise, it appears that a `-1` is no longer the expected value for an error. The *expected* value is now a Dictionary based on the error message:

> Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Operator '==' cannot be applied to operands of type 'System.Collections.Generic.Dictionary<string,object>' and 'int'

Here's the error case from the canonical data:

```
{
    "description": "rejects negative span",
    "property": "largestProduct",
    "input": {
        "digits": "12345",
        "span": -1
    },
    "expected": {"error": "span must be greater than zero"}
}
``` 