### PR TITLE
Update RobotName name test to be more restrictive

### DIFF
--- a/exercises/robot-name/RobotNameTest.cs
+++ b/exercises/robot-name/RobotNameTest.cs
@@ -7,7 +7,7 @@ public class RobotNameTest
     [Fact]
     public void Robot_has_a_name()
     {
-        Assert.Matches(@"[A-Z]{2}\d{3}", robot.Name);
+        Assert.Matches(@"^[A-Z]{2}\d{3}$", robot.Name);
     }
 
     [Fact(Skip = "Remove to run test")]


### PR DESCRIPTION
Previously the tests would not catch invalid robot names such as AB1234, or ABC123 because the regex did not have start or end anchors specified. This commit updates the regex so that those names are no longer accepted by the tests.