### PR TITLE
space-age: update tests

### DIFF
--- a/exercises/space-age/Example.cs
+++ b/exercises/space-age/Example.cs
@@ -8,7 +8,7 @@ public class SpaceAge
         Earth, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune
     }
 
-    private readonly long seconds;
+    private readonly int seconds;
 
     private readonly Dictionary<Planet, double> earthYearToPlanetPeriod = new Dictionary<Planet, double>
         {
@@ -22,7 +22,7 @@ public class SpaceAge
             { Planet.Neptune, 164.79132 },
         };
 
-    public SpaceAge(long seconds)
+    public SpaceAge(int seconds)
     {
         this.seconds = seconds;
     }

--- a/exercises/space-age/SpaceAge.cs
+++ b/exercises/space-age/SpaceAge.cs
@@ -2,7 +2,7 @@ using System;
 
 public class SpaceAge
 {
-    public SpaceAge(long seconds)
+    public SpaceAge(int seconds)
     {
     }
 

--- a/exercises/space-age/SpaceAgeTest.cs
+++ b/exercises/space-age/SpaceAgeTest.cs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.1.0 of the canonical data.
+// This file was auto-generated based on version 1.2.0 of the canonical data.
 
 using Xunit;
 
@@ -28,8 +28,8 @@ public class SpaceAgeTest
     [Fact(Skip = "Remove to run test")]
     public void Age_on_mars()
     {
-        var sut = new SpaceAge(2329871239);
-        Assert.Equal(39.25, sut.OnMars(), precision: 2);
+        var sut = new SpaceAge(2129871239);
+        Assert.Equal(35.88, sut.OnMars(), precision: 2);
     }
 
     [Fact(Skip = "Remove to run test")]
@@ -42,21 +42,21 @@ public class SpaceAgeTest
     [Fact(Skip = "Remove to run test")]
     public void Age_on_saturn()
     {
-        var sut = new SpaceAge(3000000000);
-        Assert.Equal(3.23, sut.OnSaturn(), precision: 2);
+        var sut = new SpaceAge(2000000000);
+        Assert.Equal(2.15, sut.OnSaturn(), precision: 2);
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Age_on_uranus()
     {
-        var sut = new SpaceAge(3210123456);
-        Assert.Equal(1.21, sut.OnUranus(), precision: 2);
+        var sut = new SpaceAge(1210123456);
+        Assert.Equal(0.46, sut.OnUranus(), precision: 2);
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Age_on_neptune()
     {
-        var sut = new SpaceAge(8210123456);
-        Assert.Equal(1.58, sut.OnNeptune(), precision: 2);
+        var sut = new SpaceAge(1821023456);
+        Assert.Equal(0.35, sut.OnNeptune(), precision: 2);
     }
 }


### PR DESCRIPTION
This PR aims to make the space-age exercise simpler, by having it only introduce the new double type, and not also introduce the long type.