### PR TITLE
resistor-color: add exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,14 +54,13 @@
       ]
     },
     {
-      "slug": "series",
-      "uuid": "9ca46617-4995-45cc-a2dd-b8630eaa288b",
+      "slug": "resistor-color",
+      "uuid": "5314dbee-4a0d-4fd6-a98a-36a746ee0d5c",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "arrays",
-        "strings"
+        "arrays"
       ]
     },
     {
@@ -266,7 +265,7 @@
       "slug": "sum-of-multiples",
       "uuid": "d985d4a9-1a2b-4bb1-ad08-961b8d36ee2e",
       "core": false,
-      "unlocked_by": "series",
+      "unlocked_by": "resistor-color",
       "difficulty": 1,
       "topics": [
         "arrays",
@@ -275,10 +274,21 @@
       ]
     },
     {
+      "slug": "series",
+      "uuid": "9ca46617-4995-45cc-a2dd-b8630eaa288b",
+      "core": false,
+      "unlocked_by": "resistor-color",
+      "difficulty": 1,
+      "topics": [
+        "arrays",
+        "strings"
+      ]
+    },
+    {
       "slug": "accumulate",
       "uuid": "3c0563dc-665a-45b4-9b29-f133e235efd0",
       "core": false,
-      "unlocked_by": "series",
+      "unlocked_by": "resistor-color",
       "difficulty": 2,
       "topics": [
         "extension_methods",
@@ -335,7 +345,7 @@
       "slug": "difference-of-squares",
       "uuid": "5554c048-0de3-4a85-b043-7577f429cba4",
       "core": false,
-      "unlocked_by": "series",
+      "unlocked_by": "resistor-color",
       "difficulty": 1,
       "topics": [
         "control_flow_loops",
@@ -620,7 +630,7 @@
       "slug": "largest-series-product",
       "uuid": "4a6621bb-e55a-4ae2-89e3-3aa7e37a8656",
       "core": false,
-      "unlocked_by": "series",
+      "unlocked_by": "resistor-color",
       "difficulty": 4,
       "topics": [
         "integers",
@@ -644,7 +654,7 @@
       "slug": "pythagorean-triplet",
       "uuid": "4d5a53df-3d6b-46cb-a964-71c676f3cd93",
       "core": false,
-      "unlocked_by": "series",
+      "unlocked_by": "resistor-color",
       "difficulty": 4,
       "topics": [
         "integers",
@@ -690,7 +700,7 @@
       "slug": "prime-factors",
       "uuid": "456ffe2c-e241-4373-8bea-d4d328f815e9",
       "core": false,
-      "unlocked_by": "series",
+      "unlocked_by": "resistor-color",
       "difficulty": 4,
       "topics": [
         "integers",
@@ -711,7 +721,7 @@
       "slug": "all-your-base",
       "uuid": "de5e2eff-2b80-4996-a322-dc59ebe25edd",
       "core": false,
-      "unlocked_by": "series",
+      "unlocked_by": "resistor-color",
       "difficulty": 4,
       "topics": [
         "integers",
@@ -723,7 +733,7 @@
       "slug": "pascals-triangle",
       "uuid": "d5d48857-5325-45d2-9969-95a0d7bba370",
       "core": false,
-      "unlocked_by": "series",
+      "unlocked_by": "resistor-color",
       "difficulty": 4,
       "topics": [
         "arrays",

--- a/exercises/Exercises.sln
+++ b/exercises/Exercises.sln
@@ -240,6 +240,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HighScores", "high-scores\H
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DndCharacter", "dnd-character\DndCharacter.csproj", "{91499710-DC6A-4494-9661-9D374829E975}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResistorColor", "resistor-color\ResistorColor.csproj", "{3E499D5B-C5A9-4BCD-BF35-46D590EC06AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -722,6 +724,10 @@ Global
 		{91499710-DC6A-4494-9661-9D374829E975}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91499710-DC6A-4494-9661-9D374829E975}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91499710-DC6A-4494-9661-9D374829E975}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E499D5B-C5A9-4BCD-BF35-46D590EC06AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E499D5B-C5A9-4BCD-BF35-46D590EC06AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E499D5B-C5A9-4BCD-BF35-46D590EC06AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E499D5B-C5A9-4BCD-BF35-46D590EC06AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/exercises/resistor-color/Example.cs
+++ b/exercises/resistor-color/Example.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+public static class ResistorColor
+{
+    private static readonly string[] AllColors = new[] { "black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white" };
+
+    public static int ColorCode(string color) => Array.IndexOf(AllColors, color);
+
+    public static string[] Colors() => AllColors;
+}

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -1,0 +1,41 @@
+# Resistor Color
+
+Resistors have color coded bands, where each color maps to a number. The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+These colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)
+
+## Running the tests
+
+To run the tests, run the command `dotnet test` from within the exercise directory.
+
+Initially, only the first test will be enabled. This is to encourage you to solve the exercise one step at a time.
+Once you get the first test passing, remove the `Skip` property from the next test and work on getting that test passing.
+Once none of the tests are skipped and they are all passing, you can submit your solution 
+using `exercism submit ResistorColor.cs`
+
+## Further information
+
+For more detailed information about the C# track, including how to get help if
+you're having trouble, please visit the exercism.io [C# language page](http://exercism.io/languages/csharp/resources).
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1458](https://github.com/exercism/problem-specifications/issues/1458)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color/ResistorColor.cs
+++ b/exercises/resistor-color/ResistorColor.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+public static class ResistorColor
+{
+    public static int ColorCode(string color)
+    {
+        throw new NotImplementedException("You need to implement this function.");
+    }
+
+    public static string[] Colors()
+    {
+        throw new NotImplementedException("You need to implement this function.");
+    }
+}

--- a/exercises/resistor-color/ResistorColor.csproj
+++ b/exercises/resistor-color/ResistorColor.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Example.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/resistor-color/ResistorColorTest.cs
+++ b/exercises/resistor-color/ResistorColorTest.cs
@@ -1,0 +1,30 @@
+// This file was auto-generated based on version 1.0.0 of the canonical data.
+
+using Xunit;
+
+public class ResistorColorTest
+{
+    [Fact]
+    public void Black()
+    {
+        Assert.Equal(0, ResistorColor.ColorCode("black"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void White()
+    {
+        Assert.Equal(9, ResistorColor.ColorCode("white"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Orange()
+    {
+        Assert.Equal(3, ResistorColor.ColorCode("orange"));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Colors()
+    {
+        Assert.Equal(new[] { "black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white" }, ResistorColor.Colors());
+    }
+}

--- a/generators/Exercises/Generators/ResistorColor.cs
+++ b/generators/Exercises/Generators/ResistorColor.cs
@@ -1,0 +1,9 @@
+﻿using Exercism.CSharp.Output;
+using Exercism.CSharp.Output.Rendering;
+
+namespace Exercism.CSharp.Exercises.Generators
+{
+    public class ResistorColor : GeneratorExercise
+    {
+    }
+}


### PR DESCRIPTION
This PR adds the new `resistor-color` exercise, which is aimed at replacing `series` as the exercise to introduce arrays with.

Closes #755 
