### PR TITLE
Regenerate outdated Leap tests.

### DIFF
--- a/exercises/leap/LeapTest.cs
+++ b/exercises/leap/LeapTest.cs
@@ -1,35 +1,41 @@
-// This file was auto-generated based on version 1.4.0 of the canonical data.
+// This file was auto-generated based on version 1.5.1 of the canonical data.
 
 using Xunit;
 
 public class LeapTest
 {
     [Fact]
-    public void Year_not_divisible_by_4_is_common_year()
+    public void Year_not_divisible_by_4_in_common_year()
     {
         Assert.False(Leap.IsLeapYear(2015));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Year_divisible_by_4_not_divisible_by_100_is_leap_year()
+    public void Year_divisible_by_2_not_divisible_by_4_in_common_year()
+    {
+        Assert.False(Leap.IsLeapYear(1970));
+    }
+
+    [Fact(Skip = "Remove to run test")]
+    public void Year_divisible_by_4_not_divisible_by_100_in_leap_year()
     {
         Assert.True(Leap.IsLeapYear(1996));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Year_divisible_by_100_not_divisible_by_400_is_common_year()
+    public void Year_divisible_by_100_not_divisible_by_400_in_common_year()
     {
         Assert.False(Leap.IsLeapYear(2100));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Year_divisible_by_400_is_leap_year()
+    public void Year_divisible_by_400_in_leap_year()
     {
         Assert.True(Leap.IsLeapYear(2000));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Year_divisible_by_200_not_divisible_by_400_is_common_year()
+    public void Year_divisible_by_200_not_divisible_by_400_in_common_year()
     {
         Assert.False(Leap.IsLeapYear(1800));
     }


### PR DESCRIPTION
Leap has new canonical data. Updated the test autodated test from canonical data v1.4.0 to v1.5.1.