### PR TITLE
Test that names are unique; test that the name is correct after reset

### DIFF
--- a/exercises/robot-name/Example.cs
+++ b/exercises/robot-name/Example.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 
 public class Robot
 {
     private static readonly Random Random = new Random();
+    private static readonly HashSet<string> names = new HashSet<string>();
 
     public string Name { get; private set; }
 
@@ -13,7 +15,14 @@ public class Robot
 
     private static string GenerateName()
     {
-        return GetRandomCharacter() + GetRandomCharacter() + Random.Next(1000).ToString("000");
+        string name;
+        do
+        {
+            name = GetRandomCharacter() + GetRandomCharacter() + Random.Next(1000).ToString("000");
+        } while (names.Contains(name));
+
+        names.Add(name);
+        return name;
     }
 
     private static string GetRandomCharacter()

--- a/exercises/robot-name/RobotNameTest.cs
+++ b/exercises/robot-name/RobotNameTest.cs
@@ -45,7 +45,7 @@ public class RobotNameTest
         var names = new HashSet<string>();
         for (int i = 0; i < 10_000; i++) {
             var robot = new Robot();
-            Assert.DoesNotContain(names, name => name == robot.Name);
+            Assert.DoesNotContain(robot.Name, names);
             names.Add(robot.Name);
         }
     }

--- a/exercises/robot-name/RobotNameTest.cs
+++ b/exercises/robot-name/RobotNameTest.cs
@@ -33,18 +33,20 @@ public class RobotNameTest
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void After_reset_the_name_is_valid() {
+    public void After_reset_the_name_is_valid()
+    {
         robot.Reset();
         Assert.Matches(@"^[A-Z]{2}\d{3}$", robot.Name);
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Robot_names_are_unique() {
+    public void Robot_names_are_unique()
+    {
         var names = new HashSet<string>();
         for (int i = 0; i < 10_000; i++) {
-            Assert.False(names.Contains(robot.Name), $"Name {robot.Name} was already used ({i})");
+            var robot = new Robot();
+            Assert.DoesNotContain(names, name => name == robot.Name);
             names.Add(robot.Name);
-            robot.Reset();
         }
     }
 }

--- a/exercises/robot-name/RobotNameTest.cs
+++ b/exercises/robot-name/RobotNameTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Xunit;
 
 public class RobotNameTest
@@ -29,5 +30,21 @@ public class RobotNameTest
         var originalName = robot.Name;
         robot.Reset();
         Assert.NotEqual(originalName, robot.Name);
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void After_reset_the_name_is_valid() {
+        robot.Reset();
+        Assert.Matches(@"^[A-Z]{2}\d{3}$", robot.Name);
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Robot_names_are_unique() {
+        var names = new HashSet<string>();
+        for (int i = 0; i < 10_000; i++) {
+            Assert.False(names.Contains(robot.Name), $"Name {robot.Name} was already used ({i})");
+            names.Add(robot.Name);
+            robot.Reset();
+        }
     }
 }


### PR DESCRIPTION
I added a couple of tests.

The first one verifies that the name is correct after reset. The existing tests can pass if the name is `""` after reset.

The second verifies that names do not repeat in 10,000 iterations (in my tests I always got collisions after no more than 2000).