### PR TITLE
Add test for side effect of sorting function

### DIFF
--- a/exercises/high-scores/HighScoresTest.cs
+++ b/exercises/high-scores/HighScoresTest.cs
@@ -60,4 +60,14 @@ public class HighScoresTest
         var sut = new HighScores(new List<int> { 40 });
         Assert.Equal(new List<int> { 40 }, sut.PersonalTopThree());
     }
+    
+    [Fact(Skip = "Remove to run test")]
+    public void Lastest_score_messed_up_after_calling_personal_best()
+    {
+        var sut = new HighScores(new List<int> { 20, 10, 30, 3, 2, 1 });
+        var latest = 1;
+        Assert.Equal(latest, sut.Latest());
+        sut.PersonalBest();
+        Assert.Equal(latest, sut.Latest());
+    }
 }


### PR DESCRIPTION
I noticed quite a high amount of people fall for an implementation of PersonalBest like
```
public int PersonalBest()
{
        scores.Sort();
        return scores.Last();
}
```

this introduces a side effect that breaks Latest().

I think it's worthwhile adding a test for it.