### PR TITLE
Add automerge for all dependabot projects in old configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,497 +12,993 @@ update_configs:
     - package_manager: "dotnet:nuget"
       directory: "/exercises/acronym"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/affine-cipher"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/all-your-base"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/allergies"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/alphametics"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/anagram"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/armstrong-numbers"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/atbash-cipher"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/bank-account"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/beer-song"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/binary"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/binary-search"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/binary-search-tree"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/bob"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/book-store"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/bowling"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/bracket-push"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/change"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/circular-buffer"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/clock"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/collatz-conjecture"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/complex-numbers"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/connect"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/crypto-square"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/custom-set"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/darts"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/diamond"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/difference-of-squares"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/diffie-hellman"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/dnd-character"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/dominoes"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/dot-dsl"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/error-handling"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/etl"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/flatten-array"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/food-chain"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/forth"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/gigasecond"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/go-counting"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/grade-school"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/grains"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/grep"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/hamming"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/hangman"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/hello-world"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/hexadecimal"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/high-scores"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/house"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/isbn-verifier"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/isogram"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/kindergarten-garden"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/largest-series-product"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/leap"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/ledger"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/linked-list"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/list-ops"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/luhn"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/markdown"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/matrix"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/meetup"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/minesweeper"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/nth-prime"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/nucleotide-count"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/ocr-numbers"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/octal"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/palindrome-products"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/pangram"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/parallel-letter-frequency"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/pascals-triangle"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/perfect-numbers"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/phone-number"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/pig-latin"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/poker"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/pov"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/prime-factors"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/protein-translation"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/proverb"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/pythagorean-triplet"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/queen-attack"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/rail-fence-cipher"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/raindrops"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/rational-numbers"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/react"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/rectangles"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/resistor-color"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/rest-api"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/reverse-string"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/rna-transcription"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/robot-name"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/robot-simulator"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/roman-numerals"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/rotational-cipher"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/run-length-encoding"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/saddle-points"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/say"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/scale-generator"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/scrabble-score"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/secret-handshake"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/series"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/sgf-parsing"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/sieve"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/simple-cipher"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/simple-linked-list"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/space-age"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/spiral-matrix"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/strain"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/sublist"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/sum-of-multiples"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/tournament"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/transpose"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/tree-building"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/triangle"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/trinary"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/twelve-days"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/two-bucket"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/two-fer"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/variable-length-quantity"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/word-count"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/word-search"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/wordy"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/yacht"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/zebra-puzzle"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/exercises/zipper"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
     - package_manager: "dotnet:nuget"
       directory: "/generators"
       update_schedule: "live"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:minor"
 
 

--- a/update-dependabot.ps1
+++ b/update-dependabot.ps1
@@ -21,6 +21,10 @@ foreach ($path in $paths)
 	[void]$output.AppendLine("    - package_manager: `"dotnet:nuget`"")
 	[void]$output.AppendLine("      directory: `"" + $relativePath + "`"")
 	[void]$output.AppendLine("      update_schedule: `"live`"")
+	[void]$output.AppendLine("      automerged_updates:")
+	[void]$output.AppendLine("        - match:")
+	[void]$output.AppendLine("            dependency_type: `"all`"")
+	[void]$output.AppendLine("            update_type: `"semver:minor`"")
 	[void]$output.AppendLine("")
 }
 


### PR DESCRIPTION
We can merge this and have dependabot cleanup existing PRs, before moving to the simplified configuration as part of #1237