### PR TITLE
structure: move circular-buffer up

### DIFF
--- a/config.json
+++ b/config.json
@@ -152,6 +152,17 @@
       ]
     },
     {
+      "slug": "circular-buffer",
+      "uuid": "657ac368-9b17-4f87-b815-decfe2bc0b5d",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "classes",
+        "queues"
+      ]
+    },
+    {
       "slug": "clock",
       "uuid": "83e4cb1e-456f-4c74-ae82-6895f0bd73ae",
       "core": true,
@@ -171,17 +182,6 @@
       "topics": [
         "control_flow_if_else_statements",
         "strings"
-      ]
-    },
-    {
-      "slug": "circular-buffer",
-      "uuid": "657ac368-9b17-4f87-b815-decfe2bc0b5d",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "classes",
-        "queues"
       ]
     },
     {


### PR DESCRIPTION
The canonical solution to the circular-buffer exercise, is to use a queue. This makes it quite simple. I do like to keep it a core exercise though, as it can teach students about different data structure (e.g. `Queue<T>`) and introduces generic classes. As such, I've moved it up a bit in the core ordering.

Closes #767