### PR TITLE
734 use decimal for money

### DIFF
--- a/exercises/bank-account/BankAccount.cs
+++ b/exercises/bank-account/BankAccount.cs
@@ -12,7 +12,7 @@ public class BankAccount
         throw new NotImplementedException("You need to implement this function.");
     }
 
-    public float Balance
+    public decimal Balance
     {
         get
         {
@@ -20,7 +20,7 @@ public class BankAccount
         }
     }
 
-    public void UpdateBalance(float change)
+    public void UpdateBalance(decimal change)
     {
         throw new NotImplementedException("You need to implement this function.");
     }

--- a/exercises/bank-account/Example.cs
+++ b/exercises/bank-account/Example.cs
@@ -4,7 +4,7 @@ public class BankAccount
 {
     private readonly object _lock = new object();
 
-    private float balance;
+    private decimal balance;
     private bool isOpen;
 
     public void Open()
@@ -23,7 +23,7 @@ public class BankAccount
         }
     }
 
-    public float Balance
+    public decimal Balance
     {
         get
         {
@@ -39,7 +39,7 @@ public class BankAccount
         }
     }
 
-    public void UpdateBalance(float change)
+    public void UpdateBalance(decimal change)
     {
         lock(_lock)
         {

--- a/exercises/book-store/BookStore.cs
+++ b/exercises/book-store/BookStore.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 public static class BookStore
 {
-    public static double Total(IEnumerable<int> books)
+    public static decimal Total(IEnumerable<int> books)
     {
         throw new NotImplementedException("You need to implement this function.");
     }

--- a/exercises/book-store/BookStoreTest.cs
+++ b/exercises/book-store/BookStoreTest.cs
@@ -9,21 +9,21 @@ public class BookStoreTest
     public void Only_a_single_book()
     {
         var basket = new[] { 1 };
-        Assert.Equal(8, BookStore.Total(basket));
+        Assert.Equal(8m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Two_of_the_same_book()
     {
         var basket = new[] { 2, 2 };
-        Assert.Equal(16, BookStore.Total(basket));
+        Assert.Equal(16m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Empty_basket()
     {
         var basket = Array.Empty<int>();
-        Assert.Equal(0, BookStore.Total(basket));
+        Assert.Equal(0m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -51,7 +51,7 @@ public class BookStoreTest
     public void Five_different_books()
     {
         var basket = new[] { 1, 2, 3, 4, 5 };
-        Assert.Equal(30, BookStore.Total(basket));
+        Assert.Equal(30m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -86,14 +86,14 @@ public class BookStoreTest
     public void Two_copies_of_each_book()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5, 5 };
-        Assert.Equal(60, BookStore.Total(basket));
+        Assert.Equal(60m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Three_copies_of_first_book_and_2_each_of_remaining()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1 };
-        Assert.Equal(68, BookStore.Total(basket));
+        Assert.Equal(68m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]

--- a/exercises/book-store/BookStoreTest.cs
+++ b/exercises/book-store/BookStoreTest.cs
@@ -30,21 +30,21 @@ public class BookStoreTest
     public void Two_different_books()
     {
         var basket = new[] { 1, 2 };
-        Assert.Equal(15.2, BookStore.Total(basket));
+        Assert.Equal(15.2m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Three_different_books()
     {
         var basket = new[] { 1, 2, 3 };
-        Assert.Equal(21.6, BookStore.Total(basket));
+        Assert.Equal(21.6m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Four_different_books()
     {
         var basket = new[] { 1, 2, 3, 4 };
-        Assert.Equal(25.6, BookStore.Total(basket));
+        Assert.Equal(25.6m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -58,28 +58,28 @@ public class BookStoreTest
     public void Two_groups_of_four_is_cheaper_than_group_of_five_plus_group_of_three()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 5 };
-        Assert.Equal(51.2, BookStore.Total(basket));
+        Assert.Equal(51.2m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Two_groups_of_four_is_cheaper_than_groups_of_five_and_three()
     {
         var basket = new[] { 1, 1, 2, 3, 4, 4, 5, 5 };
-        Assert.Equal(51.2, BookStore.Total(basket));
+        Assert.Equal(51.2m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Group_of_four_plus_group_of_two_is_cheaper_than_two_groups_of_three()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 4 };
-        Assert.Equal(40.8, BookStore.Total(basket));
+        Assert.Equal(40.8m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Two_each_of_first_4_books_and_1_copy_each_of_rest()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5 };
-        Assert.Equal(55.6, BookStore.Total(basket));
+        Assert.Equal(55.6m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -100,13 +100,13 @@ public class BookStoreTest
     public void Three_each_of_first_2_books_and_2_each_of_remaining_books()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2 };
-        Assert.Equal(75.2, BookStore.Total(basket));
+        Assert.Equal(75.2m, BookStore.Total(basket));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Four_groups_of_four_are_cheaper_than_two_groups_each_of_five_and_three()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 5 };
-        Assert.Equal(102.4, BookStore.Total(basket));
+        Assert.Equal(102.4m, BookStore.Total(basket));
     }
 }

--- a/exercises/book-store/Example.cs
+++ b/exercises/book-store/Example.cs
@@ -4,17 +4,17 @@ using System.Linq;
 
 public static class BookStore
 {
-    private const double BookPrice = 8.0;
+    private const decimal BookPrice = 8.0m;
 
-    public static double Total(int[] books)
+    public static decimal Total(int[] books)
     {
         if (books.Length == 0)
-            return 0.0;
+            return 0.0m;
 
         var bookGroups = BookGroupsWithCount(books);
 
         return Enumerable.Range(1, bookGroups.Length)
-            .Min(size => CalculateTotalCost(bookGroups, size, 0.0));
+            .Min(size => CalculateTotalCost(bookGroups, size, 0.0m));
     }
 
     private static int[] BookGroupsWithCount(int[] books)
@@ -24,7 +24,7 @@ public static class BookStore
             .OrderByDescending(book => book)
             .ToArray();
 
-    private static double CalculateTotalCost(int[] bookGroups, int numberOfBooksToRemove, double totalCost)
+    private static decimal CalculateTotalCost(int[] bookGroups, int numberOfBooksToRemove, decimal totalCost)
     {
         var numberOfBooks = Math.Min(numberOfBooksToRemove, bookGroups.Length);
         if (numberOfBooks == 0)
@@ -48,23 +48,23 @@ public static class BookStore
 
     private static int RemoveBook(int books) => books - 1;
 
-    private static double BooksPrice(int differentBooks)
+    private static decimal BooksPrice(int differentBooks)
         => ApplyDiscount(RegularPrice(differentBooks), DiscountPercentage(differentBooks));
 
-    private static double RegularPrice(int books) => books * BookPrice;
+    private static decimal RegularPrice(int books) => books * BookPrice;
 
-    private static double DiscountPercentage(int differentBooks)
+    private static decimal DiscountPercentage(int differentBooks)
     {
         switch (differentBooks)
         {
-            case 5: return 25.0;
-            case 4: return 20.0;
-            case 3: return 10.0;
-            case 2: return 5.0;
-            default: return 0.0;
+            case 5: return 25.0m;
+            case 4: return 20.0m;
+            case 3: return 10.0m;
+            case 2: return 5.0m;
+            default: return 0.0m;
         }
     }
 
-    private static double ApplyDiscount(double price, double discountPercentage)
-        => Math.Round(price * (100.0f - discountPercentage) / 100.0f, 2);
+    private static decimal ApplyDiscount(decimal price, decimal discountPercentage)
+        => Math.Round(price * (100.0m - discountPercentage) / 100.0m, 2);
 }

--- a/exercises/ledger/Example.cs
+++ b/exercises/ledger/Example.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 public class LedgerEntry
 {
-    public LedgerEntry(DateTime date, string description, float change)
+    public LedgerEntry(DateTime date, string description, decimal change)
     {
         Date = date;
         Description = description;
@@ -14,7 +14,7 @@ public class LedgerEntry
 
     public DateTime Date { get; }
     public string Description { get; }
-    public float Change { get; }
+    public decimal Change { get; }
 }
 
 public static class Ledger
@@ -27,7 +27,7 @@ public static class Ledger
 
     private static DateTime ParseDate(string date) => DateTime.Parse(date, System.Globalization.CultureInfo.InvariantCulture);
 
-    private static float ParseChange(int change) => change / 100.0f;
+    private static decimal ParseChange(int change) => change / 100.0m;
 
     private static CultureInfo CultureInfo(string locale)
     {
@@ -93,8 +93,8 @@ public static class Ledger
     private static string FormatDescription(string description) =>
         description.Length <= TruncateLength ? description : description.Substring(0, TruncateLength - TruncateSuffix.Length) + TruncateSuffix;
 
-    private static string FormatChange(IFormatProvider culture, float change) =>
-        change < 0.0 ? change.ToString("C", culture) : change.ToString("C", culture) + " ";
+    private static string FormatChange(IFormatProvider culture, decimal change) =>
+        change < 0.0m ? change.ToString("C", culture) : change.ToString("C", culture) + " ";
 
     private static string FormatEntry(IFormatProvider culture, LedgerEntry entry) =>
         string.Format("{0} | {1,-25} | {2,13}", FormatDate(culture, entry.Date), FormatDescription(entry.Description), FormatChange(culture, entry.Change));

--- a/exercises/ledger/Ledger.cs
+++ b/exercises/ledger/Ledger.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 public class LedgerEntry
 {
-   public LedgerEntry(DateTime date, string desc, float chg)
+   public LedgerEntry(DateTime date, string desc, decimal chg)
    {
        Date = date;
        Desc = desc;
@@ -14,14 +14,14 @@ public class LedgerEntry
 
    public DateTime Date { get; }
    public string Desc { get; }
-   public float Chg { get; }
+   public decimal Chg { get; }
 }
 
 public static class Ledger
 {
    public static LedgerEntry CreateEntry(string date, string desc, int chng)
    {
-       return new LedgerEntry(DateTime.Parse(date, CultureInfo.InvariantCulture), desc, chng / 100.0f);
+       return new LedgerEntry(DateTime.Parse(date, CultureInfo.InvariantCulture), desc, chng / 100.0m);
    }
 
    private static CultureInfo CreateCulture(string cur, string loc)
@@ -113,9 +113,9 @@ public static class Ledger
        return desc;
    }
 
-   private static string Change(IFormatProvider culture, float cgh)
+   private static string Change(IFormatProvider culture, decimal cgh)
    {
-       return cgh < 0.0 ? cgh.ToString("C", culture) : cgh.ToString("C", culture) + " ";
+       return cgh < 0.0m ? cgh.ToString("C", culture) : cgh.ToString("C", culture) + " ";
    }
 
    private static string PrintEntry(IFormatProvider culture, LedgerEntry entry)

--- a/generators/Exercises/Generators/BookStore.cs
+++ b/generators/Exercises/Generators/BookStore.cs
@@ -12,7 +12,7 @@ namespace Exercism.CSharp.Exercises.Generators
             if (testMethod.Input["basket"] is JArray)
                 testMethod.Input["basket"] = Array.Empty<int>();
             
-            testMethod.Expected = testMethod.Expected / 100.0f;
+            testMethod.Expected = testMethod.Expected / 100.0m;
             testMethod.InputParameters = new[] { "basket" };
             testMethod.UseVariablesForInput = true;
         }

--- a/generators/Output/Rendering/Render.cs
+++ b/generators/Output/Rendering/Render.cs
@@ -16,6 +16,7 @@ namespace Exercism.CSharp.Output.Rendering
             switch (val)
             {
                 case string str: return String(str);
+                case decimal dec: return Decimal(dec);
                 case double dbl: return Double(dbl);
                 case int i: return Int(i);
                 case uint ui: return Uint(ui);

--- a/generators/Output/Rendering/RenderNumber.cs
+++ b/generators/Output/Rendering/RenderNumber.cs
@@ -5,6 +5,7 @@ namespace Exercism.CSharp.Output.Rendering
 {
     public partial class Render
     {
+        public string Decimal(decimal dec) => $"{dec.ToString(CultureInfo.InvariantCulture)}m";
         public string Double(double dbl) => dbl.ToString(CultureInfo.InvariantCulture);
 
         public string Float(float flt) => flt.ToString(CultureInfo.InvariantCulture);

--- a/generators/Output/Rendering/RenderNumber.cs
+++ b/generators/Output/Rendering/RenderNumber.cs
@@ -6,6 +6,7 @@ namespace Exercism.CSharp.Output.Rendering
     public partial class Render
     {
         public string Decimal(decimal dec) => $"{dec.ToString(CultureInfo.InvariantCulture)}m";
+
         public string Double(double dbl) => dbl.ToString(CultureInfo.InvariantCulture);
 
         public string Float(float flt) => flt.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
Updated BankAccount, BookStore and Ledger exercises to use decimal for money instead of float or double.
Updated RenderNumber and Render with decimal rendering.
Updated BookStore test generator to use decimal literals for BookStore tests.