### PR TITLE
WIP Update prime factors to use longs

### DIFF
--- a/exercises/prime-factors/Example.cs
+++ b/exercises/prime-factors/Example.cs
@@ -2,10 +2,10 @@ using System.Collections.Generic;
 
 public class PrimeFactors
 {
-    public static int[] Factors(long number)
+    public static long[] Factors(long number)
     {
-        var primes = new List<int>();
-        int divisor = 2;
+        var primes = new List<long>();
+        long divisor = 2;
         while (number > 1)
         {
             while (number % divisor == 0)

--- a/exercises/prime-factors/PrimeFactors.cs
+++ b/exercises/prime-factors/PrimeFactors.cs
@@ -2,7 +2,7 @@ using System;
 
 public static class PrimeFactors
 {
-    public static int[] Factors(long number)
+    public static long[] Factors(long number)
     {
         throw new NotImplementedException();
     }

--- a/exercises/prime-factors/PrimeFactorsTest.cs
+++ b/exercises/prime-factors/PrimeFactorsTest.cs
@@ -7,42 +7,42 @@ public class PrimeFactorsTest
     [Fact]
     public void No_factors()
     {
-        Assert.Empty(PrimeFactors.Factors(1));
+        Assert.Empty(PrimeFactors.Factors(1L));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Prime_number()
     {
-        Assert.Equal(new[] { 2 }, PrimeFactors.Factors(2));
+        Assert.Equal(new[] { 2L }, PrimeFactors.Factors(2L));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Square_of_a_prime()
     {
-        Assert.Equal(new[] { 3, 3 }, PrimeFactors.Factors(9));
+        Assert.Equal(new[] { 3L, 3L }, PrimeFactors.Factors(9L));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Cube_of_a_prime()
     {
-        Assert.Equal(new[] { 2, 2, 2 }, PrimeFactors.Factors(8));
+        Assert.Equal(new[] { 2L, 2L, 2L }, PrimeFactors.Factors(8L));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Product_of_primes_and_non_primes()
     {
-        Assert.Equal(new[] { 2, 2, 3 }, PrimeFactors.Factors(12));
+        Assert.Equal(new[] { 2L, 2L, 3L }, PrimeFactors.Factors(12L));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Product_of_primes()
     {
-        Assert.Equal(new[] { 5, 17, 23, 461 }, PrimeFactors.Factors(901255));
+        Assert.Equal(new[] { 5L, 17L, 23L, 461L }, PrimeFactors.Factors(901255L));
     }
 
     [Fact(Skip = "Remove to run test")]
     public void Factors_include_a_large_prime()
     {
-        Assert.Equal(new[] { 11, 9539, 894119 }, PrimeFactors.Factors(93819012551));
+        Assert.Equal(new[] { 11L, 9539L, 894119L }, PrimeFactors.Factors(93819012551L));
     }
 }

--- a/generators/Exercises/Generators/PrimeFactors.cs
+++ b/generators/Exercises/Generators/PrimeFactors.cs
@@ -1,6 +1,16 @@
-﻿namespace Exercism.CSharp.Exercises.Generators
+﻿using System.Linq;
+using Exercism.CSharp.Output;
+
+namespace Exercism.CSharp.Exercises.Generators
 {
     public class PrimeFactors : GeneratorExercise
     {
+        protected override void UpdateTestMethod(TestMethod testMethod)
+        {
+            if (testMethod.Expected is int[])
+            {
+                testMethod.Expected = ((int[])testMethod.Expected).Select(l => (long)l).ToArray();
+            }
+        }
     }
 }

--- a/generators/Output/Rendering/Render.cs
+++ b/generators/Output/Rendering/Render.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using System.Text.RegularExpressions;
 
@@ -21,6 +20,7 @@ namespace Exercism.CSharp.Output.Rendering
                 case int i: return Int(i);
                 case uint ui: return Uint(ui);
                 case float flt: return Float(flt);
+                case long lng: return Long(lng);
                 case ulong ulng: return Ulong(ulng);
                 case char c: return Char(c);
                 case DateTime dateTime: return DateTime(dateTime);

--- a/generators/Output/Rendering/RenderNumber.cs
+++ b/generators/Output/Rendering/RenderNumber.cs
@@ -13,6 +13,8 @@ namespace Exercism.CSharp.Output.Rendering
 
         public string Int(int i) => i.ToString(CultureInfo.InvariantCulture);
 
+        public string Long(long lng) => $"{lng}L";
+
         public string Ulong(ulong ulng) => $"{ulng}UL";
 
         public string Uint(uint ui) => string.Format("0x{0:X}u", ui);

--- a/generators/Output/TestMethodOutput.cs
+++ b/generators/Output/TestMethodOutput.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Exercism.CSharp.Exercises;
 using Exercism.CSharp.Helpers;
-using Exercism.CSharp.Input;
 using Exercism.CSharp.Output.Rendering;
 
 namespace Exercism.CSharp.Output


### PR DESCRIPTION
This change causes all of the ints to be treated as longs throughout the rest of the exercises. I left the other exercises out of this WIP PR so it makes it easier to see what changes I made.

@ErikSchierboom do you have an idea what I'm doing wrong?

Fixes #1309