### PR TITLE
Ensure PowerShell errors are propagated

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,4 @@
 dotnet tool install -g Cake.Tool --version 0.33.0
 dotnet cake build.cake $args
+
+exit $LastExitCode

--- a/copy-track-files-to-exercise.ps1
+++ b/copy-track-files-to-exercise.ps1
@@ -8,3 +8,5 @@ Get-Childitem –Path "exercises" -Directory | ForEach-Object {
 
     Set-Content -Path $ExerciseEditorConfigPath $ExerciseEditorConfigSettings
 }
+
+exit $LastExitCode

--- a/exercises/diffie-hellman/DiffieHellmanTest.cs
+++ b/exercises/diffie-hellman/DiffieHellmanTest.cs
@@ -50,10 +50,10 @@ public class DiffieHellmanTest
         var g = new BigInteger(5);
         var alicePrivateKey = DiffieHellman.PrivateKey(p);
         var bobPrivateKey = DiffieHellman.PrivateKey(p);
-        var alicePublicKey = DiffieHellman.PublicKey(p,G,AlicePrivateKey);
-        var bobPublicKey = DiffieHellman.PublicKey(p,G,BobPrivateKey);
-        var secretA = DiffieHellman.Secret(p,BobPublicKey,AlicePrivateKey);
-        var secretB = DiffieHellman.Secret(p,AlicePublicKey,BobPrivateKey);
+        var alicePublicKey = DiffieHellman.PublicKey(p, g, alicePrivateKey);
+        var bobPublicKey = DiffieHellman.PublicKey(p, g, bobPrivateKey);
+        var secretA = DiffieHellman.Secret(p, bobPublicKey, alicePrivateKey);
+        var secretB = DiffieHellman.Secret(p, alicePublicKey, bobPrivateKey);
         Assert.Equal(secretA, secretB);
     }
 }

--- a/exercises/dnd-character/DndCharacterTest.cs
+++ b/exercises/dnd-character/DndCharacterTest.cs
@@ -1,5 +1,6 @@
 // This file was auto-generated based on version 1.1.0 of the canonical data.
 
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -144,7 +145,8 @@ public class DndCharacterTest
     [Fact(Skip = "Remove to run test")]
     public void Random_ability_is_distributed_correctly()
     {
-        var expectedDistribution = new Dictionary<int, int>() {
+        var expectedDistribution = new Dictionary<int, int>
+        {
             [3] = 1,        [4] = 4,
             [5] = 10,       [6] = 21,
             [7] = 38,       [8] = 62,
@@ -155,18 +157,18 @@ public class DndCharacterTest
             [17] = 54,      [18] = 21
         };
         var actualDistribution = new Dictionary<int, int>();
-        var times = 100;
-        const int PossibleCombinationsCount = 6*6*6*6; // 4d6
+        const int times = 100;
+        const int possibleCombinationsCount = 6*6*6*6; // 4d6
         for (var i = 3; i <= 18; i++)
             actualDistribution[i] = 0;
-        for (var i = 0; i < times * PossibleCombinationsCount; i++)
+        for (var i = 0; i < times * possibleCombinationsCount; i++)
         {
             var ability = DndCharacter.Ability();
             actualDistribution[ability]++;
         }
         int min(int expected) => (int)(expected * (times * 0.8));
         int max(int expected) => (int)(expected * (times * 1.2));
-        foreach (var k in idealDistribution.Keys)
+        foreach (var k in expectedDistribution.Keys)
             Assert.InRange(actualDistribution[k], min(expectedDistribution[k]), max(expectedDistribution[k]));
     }
 }

--- a/generators/Exercises/Generators/DiffieHellman.cs
+++ b/generators/Exercises/Generators/DiffieHellman.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+using Exercism.CSharp.Helpers;
 using Exercism.CSharp.Output;
 using Exercism.CSharp.Output.Rendering;
 using Humanizer;
@@ -96,7 +97,7 @@ namespace Exercism.CSharp.Exercises.Generators
                 case long l:
                     return new BigInteger(l);
                 case string str:
-                    return new UnescapedValue($"{testMethod.TestedClass}.{str.Pascalize()}");
+                    return new UnescapedValue($"{testMethod.TestedClass}.{char.ToUpper(str[0]) + str.Substring(1)}");
                 default:
                     return input;
             }

--- a/generators/Exercises/Generators/DndCharacter.cs
+++ b/generators/Exercises/Generators/DndCharacter.cs
@@ -39,7 +39,7 @@ namespace Exercism.CSharp.Exercises.Generators
             return assert.ToString();
         }
 
-        private void UpdateTestMethodForCharacterProperty(TestMethod testMethod) 
+        private void UpdateTestMethodForCharacterProperty(TestMethod testMethod)
             => testMethod.Assert = RenderAssertForCharacterProperty(testMethod);
 
         private string RenderAssertForCharacterProperty(TestMethod testMethod)
@@ -86,7 +86,8 @@ namespace Exercism.CSharp.Exercises.Generators
 [Fact(Skip = ""Remove to run test"")]
 public void Random_ability_is_distributed_correctly()
 {
-    var expectedDistribution = new Dictionary<int, int>() {
+    var expectedDistribution = new Dictionary<int, int>
+    {
         [3] = 1,        [4] = 4,
         [5] = 10,       [6] = 21,
         [7] = 38,       [8] = 62,
@@ -97,23 +98,30 @@ public void Random_ability_is_distributed_correctly()
         [17] = 54,      [18] = 21
     };
     var actualDistribution = new Dictionary<int, int>();
-    var times = 100;
-    const int PossibleCombinationsCount = 6*6*6*6; // 4d6
+    const int times = 100;
+    const int possibleCombinationsCount = 6*6*6*6; // 4d6
+
     for (var i = 3; i <= 18; i++)
         actualDistribution[i] = 0;
-    for (var i = 0; i < times * PossibleCombinationsCount; i++)
+
+    for (var i = 0; i < times * possibleCombinationsCount; i++)
     {
         var ability = DndCharacter.Ability();
         actualDistribution[ability]++;
     }
+
     int min(int expected) => (int)(expected * (times * 0.8));
     int max(int expected) => (int)(expected * (times * 1.2));
-    foreach (var k in idealDistribution.Keys)
+
+    foreach (var k in expectedDistribution.Keys)
         Assert.InRange(actualDistribution[k], min(expectedDistribution[k]), max(expectedDistribution[k]));
 }");
         }
 
         protected override void UpdateNamespaces(ISet<string> namespaces)
-            => namespaces.Add(typeof(System.Linq.Enumerable).Namespace);
+        {
+            namespaces.Add(typeof(Enumerable).Namespace);
+            namespaces.Add(typeof(Dictionary<int, int>).Namespace);
+        }
     }
 }

--- a/update-docs.ps1
+++ b/update-docs.ps1
@@ -6,3 +6,5 @@ git submodule update --remote
 
 .\bin\fetch-configlet
 .\bin\configlet generate . -p problem-specifications $args
+
+exit $LastExitCode


### PR DESCRIPTION
When issue #1299 was created, I found out that there was something wrong with our build pipeline. The [CI run](https://travis-ci.org/exercism/csharp/builds/554366818?utm_source=github_status&utm_medium=notification) had an error, but Travis still thought that it was a succesful build. Apparently, one has to be explicit about returning the error code of called scripts, which is what this PR adds.