### PR TITLE
Add retries to the build for the configlet step to hide transient failures

### DIFF
--- a/shared.ps1
+++ b/shared.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 
 # PowerShell does not check the return code of native commands.
 # There is a pending proposal to support this: https://github.com/PowerShell/PowerShell-RFC/pull/88/files
-function Run-Command ($Command) {
+function Run-Command ($Command, $NumRetries = 0) {
     <#
         .SYNOPSIS
             Run a native command.
@@ -14,9 +14,15 @@ function Run-Command ($Command) {
             Run-Command "./bin/configlet hint ."
     #>
 
-    Invoke-Expression $Command
-    
-    if ($Lastexitcode -ne 0) {
-        exit $Lastexitcode
-    }
+	for ($i = 0; $i -le $NumRetries; $i++) {
+		Invoke-Expression $Command
+	
+		if ($Lastexitcode -eq 0) {
+			return
+		}
+		
+		Start-Sleep -Seconds 5
+	}
+
+    exit $Lastexitcode
 }

--- a/test.ps1
+++ b/test.ps1
@@ -30,7 +30,7 @@ $exercisesDir = Resolve-Path "exercises"
 
 function Configlet-Lint {
     Write-Output "Linting config.json"
-    Run-Command "./bin/fetch-configlet"
+    Run-Command "./bin/fetch-configlet" 2
     Run-Command "./bin/configlet lint ."
 }
 


### PR DESCRIPTION
Let's give this a try and see if it helps...