### PR TITLE
Fix FileNotFoundException when running generators on Windows from VisualStudio

### DIFF
--- a/generators/Generators.csproj
+++ b/generators/Generators.csproj
@@ -16,4 +16,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Output\Rendering\Templates\*.liquid" />
   </ItemGroup>
+  <PropertyGroup>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
There's now a workaround to fix #723