### PR TITLE
Fix link formatting in the Clock exercise's README

### DIFF
--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -8,7 +8,7 @@ Two clocks that represent the same time should be equal to each other.
 
 ## Hints
 This exercise requires you to implement a type-specific method for determining equality of instances.
-For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/core/api/System.IEquatable-1).
+For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1?view=netcore-2.1).
 
 
 ## Running the tests

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -8,8 +8,7 @@ Two clocks that represent the same time should be equal to each other.
 
 ## Hints
 This exercise requires you to implement a type-specific method for determining equality of instances.
-For more information, see [this page]
-(https://docs.microsoft.com/en-us/dotnet/core/api/System.IEquatable-1).
+For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/core/api/System.IEquatable-1).
 
 
 ## Running the tests


### PR DESCRIPTION
This is a very small fix. Just removed a wrongly added space between the link's name and the actual link, so that markdown actually understands what it is.