### PR TITLE
Left align example table for two-fer readme

### DIFF
--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -18,12 +18,12 @@ One for you, one for me.
 
 Here are some examples:
 
-|Name    | String to return 
-|:------:|:-----------------: 
-|Alice   | One for Alice, one for me. 
-|Bob     | One for Bob, one for me.
-|        | One for you, one for me.
-|Zaphod  | One for Zaphod, one for me.
+|Name   |String to return
+|:------|:---------------
+|Alice  | One for Alice, one for me. 
+|Bob    | One for Bob, one for me.
+|       | One for you, one for me.
+|Zaphod | One for Zaphod, one for me.
 
 ## Running the tests
 


### PR DESCRIPTION
The table table with examples in the two-fer readme is center aligned this is not very readable. This PR makes the table left aligned.

<img width="567" alt="afbeelding" src="https://user-images.githubusercontent.com/7275740/54120240-8a6ea180-43f7-11e9-9eba-81ac147c87b5.png">