### PR TITLE
Improve Skip string

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -8,7 +8,7 @@ dotnet test
 
 ## Solving the exercise
 
-Solving an exercise means making all its tests pass. By default, only one test (the first one) is executed when you run the tests. This is intentional, as it allows you to focus on just making that one test pass. Once it passes, you can enable the next test by removing `Skip = "Remove to run test"` from the test's `[Fact]` or `[Theory]` attribute. When all tests have been enabled and your implementation makes them all pass, you'll have solved the exercise!
+Solving an exercise means making all its tests pass. By default, only one test (the first one) is executed when you run the tests. This is intentional, as it allows you to focus on just making that one test pass. Once it passes, you can enable the next test by removing `Skip = "Remove this Skip property to run this test"` from the test's `[Fact]` or `[Theory]` attribute. When all tests have been enabled and your implementation makes them all pass, you'll have solved the exercise!
 
 To help you get started, each exercise comes with a stub implementation file. You can use this file as a starting point for building your solution. Feel free to remove or change this file if you think it is the right thing to do.
 

--- a/exercises/accumulate/AccumulateTests.cs
+++ b/exercises/accumulate/AccumulateTests.cs
@@ -11,19 +11,19 @@ public class AccumulateTests
         Assert.Equal(new int[0], new int[0].Accumulate(x => x * x));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Accumulate_squares()
     {
         Assert.Equal(new[] { 1, 4, 9 }, new[] { 1, 2, 3 }.Accumulate(x => x * x));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Accumulate_upcases()
     {
         Assert.Equal(new List<string> { "HELLO", "WORLD" }, new List<string> { "hello", "world" }.Accumulate(x => x.ToUpper()));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Accumulate_reversed_strings()
     {
         Assert.Equal("eht kciuq nworb xof cte".Split(' '), "the quick brown fox etc".Split(' ').Accumulate(Reverse));
@@ -36,7 +36,7 @@ public class AccumulateTests
         return new string(array);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Accumulate_within_accumulate()
     {
         var actual = new[] { "a", "b", "c" }.Accumulate(c =>
@@ -44,7 +44,7 @@ public class AccumulateTests
         Assert.Equal(new[] { "a1 a2 a3", "b1 b2 b3", "c1 c2 c3" }, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Accumulate_is_lazy()
     {
         var counter = 0;
@@ -55,7 +55,7 @@ public class AccumulateTests
         Assert.Equal(3, counter);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Accumulate_allows_different_return_type()
     {
         Assert.Equal(new[] { "1", "2", "3" }, new[] { 1, 2, 3 }.Accumulate(x => x.ToString()));

--- a/exercises/acronym/AcronymTests.cs
+++ b/exercises/acronym/AcronymTests.cs
@@ -10,49 +10,49 @@ public class AcronymTests
         Assert.Equal("PNG", Acronym.Abbreviate("Portable Network Graphics"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Lowercase_words()
     {
         Assert.Equal("ROR", Acronym.Abbreviate("Ruby on Rails"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Punctuation()
     {
         Assert.Equal("FIFO", Acronym.Abbreviate("First In, First Out"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_caps_word()
     {
         Assert.Equal("GIMP", Acronym.Abbreviate("GNU Image Manipulation Program"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Punctuation_without_whitespace()
     {
         Assert.Equal("CMOS", Acronym.Abbreviate("Complementary metal-oxide semiconductor"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Very_long_abbreviation()
     {
         Assert.Equal("ROTFLSHTMDCOALM", Acronym.Abbreviate("Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Consecutive_delimiters()
     {
         Assert.Equal("SIMUFTA", Acronym.Abbreviate("Something - I made up from thin air"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Apostrophes()
     {
         Assert.Equal("HC", Acronym.Abbreviate("Halley's Comet"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Underscore_emphasis()
     {
         Assert.Equal("TRNT", Acronym.Abbreviate("The Road _Not_ Taken"));

--- a/exercises/affine-cipher/AffineCipherTests.cs
+++ b/exercises/affine-cipher/AffineCipherTests.cs
@@ -11,91 +11,91 @@ public class AffineCipherTests
         Assert.Equal("xbt", AffineCipher.Encode("yes", 5, 7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_no()
     {
         Assert.Equal("fu", AffineCipher.Encode("no", 15, 18));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_omg()
     {
         Assert.Equal("lvz", AffineCipher.Encode("OMG", 21, 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_o_m_g()
     {
         Assert.Equal("hjp", AffineCipher.Encode("O M G", 25, 47));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_mindblowingly()
     {
         Assert.Equal("rzcwa gnxzc dgt", AffineCipher.Encode("mindblowingly", 11, 15));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_numbers()
     {
         Assert.Equal("jqgjc rw123 jqgjc rw", AffineCipher.Encode("Testing,1 2 3, testing.", 3, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_deep_thought()
     {
         Assert.Equal("iynia fdqfb ifje", AffineCipher.Encode("Truth is fiction.", 5, 17));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_all_the_letters()
     {
         Assert.Equal("swxtj npvyk lruol iejdc blaxk swxmh qzglf", AffineCipher.Encode("The quick brown fox jumps over the lazy dog.", 17, 33));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_with_a_not_coprime_to_m()
     {
         Assert.Throws<ArgumentException>(() => AffineCipher.Encode("This is a test.", 6, 17));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_exercism()
     {
         Assert.Equal("exercism", AffineCipher.Decode("tytgn fjr", 3, 7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_a_sentence()
     {
         Assert.Equal("anobstacleisoftenasteppingstone", AffineCipher.Decode("qdwju nqcro muwhn odqun oppmd aunwd o", 19, 16));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_numbers()
     {
         Assert.Equal("testing123testing", AffineCipher.Decode("odpoz ub123 odpoz ub", 25, 7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_all_the_letters()
     {
         Assert.Equal("thequickbrownfoxjumpsoverthelazydog", AffineCipher.Decode("swxtj npvyk lruol iejdc blaxk swxmh qzglf", 17, 33));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_with_no_spaces_in_input()
     {
         Assert.Equal("thequickbrownfoxjumpsoverthelazydog", AffineCipher.Decode("swxtjnpvyklruoliejdcblaxkswxmhqzglf", 17, 33));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_with_too_many_spaces()
     {
         Assert.Equal("jollygreengiant", AffineCipher.Decode("vszzm    cly   yd cg    qdp", 15, 16));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_with_a_not_coprime_to_m()
     {
         Assert.Throws<ArgumentException>(() => AffineCipher.Decode("Test", 13, 5));

--- a/exercises/all-your-base/AllYourBaseTests.cs
+++ b/exercises/all-your-base/AllYourBaseTests.cs
@@ -15,7 +15,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_to_single_decimal()
     {
         var inputBase = 2;
@@ -25,7 +25,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_decimal_to_binary()
     {
         var inputBase = 10;
@@ -35,7 +35,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_to_multiple_decimal()
     {
         var inputBase = 2;
@@ -45,7 +45,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decimal_to_binary()
     {
         var inputBase = 10;
@@ -55,7 +55,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trinary_to_hexadecimal()
     {
         var inputBase = 3;
@@ -65,7 +65,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_to_trinary()
     {
         var inputBase = 16;
@@ -75,7 +75,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_15_bit_integer()
     {
         var inputBase = 97;
@@ -85,7 +85,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_list()
     {
         var inputBase = 2;
@@ -95,7 +95,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_zero()
     {
         var inputBase = 10;
@@ -105,7 +105,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_zeros()
     {
         var inputBase = 10;
@@ -115,7 +115,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Leading_zeros()
     {
         var inputBase = 7;
@@ -125,7 +125,7 @@ public class AllYourBaseTests
         Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Input_base_is_one()
     {
         var inputBase = 1;
@@ -134,7 +134,7 @@ public class AllYourBaseTests
         Assert.Throws<ArgumentException>(() => AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Input_base_is_zero()
     {
         var inputBase = 0;
@@ -143,7 +143,7 @@ public class AllYourBaseTests
         Assert.Throws<ArgumentException>(() => AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Input_base_is_negative()
     {
         var inputBase = -2;
@@ -152,7 +152,7 @@ public class AllYourBaseTests
         Assert.Throws<ArgumentException>(() => AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_digit()
     {
         var inputBase = 2;
@@ -161,7 +161,7 @@ public class AllYourBaseTests
         Assert.Throws<ArgumentException>(() => AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_positive_digit()
     {
         var inputBase = 2;
@@ -170,7 +170,7 @@ public class AllYourBaseTests
         Assert.Throws<ArgumentException>(() => AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Output_base_is_one()
     {
         var inputBase = 2;
@@ -179,7 +179,7 @@ public class AllYourBaseTests
         Assert.Throws<ArgumentException>(() => AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Output_base_is_zero()
     {
         var inputBase = 10;
@@ -188,7 +188,7 @@ public class AllYourBaseTests
         Assert.Throws<ArgumentException>(() => AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Output_base_is_negative()
     {
         var inputBase = 2;
@@ -197,7 +197,7 @@ public class AllYourBaseTests
         Assert.Throws<ArgumentException>(() => AllYourBase.Rebase(inputBase, digits, outputBase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_bases_are_negative()
     {
         var inputBase = -2;

--- a/exercises/allergies/AllergiesTests.cs
+++ b/exercises/allergies/AllergiesTests.cs
@@ -11,287 +11,287 @@ public class AllergiesTests
         Assert.False(sut.IsAllergicTo(Allergen.Eggs));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_eggs_allergy_allergic_only_to_eggs()
     {
         var sut = new Allergies(1);
         Assert.True(sut.IsAllergicTo(Allergen.Eggs));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_eggs_allergy_allergic_to_eggs_and_something_else()
     {
         var sut = new Allergies(3);
         Assert.True(sut.IsAllergicTo(Allergen.Eggs));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_eggs_allergy_allergic_to_something_but_not_eggs()
     {
         var sut = new Allergies(2);
         Assert.False(sut.IsAllergicTo(Allergen.Eggs));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_eggs_allergy_allergic_to_everything()
     {
         var sut = new Allergies(255);
         Assert.True(sut.IsAllergicTo(Allergen.Eggs));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_peanuts_allergy_not_allergic_to_anything()
     {
         var sut = new Allergies(0);
         Assert.False(sut.IsAllergicTo(Allergen.Peanuts));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_peanuts_allergy_allergic_only_to_peanuts()
     {
         var sut = new Allergies(2);
         Assert.True(sut.IsAllergicTo(Allergen.Peanuts));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_peanuts_allergy_allergic_to_peanuts_and_something_else()
     {
         var sut = new Allergies(7);
         Assert.True(sut.IsAllergicTo(Allergen.Peanuts));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_peanuts_allergy_allergic_to_something_but_not_peanuts()
     {
         var sut = new Allergies(5);
         Assert.False(sut.IsAllergicTo(Allergen.Peanuts));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_peanuts_allergy_allergic_to_everything()
     {
         var sut = new Allergies(255);
         Assert.True(sut.IsAllergicTo(Allergen.Peanuts));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_shellfish_allergy_not_allergic_to_anything()
     {
         var sut = new Allergies(0);
         Assert.False(sut.IsAllergicTo(Allergen.Shellfish));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_shellfish_allergy_allergic_only_to_shellfish()
     {
         var sut = new Allergies(4);
         Assert.True(sut.IsAllergicTo(Allergen.Shellfish));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_shellfish_allergy_allergic_to_shellfish_and_something_else()
     {
         var sut = new Allergies(14);
         Assert.True(sut.IsAllergicTo(Allergen.Shellfish));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_shellfish_allergy_allergic_to_something_but_not_shellfish()
     {
         var sut = new Allergies(10);
         Assert.False(sut.IsAllergicTo(Allergen.Shellfish));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_shellfish_allergy_allergic_to_everything()
     {
         var sut = new Allergies(255);
         Assert.True(sut.IsAllergicTo(Allergen.Shellfish));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_strawberries_allergy_not_allergic_to_anything()
     {
         var sut = new Allergies(0);
         Assert.False(sut.IsAllergicTo(Allergen.Strawberries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_strawberries_allergy_allergic_only_to_strawberries()
     {
         var sut = new Allergies(8);
         Assert.True(sut.IsAllergicTo(Allergen.Strawberries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_strawberries_allergy_allergic_to_strawberries_and_something_else()
     {
         var sut = new Allergies(28);
         Assert.True(sut.IsAllergicTo(Allergen.Strawberries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_strawberries_allergy_allergic_to_something_but_not_strawberries()
     {
         var sut = new Allergies(20);
         Assert.False(sut.IsAllergicTo(Allergen.Strawberries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_strawberries_allergy_allergic_to_everything()
     {
         var sut = new Allergies(255);
         Assert.True(sut.IsAllergicTo(Allergen.Strawberries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_tomatoes_allergy_not_allergic_to_anything()
     {
         var sut = new Allergies(0);
         Assert.False(sut.IsAllergicTo(Allergen.Tomatoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_tomatoes_allergy_allergic_only_to_tomatoes()
     {
         var sut = new Allergies(16);
         Assert.True(sut.IsAllergicTo(Allergen.Tomatoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_tomatoes_allergy_allergic_to_tomatoes_and_something_else()
     {
         var sut = new Allergies(56);
         Assert.True(sut.IsAllergicTo(Allergen.Tomatoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_tomatoes_allergy_allergic_to_something_but_not_tomatoes()
     {
         var sut = new Allergies(40);
         Assert.False(sut.IsAllergicTo(Allergen.Tomatoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_tomatoes_allergy_allergic_to_everything()
     {
         var sut = new Allergies(255);
         Assert.True(sut.IsAllergicTo(Allergen.Tomatoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_chocolate_allergy_not_allergic_to_anything()
     {
         var sut = new Allergies(0);
         Assert.False(sut.IsAllergicTo(Allergen.Chocolate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_chocolate_allergy_allergic_only_to_chocolate()
     {
         var sut = new Allergies(32);
         Assert.True(sut.IsAllergicTo(Allergen.Chocolate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_chocolate_allergy_allergic_to_chocolate_and_something_else()
     {
         var sut = new Allergies(112);
         Assert.True(sut.IsAllergicTo(Allergen.Chocolate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_chocolate_allergy_allergic_to_something_but_not_chocolate()
     {
         var sut = new Allergies(80);
         Assert.False(sut.IsAllergicTo(Allergen.Chocolate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_chocolate_allergy_allergic_to_everything()
     {
         var sut = new Allergies(255);
         Assert.True(sut.IsAllergicTo(Allergen.Chocolate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_pollen_allergy_not_allergic_to_anything()
     {
         var sut = new Allergies(0);
         Assert.False(sut.IsAllergicTo(Allergen.Pollen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_pollen_allergy_allergic_only_to_pollen()
     {
         var sut = new Allergies(64);
         Assert.True(sut.IsAllergicTo(Allergen.Pollen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_pollen_allergy_allergic_to_pollen_and_something_else()
     {
         var sut = new Allergies(224);
         Assert.True(sut.IsAllergicTo(Allergen.Pollen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_pollen_allergy_allergic_to_something_but_not_pollen()
     {
         var sut = new Allergies(160);
         Assert.False(sut.IsAllergicTo(Allergen.Pollen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_pollen_allergy_allergic_to_everything()
     {
         var sut = new Allergies(255);
         Assert.True(sut.IsAllergicTo(Allergen.Pollen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_cats_allergy_not_allergic_to_anything()
     {
         var sut = new Allergies(0);
         Assert.False(sut.IsAllergicTo(Allergen.Cats));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_cats_allergy_allergic_only_to_cats()
     {
         var sut = new Allergies(128);
         Assert.True(sut.IsAllergicTo(Allergen.Cats));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_cats_allergy_allergic_to_cats_and_something_else()
     {
         var sut = new Allergies(192);
         Assert.True(sut.IsAllergicTo(Allergen.Cats));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_cats_allergy_allergic_to_something_but_not_cats()
     {
         var sut = new Allergies(64);
         Assert.False(sut.IsAllergicTo(Allergen.Cats));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Testing_for_cats_allergy_allergic_to_everything()
     {
         var sut = new Allergies(255);
         Assert.True(sut.IsAllergicTo(Allergen.Cats));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_allergies()
     {
         var sut = new Allergies(0);
         Assert.Empty(sut.List());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_eggs()
     {
         var sut = new Allergies(1);
@@ -299,7 +299,7 @@ public class AllergiesTests
         Assert.Equal(expected, sut.List());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_peanuts()
     {
         var sut = new Allergies(2);
@@ -307,7 +307,7 @@ public class AllergiesTests
         Assert.Equal(expected, sut.List());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_strawberries()
     {
         var sut = new Allergies(8);
@@ -315,7 +315,7 @@ public class AllergiesTests
         Assert.Equal(expected, sut.List());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Eggs_and_peanuts()
     {
         var sut = new Allergies(3);
@@ -323,7 +323,7 @@ public class AllergiesTests
         Assert.Equal(expected, sut.List());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void More_than_eggs_but_not_peanuts()
     {
         var sut = new Allergies(5);
@@ -331,7 +331,7 @@ public class AllergiesTests
         Assert.Equal(expected, sut.List());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Lots_of_stuff()
     {
         var sut = new Allergies(248);
@@ -339,7 +339,7 @@ public class AllergiesTests
         Assert.Equal(expected, sut.List());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Everything()
     {
         var sut = new Allergies(255);
@@ -347,7 +347,7 @@ public class AllergiesTests
         Assert.Equal(expected, sut.List());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_allergen_score_parts()
     {
         var sut = new Allergies(509);

--- a/exercises/alphametics/AlphameticsTests.cs
+++ b/exercises/alphametics/AlphameticsTests.cs
@@ -19,19 +19,19 @@ public class AlphameticsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Solution_must_have_unique_value_for_each_letter()
     {
         Assert.Throws<ArgumentException>(() => Alphametics.Solve("A == B"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Leading_zero_solution_is_invalid()
     {
         Assert.Throws<ArgumentException>(() => Alphametics.Solve("ACA + DD == BD"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Puzzle_with_two_digits_final_carry()
     {
         var actual = Alphametics.Solve("A + A + A + A + A + A + A + A + A + A + A + B == BCC");
@@ -44,7 +44,7 @@ public class AlphameticsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Puzzle_with_four_letters()
     {
         var actual = Alphametics.Solve("AS + A == MOM");
@@ -58,7 +58,7 @@ public class AlphameticsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Puzzle_with_six_letters()
     {
         var actual = Alphametics.Solve("NO + NO + TOO == LATE");
@@ -74,7 +74,7 @@ public class AlphameticsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Puzzle_with_seven_letters()
     {
         var actual = Alphametics.Solve("HE + SEES + THE == LIGHT");
@@ -91,7 +91,7 @@ public class AlphameticsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Puzzle_with_eight_letters()
     {
         var actual = Alphametics.Solve("SEND + MORE == MONEY");
@@ -109,7 +109,7 @@ public class AlphameticsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Puzzle_with_ten_letters()
     {
         var actual = Alphametics.Solve("AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE");
@@ -129,7 +129,7 @@ public class AlphameticsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Puzzle_with_ten_letters_and_199_addends()
     {
         var actual = Alphametics.Solve("THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES");

--- a/exercises/anagram/AnagramTests.cs
+++ b/exercises/anagram/AnagramTests.cs
@@ -12,7 +12,7 @@ public class AnagramTests
         Assert.Empty(sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Detects_two_anagrams()
     {
         var candidates = new[] { "stream", "pigeon", "maters" };
@@ -21,7 +21,7 @@ public class AnagramTests
         Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Does_not_detect_anagram_subsets()
     {
         var candidates = new[] { "dog", "goody" };
@@ -29,7 +29,7 @@ public class AnagramTests
         Assert.Empty(sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Detects_anagram()
     {
         var candidates = new[] { "enlists", "google", "inlets", "banana" };
@@ -38,7 +38,7 @@ public class AnagramTests
         Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Detects_three_anagrams()
     {
         var candidates = new[] { "gallery", "ballerina", "regally", "clergy", "largely", "leading" };
@@ -47,7 +47,7 @@ public class AnagramTests
         Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Detects_multiple_anagrams_with_different_case()
     {
         var candidates = new[] { "Eons", "ONES" };
@@ -56,7 +56,7 @@ public class AnagramTests
         Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Does_not_detect_non_anagrams_with_identical_checksum()
     {
         var candidates = new[] { "last" };
@@ -64,7 +64,7 @@ public class AnagramTests
         Assert.Empty(sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Detects_anagrams_case_insensitively()
     {
         var candidates = new[] { "cashregister", "Carthorse", "radishes" };
@@ -73,7 +73,7 @@ public class AnagramTests
         Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Detects_anagrams_using_case_insensitive_subject()
     {
         var candidates = new[] { "cashregister", "carthorse", "radishes" };
@@ -82,7 +82,7 @@ public class AnagramTests
         Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Detects_anagrams_using_case_insensitive_possible_matches()
     {
         var candidates = new[] { "cashregister", "Carthorse", "radishes" };
@@ -91,7 +91,7 @@ public class AnagramTests
         Assert.Equal(expected, sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Does_not_detect_an_anagram_if_the_original_word_is_repeated()
     {
         var candidates = new[] { "go Go GO" };
@@ -99,7 +99,7 @@ public class AnagramTests
         Assert.Empty(sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Anagrams_must_use_all_letters_exactly_once()
     {
         var candidates = new[] { "patter" };
@@ -107,7 +107,7 @@ public class AnagramTests
         Assert.Empty(sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Words_are_not_anagrams_of_themselves_case_insensitive_()
     {
         var candidates = new[] { "BANANA", "Banana", "banana" };
@@ -115,7 +115,7 @@ public class AnagramTests
         Assert.Empty(sut.FindAnagrams(candidates));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Words_other_than_themselves_can_be_anagrams()
     {
         var candidates = new[] { "Listen", "Silent", "LISTEN" };

--- a/exercises/armstrong-numbers/ArmstrongNumbersTests.cs
+++ b/exercises/armstrong-numbers/ArmstrongNumbersTests.cs
@@ -10,49 +10,49 @@ public class ArmstrongNumbersTests
         Assert.True(ArmstrongNumbers.IsArmstrongNumber(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_digit_numbers_are_armstrong_numbers()
     {
         Assert.True(ArmstrongNumbers.IsArmstrongNumber(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void There_are_no_2_digit_armstrong_numbers()
     {
         Assert.False(ArmstrongNumbers.IsArmstrongNumber(10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_digit_number_that_is_an_armstrong_number()
     {
         Assert.True(ArmstrongNumbers.IsArmstrongNumber(153));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_digit_number_that_is_not_an_armstrong_number()
     {
         Assert.False(ArmstrongNumbers.IsArmstrongNumber(100));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_digit_number_that_is_an_armstrong_number()
     {
         Assert.True(ArmstrongNumbers.IsArmstrongNumber(9474));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_digit_number_that_is_not_an_armstrong_number()
     {
         Assert.False(ArmstrongNumbers.IsArmstrongNumber(9475));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Seven_digit_number_that_is_an_armstrong_number()
     {
         Assert.True(ArmstrongNumbers.IsArmstrongNumber(9926315));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Seven_digit_number_that_is_not_an_armstrong_number()
     {
         Assert.False(ArmstrongNumbers.IsArmstrongNumber(9926314));

--- a/exercises/atbash-cipher/AtbashCipherTests.cs
+++ b/exercises/atbash-cipher/AtbashCipherTests.cs
@@ -10,79 +10,79 @@ public class AtbashCipherTests
         Assert.Equal("bvh", AtbashCipher.Encode("yes"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_no()
     {
         Assert.Equal("ml", AtbashCipher.Encode("no"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_omg()
     {
         Assert.Equal("lnt", AtbashCipher.Encode("OMG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_spaces()
     {
         Assert.Equal("lnt", AtbashCipher.Encode("O M G"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_mindblowingly()
     {
         Assert.Equal("nrmwy oldrm tob", AtbashCipher.Encode("mindblowingly"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_numbers()
     {
         Assert.Equal("gvhgr mt123 gvhgr mt", AtbashCipher.Encode("Testing,1 2 3, testing."));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_deep_thought()
     {
         Assert.Equal("gifgs rhurx grlm", AtbashCipher.Encode("Truth is fiction."));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_all_the_letters()
     {
         Assert.Equal("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt", AtbashCipher.Encode("The quick brown fox jumps over the lazy dog."));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_exercism()
     {
         Assert.Equal("exercism", AtbashCipher.Decode("vcvix rhn"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_a_sentence()
     {
         Assert.Equal("anobstacleisoftenasteppingstone", AtbashCipher.Decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_numbers()
     {
         Assert.Equal("testing123testing", AtbashCipher.Decode("gvhgr mt123 gvhgr mt"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_all_the_letters()
     {
         Assert.Equal("thequickbrownfoxjumpsoverthelazydog", AtbashCipher.Decode("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_with_too_many_spaces()
     {
         Assert.Equal("exercism", AtbashCipher.Decode("vc vix    r hn"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_with_no_spaces()
     {
         Assert.Equal("anobstacleisoftenasteppingstone", AtbashCipher.Decode("zmlyhgzxovrhlugvmzhgvkkrmthglmv"));

--- a/exercises/bank-account/BankAccountTests.cs
+++ b/exercises/bank-account/BankAccountTests.cs
@@ -14,7 +14,7 @@ public class BankAccountTests
         Assert.Equal(0, account.Balance);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Check_basic_balance()
     {
         var account = new BankAccount();
@@ -29,7 +29,7 @@ public class BankAccountTests
         Assert.Equal(10, updatedBalance);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Balance_can_increment_and_decrement()
     {
         var account = new BankAccount();
@@ -47,7 +47,7 @@ public class BankAccountTests
         Assert.Equal(-5, subtractedBalance);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Closed_account_throws_exception_when_checking_balance()
     {
         var account = new BankAccount();
@@ -57,7 +57,7 @@ public class BankAccountTests
         Assert.Throws<InvalidOperationException>(() => account.Balance);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Change_account_balance_from_multiple_threads()
     {
         var account = new BankAccount();

--- a/exercises/beer-song/BeerSongTests.cs
+++ b/exercises/beer-song/BeerSongTests.cs
@@ -13,7 +13,7 @@ public class BeerSongTests
         Assert.Equal(expected, BeerSong.Recite(99, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_generic_verse()
     {
         var expected = 
@@ -22,7 +22,7 @@ public class BeerSongTests
         Assert.Equal(expected, BeerSong.Recite(3, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_with_2_bottles()
     {
         var expected = 
@@ -31,7 +31,7 @@ public class BeerSongTests
         Assert.Equal(expected, BeerSong.Recite(2, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_with_1_bottle()
     {
         var expected = 
@@ -40,7 +40,7 @@ public class BeerSongTests
         Assert.Equal(expected, BeerSong.Recite(1, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_with_0_bottles()
     {
         var expected = 
@@ -49,7 +49,7 @@ public class BeerSongTests
         Assert.Equal(expected, BeerSong.Recite(0, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_two_verses()
     {
         var expected = 
@@ -61,7 +61,7 @@ public class BeerSongTests
         Assert.Equal(expected, BeerSong.Recite(99, 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_three_verses()
     {
         var expected = 
@@ -76,7 +76,7 @@ public class BeerSongTests
         Assert.Equal(expected, BeerSong.Recite(2, 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_verses()
     {
         var expected = 

--- a/exercises/binary-search-tree/BinarySearchTreeTests.cs
+++ b/exercises/binary-search-tree/BinarySearchTreeTests.cs
@@ -12,7 +12,7 @@ public class BinarySearchTreeTests
         Assert.Equal(4, tree.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Smaller_number_at_left_node()
     {
         var tree = new BinarySearchTree(new[] { 4, 2 });
@@ -20,7 +20,7 @@ public class BinarySearchTreeTests
         Assert.Equal(2, tree.Left.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Same_number_at_left_node()
     {
         var tree = new BinarySearchTree(new[] { 4, 4 });
@@ -28,7 +28,7 @@ public class BinarySearchTreeTests
         Assert.Equal(4, tree.Left.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Greater_number_at_right_node()
     {
         var tree = new BinarySearchTree(new[] { 4, 5 });
@@ -36,7 +36,7 @@ public class BinarySearchTreeTests
         Assert.Equal(5, tree.Right.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_create_complex_tree()
     {
         var tree = new BinarySearchTree(new[] { 4, 2, 6, 1, 3, 5, 7 });
@@ -49,35 +49,35 @@ public class BinarySearchTreeTests
         Assert.Equal(7, tree.Right.Right.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_sort_single_number()
     {
         var tree = new BinarySearchTree(2);
         Assert.Equal(new[] { 2 }, tree.AsEnumerable());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_sort_if_second_number_is_smaller_than_first()
     {
         var tree = new BinarySearchTree(new[] { 2, 1 });
         Assert.Equal(new[] { 1, 2 }, tree.AsEnumerable());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_sort_if_second_number_is_same_as_first()
     {
         var tree = new BinarySearchTree(new[] { 2, 2 });
         Assert.Equal(new[] { 2, 2 }, tree.AsEnumerable());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_sort_if_second_number_is_greater_than_first()
     {
         var tree = new BinarySearchTree(new[] { 2, 3 });
         Assert.Equal(new[] { 2, 3 }, tree.AsEnumerable());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_sort_complex_tree()
     {
         var tree = new BinarySearchTree(new[] { 2, 1, 3, 6, 7, 5 });

--- a/exercises/binary-search/BinarySearchTests.cs
+++ b/exercises/binary-search/BinarySearchTests.cs
@@ -13,7 +13,7 @@ public class BinarySearchTests
         Assert.Equal(0, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Finds_a_value_in_the_middle_of_an_array()
     {
         var array = new[] { 1, 3, 4, 6, 8, 9, 11 };
@@ -21,7 +21,7 @@ public class BinarySearchTests
         Assert.Equal(3, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Finds_a_value_at_the_beginning_of_an_array()
     {
         var array = new[] { 1, 3, 4, 6, 8, 9, 11 };
@@ -29,7 +29,7 @@ public class BinarySearchTests
         Assert.Equal(0, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Finds_a_value_at_the_end_of_an_array()
     {
         var array = new[] { 1, 3, 4, 6, 8, 9, 11 };
@@ -37,7 +37,7 @@ public class BinarySearchTests
         Assert.Equal(6, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Finds_a_value_in_an_array_of_odd_length()
     {
         var array = new[] { 1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634 };
@@ -45,7 +45,7 @@ public class BinarySearchTests
         Assert.Equal(9, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Finds_a_value_in_an_array_of_even_length()
     {
         var array = new[] { 1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377 };
@@ -53,7 +53,7 @@ public class BinarySearchTests
         Assert.Equal(5, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Identifies_that_a_value_is_not_included_in_the_array()
     {
         var array = new[] { 1, 3, 4, 6, 8, 9, 11 };
@@ -61,7 +61,7 @@ public class BinarySearchTests
         Assert.Equal(-1, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_value_smaller_than_the_arrays_smallest_value_is_not_found()
     {
         var array = new[] { 1, 3, 4, 6, 8, 9, 11 };
@@ -69,7 +69,7 @@ public class BinarySearchTests
         Assert.Equal(-1, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_value_larger_than_the_arrays_largest_value_is_not_found()
     {
         var array = new[] { 1, 3, 4, 6, 8, 9, 11 };
@@ -77,7 +77,7 @@ public class BinarySearchTests
         Assert.Equal(-1, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Nothing_is_found_in_an_empty_array()
     {
         var array = Array.Empty<int>();
@@ -85,7 +85,7 @@ public class BinarySearchTests
         Assert.Equal(-1, BinarySearch.Find(array, value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Nothing_is_found_when_the_left_and_right_bounds_cross()
     {
         var array = new[] { 1, 2 };

--- a/exercises/binary/BinaryTests.cs
+++ b/exercises/binary/BinaryTests.cs
@@ -8,85 +8,85 @@ public class BinaryTest
         Assert.Equal(0, Binary.ToDecimal("0"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_1_is_decimal_1()
     {
         Assert.Equal(1, Binary.ToDecimal("1"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_10_is_decimal_2()
     {
         Assert.Equal(2, Binary.ToDecimal("10"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_11_is_decimal_3()
     {
         Assert.Equal(3, Binary.ToDecimal("11"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_100_is_decimal_4()
     {
         Assert.Equal(4, Binary.ToDecimal("100"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_1001_is_decimal_9()
     {
         Assert.Equal(9, Binary.ToDecimal("1001"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_11010_is_decimal_26()
     {
         Assert.Equal(26, Binary.ToDecimal("11010"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_10001101000_is_decimal_1128()
     {
         Assert.Equal(1128, Binary.ToDecimal("10001101000"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_ignores_leading_zeros()
     {
         Assert.Equal(31, Binary.ToDecimal("000011111"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_binary_2_converts_to_decimal_0()
     {
         Assert.Equal(0, Binary.ToDecimal("2"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_number_containing_a_non_binary_digit_is_invalid()
     {
         Assert.Equal(0, Binary.ToDecimal("01201"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_number_with_trailing_non_binary_characters_is_invalid()
     {
         Assert.Equal(0, Binary.ToDecimal("10nope"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_number_with_leading_non_binary_characters_is_invalid()
     {
         Assert.Equal(0, Binary.ToDecimal("nope10"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_number_with_internal_non_binary_characters_is_invalid()
     {
         Assert.Equal(0, Binary.ToDecimal("10nope10"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_number_and_a_word_whitespace_separated_is_invalid()
     {
         Assert.Equal(0, Binary.ToDecimal("001 nope"));

--- a/exercises/bob/BobTests.cs
+++ b/exercises/bob/BobTests.cs
@@ -10,145 +10,145 @@ public class BobTests
         Assert.Equal("Whatever.", Bob.Response("Tom-ay-to, tom-aaaah-to."));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Shouting()
     {
         Assert.Equal("Whoa, chill out!", Bob.Response("WATCH OUT!"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Shouting_gibberish()
     {
         Assert.Equal("Whoa, chill out!", Bob.Response("FCECDFCAAB"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Asking_a_question()
     {
         Assert.Equal("Sure.", Bob.Response("Does this cryogenic chamber make me look fat?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Asking_a_numeric_question()
     {
         Assert.Equal("Sure.", Bob.Response("You are, what, like 15?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Asking_gibberish()
     {
         Assert.Equal("Sure.", Bob.Response("fffbbcbeab?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Talking_forcefully()
     {
         Assert.Equal("Whatever.", Bob.Response("Hi there!"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Using_acronyms_in_regular_speech()
     {
         Assert.Equal("Whatever.", Bob.Response("It's OK if you don't want to go work for NASA."));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Forceful_question()
     {
         Assert.Equal("Calm down, I know what I'm doing!", Bob.Response("WHAT'S GOING ON?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Shouting_numbers()
     {
         Assert.Equal("Whoa, chill out!", Bob.Response("1, 2, 3 GO!"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_letters()
     {
         Assert.Equal("Whatever.", Bob.Response("1, 2, 3"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Question_with_no_letters()
     {
         Assert.Equal("Sure.", Bob.Response("4?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Shouting_with_special_characters()
     {
         Assert.Equal("Whoa, chill out!", Bob.Response("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Shouting_with_no_exclamation_mark()
     {
         Assert.Equal("Whoa, chill out!", Bob.Response("I HATE THE DENTIST"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Statement_containing_question_mark()
     {
         Assert.Equal("Whatever.", Bob.Response("Ending with ? means a question."));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Non_letters_with_question()
     {
         Assert.Equal("Sure.", Bob.Response(":) ?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Prattling_on()
     {
         Assert.Equal("Sure.", Bob.Response("Wait! Hang on. Are you going to be OK?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Silence()
     {
         Assert.Equal("Fine. Be that way!", Bob.Response(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Prolonged_silence()
     {
         Assert.Equal("Fine. Be that way!", Bob.Response("          "));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Alternate_silence()
     {
         Assert.Equal("Fine. Be that way!", Bob.Response("\t\t\t\t\t\t\t\t\t\t"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_line_question()
     {
         Assert.Equal("Whatever.", Bob.Response("\nDoes this cryogenic chamber make me look fat?\nNo."));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Starting_with_whitespace()
     {
         Assert.Equal("Whatever.", Bob.Response("         hmmmmmmm..."));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ending_with_whitespace()
     {
         Assert.Equal("Sure.", Bob.Response("Okay if like my  spacebar  quite a bit?   "));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Other_whitespace()
     {
         Assert.Equal("Fine. Be that way!", Bob.Response("\n\r \t"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Non_question_ending_with_whitespace()
     {
         Assert.Equal("Whatever.", Bob.Response("This is a statement ending with whitespace      "));

--- a/exercises/book-store/BookStoreTests.cs
+++ b/exercises/book-store/BookStoreTests.cs
@@ -12,98 +12,98 @@ public class BookStoreTests
         Assert.Equal(8m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_of_the_same_book()
     {
         var basket = new[] { 2, 2 };
         Assert.Equal(16m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_basket()
     {
         var basket = Array.Empty<int>();
         Assert.Equal(0m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_different_books()
     {
         var basket = new[] { 1, 2 };
         Assert.Equal(15.2m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_different_books()
     {
         var basket = new[] { 1, 2, 3 };
         Assert.Equal(21.6m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_different_books()
     {
         var basket = new[] { 1, 2, 3, 4 };
         Assert.Equal(25.6m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Five_different_books()
     {
         var basket = new[] { 1, 2, 3, 4, 5 };
         Assert.Equal(30m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_groups_of_four_is_cheaper_than_group_of_five_plus_group_of_three()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 5 };
         Assert.Equal(51.2m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_groups_of_four_is_cheaper_than_groups_of_five_and_three()
     {
         var basket = new[] { 1, 1, 2, 3, 4, 4, 5, 5 };
         Assert.Equal(51.2m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Group_of_four_plus_group_of_two_is_cheaper_than_two_groups_of_three()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 4 };
         Assert.Equal(40.8m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_each_of_first_4_books_and_1_copy_each_of_rest()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5 };
         Assert.Equal(55.6m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_copies_of_each_book()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5, 5 };
         Assert.Equal(60m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_copies_of_first_book_and_2_each_of_remaining()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1 };
         Assert.Equal(68m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_each_of_first_2_books_and_2_each_of_remaining_books()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2 };
         Assert.Equal(75.2m, BookStore.Total(basket));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_groups_of_four_are_cheaper_than_two_groups_each_of_five_and_three()
     {
         var basket = new[] { 1, 1, 2, 2, 3, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 5 };

--- a/exercises/bowling/BowlingTests.cs
+++ b/exercises/bowling/BowlingTests.cs
@@ -16,7 +16,7 @@ public class BowlingTests
         Assert.Equal(0, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_be_able_to_score_a_game_with_no_strikes_or_spares()
     {
         var sut = new BowlingGame();
@@ -26,7 +26,7 @@ public class BowlingTests
         Assert.Equal(90, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_spare_followed_by_zeros_is_worth_ten_points()
     {
         var sut = new BowlingGame();
@@ -36,7 +36,7 @@ public class BowlingTests
         Assert.Equal(10, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Points_scored_in_the_roll_after_a_spare_are_counted_twice()
     {
         var sut = new BowlingGame();
@@ -46,7 +46,7 @@ public class BowlingTests
         Assert.Equal(16, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Consecutive_spares_each_get_a_one_roll_bonus()
     {
         var sut = new BowlingGame();
@@ -56,7 +56,7 @@ public class BowlingTests
         Assert.Equal(31, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_spare_in_the_last_frame_gets_a_one_roll_bonus_that_is_counted_once()
     {
         var sut = new BowlingGame();
@@ -66,7 +66,7 @@ public class BowlingTests
         Assert.Equal(17, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_strike_earns_ten_points_in_a_frame_with_a_single_roll()
     {
         var sut = new BowlingGame();
@@ -76,7 +76,7 @@ public class BowlingTests
         Assert.Equal(10, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Points_scored_in_the_two_rolls_after_a_strike_are_counted_twice_as_a_bonus()
     {
         var sut = new BowlingGame();
@@ -86,7 +86,7 @@ public class BowlingTests
         Assert.Equal(26, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Consecutive_strikes_each_get_the_two_roll_bonus()
     {
         var sut = new BowlingGame();
@@ -96,7 +96,7 @@ public class BowlingTests
         Assert.Equal(81, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_strike_in_the_last_frame_gets_a_two_roll_bonus_that_is_counted_once()
     {
         var sut = new BowlingGame();
@@ -106,7 +106,7 @@ public class BowlingTests
         Assert.Equal(18, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rolling_a_spare_with_the_two_roll_bonus_does_not_get_a_bonus_roll()
     {
         var sut = new BowlingGame();
@@ -116,7 +116,7 @@ public class BowlingTests
         Assert.Equal(20, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Strikes_with_the_two_roll_bonus_do_not_get_bonus_rolls()
     {
         var sut = new BowlingGame();
@@ -126,7 +126,7 @@ public class BowlingTests
         Assert.Equal(30, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_strike_with_the_one_roll_bonus_after_a_spare_in_the_last_frame_does_not_get_a_bonus()
     {
         var sut = new BowlingGame();
@@ -136,7 +136,7 @@ public class BowlingTests
         Assert.Equal(20, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_strikes_is_a_perfect_game()
     {
         var sut = new BowlingGame();
@@ -146,7 +146,7 @@ public class BowlingTests
         Assert.Equal(300, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rolls_cannot_score_negative_points()
     {
         var sut = new BowlingGame();
@@ -155,7 +155,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(-1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_roll_cannot_score_more_than_10_points()
     {
         var sut = new BowlingGame();
@@ -164,7 +164,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(11));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_rolls_in_a_frame_cannot_score_more_than_10_points()
     {
         var sut = new BowlingGame();
@@ -173,7 +173,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Bonus_roll_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points()
     {
         var sut = new BowlingGame();
@@ -182,7 +182,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(11));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_bonus_rolls_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points()
     {
         var sut = new BowlingGame();
@@ -191,7 +191,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_bonus_rolls_after_a_strike_in_the_last_frame_can_score_more_than_10_points_if_one_is_a_strike()
     {
         var sut = new BowlingGame();
@@ -201,7 +201,7 @@ public class BowlingTests
         Assert.Equal(26, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_second_bonus_rolls_after_a_strike_in_the_last_frame_cannot_be_a_strike_if_the_first_one_is_not_a_strike()
     {
         var sut = new BowlingGame();
@@ -210,7 +210,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_bonus_roll_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points()
     {
         var sut = new BowlingGame();
@@ -219,7 +219,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(11));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void An_unstarted_game_cannot_be_scored()
     {
         var sut = new BowlingGame();
@@ -228,7 +228,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Score());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void An_incomplete_game_cannot_be_scored()
     {
         var sut = new BowlingGame();
@@ -237,7 +237,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Score());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cannot_roll_if_game_already_has_ten_frames()
     {
         var sut = new BowlingGame();
@@ -246,7 +246,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated()
     {
         var sut = new BowlingGame();
@@ -255,7 +255,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Score());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated()
     {
         var sut = new BowlingGame();
@@ -264,7 +264,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Score());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Bonus_roll_for_a_spare_in_the_last_frame_must_be_rolled_before_score_can_be_calculated()
     {
         var sut = new BowlingGame();
@@ -273,7 +273,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Score());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cannot_roll_after_bonus_roll_for_spare()
     {
         var sut = new BowlingGame();
@@ -282,7 +282,7 @@ public class BowlingTests
         Assert.Throws<ArgumentException>(() => sut.Roll(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cannot_roll_after_bonus_rolls_for_strike()
     {
         var sut = new BowlingGame();

--- a/exercises/change/ChangeTests.cs
+++ b/exercises/change/ChangeTests.cs
@@ -14,7 +14,7 @@ public class ChangeTests
         Assert.Equal(expected, Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_coin_change()
     {
         var coins = new[] { 1, 5, 10, 25, 100 };
@@ -23,7 +23,7 @@ public class ChangeTests
         Assert.Equal(expected, Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Change_with_lilliputian_coins()
     {
         var coins = new[] { 1, 4, 15, 20, 50 };
@@ -32,7 +32,7 @@ public class ChangeTests
         Assert.Equal(expected, Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Change_with_lower_elbonia_coins()
     {
         var coins = new[] { 1, 5, 10, 21, 25 };
@@ -41,7 +41,7 @@ public class ChangeTests
         Assert.Equal(expected, Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Large_target_values()
     {
         var coins = new[] { 1, 2, 5, 10, 20, 50, 100 };
@@ -50,7 +50,7 @@ public class ChangeTests
         Assert.Equal(expected, Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Possible_change_without_unit_coins_available()
     {
         var coins = new[] { 2, 5, 10, 20, 50 };
@@ -59,7 +59,7 @@ public class ChangeTests
         Assert.Equal(expected, Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Another_possible_change_without_unit_coins_available()
     {
         var coins = new[] { 4, 5 };
@@ -68,7 +68,7 @@ public class ChangeTests
         Assert.Equal(expected, Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_coins_make_0_change()
     {
         var coins = new[] { 1, 5, 10, 21, 25 };
@@ -76,7 +76,7 @@ public class ChangeTests
         Assert.Empty(Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Error_testing_for_change_smaller_than_the_smallest_of_coins()
     {
         var coins = new[] { 5, 10 };
@@ -84,7 +84,7 @@ public class ChangeTests
         Assert.Throws<ArgumentException>(() => Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Error_if_no_combination_can_add_up_to_target()
     {
         var coins = new[] { 5, 10 };
@@ -92,7 +92,7 @@ public class ChangeTests
         Assert.Throws<ArgumentException>(() => Change.FindFewestCoins(coins, target));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cannot_find_negative_change_values()
     {
         var coins = new[] { 1, 2, 5 };

--- a/exercises/circular-buffer/CircularBufferTests.cs
+++ b/exercises/circular-buffer/CircularBufferTests.cs
@@ -12,7 +12,7 @@ public class CircularBufferTests
         Assert.Throws<InvalidOperationException>(() => buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_read_an_item_just_written()
     {
         var buffer = new CircularBuffer<int>(capacity: 1);
@@ -20,7 +20,7 @@ public class CircularBufferTests
         Assert.Equal(1, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Each_item_may_only_be_read_once()
     {
         var buffer = new CircularBuffer<int>(capacity: 1);
@@ -29,7 +29,7 @@ public class CircularBufferTests
         Assert.Throws<InvalidOperationException>(() => buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Items_are_read_in_the_order_they_are_written()
     {
         var buffer = new CircularBuffer<int>(capacity: 2);
@@ -39,7 +39,7 @@ public class CircularBufferTests
         Assert.Equal(2, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_buffer_cant_be_written_to()
     {
         var buffer = new CircularBuffer<int>(capacity: 1);
@@ -47,7 +47,7 @@ public class CircularBufferTests
         Assert.Throws<InvalidOperationException>(() => buffer.Write(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_read_frees_up_capacity_for_another_write()
     {
         var buffer = new CircularBuffer<int>(capacity: 1);
@@ -57,7 +57,7 @@ public class CircularBufferTests
         Assert.Equal(2, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Read_position_is_maintained_even_across_multiple_writes()
     {
         var buffer = new CircularBuffer<int>(capacity: 3);
@@ -69,7 +69,7 @@ public class CircularBufferTests
         Assert.Equal(3, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Items_cleared_out_of_buffer_cant_be_read()
     {
         var buffer = new CircularBuffer<int>(capacity: 1);
@@ -78,7 +78,7 @@ public class CircularBufferTests
         Assert.Throws<InvalidOperationException>(() => buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clear_frees_up_capacity_for_another_write()
     {
         var buffer = new CircularBuffer<int>(capacity: 1);
@@ -88,7 +88,7 @@ public class CircularBufferTests
         Assert.Equal(2, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clear_does_nothing_on_empty_buffer()
     {
         var buffer = new CircularBuffer<int>(capacity: 1);
@@ -97,7 +97,7 @@ public class CircularBufferTests
         Assert.Equal(1, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Overwrite_acts_like_write_on_non_full_buffer()
     {
         var buffer = new CircularBuffer<int>(capacity: 2);
@@ -107,7 +107,7 @@ public class CircularBufferTests
         Assert.Equal(2, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Overwrite_replaces_the_oldest_item_on_full_buffer()
     {
         var buffer = new CircularBuffer<int>(capacity: 2);
@@ -118,7 +118,7 @@ public class CircularBufferTests
         Assert.Equal(3, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Overwrite_replaces_the_oldest_item_remaining_in_buffer_following_a_read()
     {
         var buffer = new CircularBuffer<int>(capacity: 3);
@@ -133,7 +133,7 @@ public class CircularBufferTests
         Assert.Equal(5, buffer.Read());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Initial_clear_does_not_affect_wrapping_around()
     {
         var buffer = new CircularBuffer<int>(capacity: 2);

--- a/exercises/clock/ClockTests.cs
+++ b/exercises/clock/ClockTests.cs
@@ -11,364 +11,364 @@ public class ClockTests
         Assert.Equal("08:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Past_the_hour()
     {
         var sut = new Clock(11, 9);
         Assert.Equal("11:09", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Midnight_is_zero_hours()
     {
         var sut = new Clock(24, 0);
         Assert.Equal("00:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hour_rolls_over()
     {
         var sut = new Clock(25, 0);
         Assert.Equal("01:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hour_rolls_over_continuously()
     {
         var sut = new Clock(100, 0);
         Assert.Equal("04:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sixty_minutes_is_next_hour()
     {
         var sut = new Clock(1, 60);
         Assert.Equal("02:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Minutes_roll_over()
     {
         var sut = new Clock(0, 160);
         Assert.Equal("02:40", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Minutes_roll_over_continuously()
     {
         var sut = new Clock(0, 1723);
         Assert.Equal("04:43", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hour_and_minutes_roll_over()
     {
         var sut = new Clock(25, 160);
         Assert.Equal("03:40", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hour_and_minutes_roll_over_continuously()
     {
         var sut = new Clock(201, 3001);
         Assert.Equal("11:01", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hour_and_minutes_roll_over_to_exactly_midnight()
     {
         var sut = new Clock(72, 8640);
         Assert.Equal("00:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_hour()
     {
         var sut = new Clock(-1, 15);
         Assert.Equal("23:15", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_hour_rolls_over()
     {
         var sut = new Clock(-25, 0);
         Assert.Equal("23:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_hour_rolls_over_continuously()
     {
         var sut = new Clock(-91, 0);
         Assert.Equal("05:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_minutes()
     {
         var sut = new Clock(1, -40);
         Assert.Equal("00:20", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_minutes_roll_over()
     {
         var sut = new Clock(1, -160);
         Assert.Equal("22:20", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_minutes_roll_over_continuously()
     {
         var sut = new Clock(1, -4820);
         Assert.Equal("16:40", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_sixty_minutes_is_previous_hour()
     {
         var sut = new Clock(2, -60);
         Assert.Equal("01:00", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_hour_and_minutes_both_roll_over()
     {
         var sut = new Clock(-25, -160);
         Assert.Equal("20:20", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_hour_and_minutes_both_roll_over_continuously()
     {
         var sut = new Clock(-121, -5810);
         Assert.Equal("22:10", sut.ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_minutes()
     {
         var sut = new Clock(10, 0);
         Assert.Equal("10:03", sut.Add(3).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_no_minutes()
     {
         var sut = new Clock(6, 41);
         Assert.Equal("06:41", sut.Add(0).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_to_next_hour()
     {
         var sut = new Clock(0, 45);
         Assert.Equal("01:25", sut.Add(40).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_more_than_one_hour()
     {
         var sut = new Clock(10, 0);
         Assert.Equal("11:01", sut.Add(61).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_more_than_two_hours_with_carry()
     {
         var sut = new Clock(0, 45);
         Assert.Equal("03:25", sut.Add(160).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_across_midnight()
     {
         var sut = new Clock(23, 59);
         Assert.Equal("00:01", sut.Add(2).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_more_than_one_day_1500_min_25_hrs_()
     {
         var sut = new Clock(5, 32);
         Assert.Equal("06:32", sut.Add(1500).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_more_than_two_days()
     {
         var sut = new Clock(1, 1);
         Assert.Equal("11:21", sut.Add(3500).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_minutes()
     {
         var sut = new Clock(10, 3);
         Assert.Equal("10:00", sut.Subtract(3).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_to_previous_hour()
     {
         var sut = new Clock(10, 3);
         Assert.Equal("09:33", sut.Subtract(30).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_more_than_an_hour()
     {
         var sut = new Clock(10, 3);
         Assert.Equal("08:53", sut.Subtract(70).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_across_midnight()
     {
         var sut = new Clock(0, 3);
         Assert.Equal("23:59", sut.Subtract(4).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_more_than_two_hours()
     {
         var sut = new Clock(0, 0);
         Assert.Equal("21:20", sut.Subtract(160).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_more_than_two_hours_with_borrow()
     {
         var sut = new Clock(6, 15);
         Assert.Equal("03:35", sut.Subtract(160).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_more_than_one_day_1500_min_25_hrs_()
     {
         var sut = new Clock(5, 32);
         Assert.Equal("04:32", sut.Subtract(1500).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_more_than_two_days()
     {
         var sut = new Clock(2, 20);
         Assert.Equal("00:20", sut.Subtract(3000).ToString());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_same_time()
     {
         var sut = new Clock(15, 37);
         Assert.Equal(new Clock(15, 37), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_a_minute_apart()
     {
         var sut = new Clock(15, 37);
         Assert.NotEqual(new Clock(15, 36), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_an_hour_apart()
     {
         var sut = new Clock(15, 37);
         Assert.NotEqual(new Clock(14, 37), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_hour_overflow()
     {
         var sut = new Clock(34, 37);
         Assert.Equal(new Clock(10, 37), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_hour_overflow_by_several_days()
     {
         var sut = new Clock(99, 11);
         Assert.Equal(new Clock(3, 11), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_negative_hour()
     {
         var sut = new Clock(-2, 40);
         Assert.Equal(new Clock(22, 40), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_negative_hour_that_wraps()
     {
         var sut = new Clock(-31, 3);
         Assert.Equal(new Clock(17, 3), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_negative_hour_that_wraps_multiple_times()
     {
         var sut = new Clock(-83, 49);
         Assert.Equal(new Clock(13, 49), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_minute_overflow()
     {
         var sut = new Clock(0, 1441);
         Assert.Equal(new Clock(0, 1), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_minute_overflow_by_several_days()
     {
         var sut = new Clock(2, 4322);
         Assert.Equal(new Clock(2, 2), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_negative_minute()
     {
         var sut = new Clock(3, -20);
         Assert.Equal(new Clock(2, 40), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_negative_minute_that_wraps()
     {
         var sut = new Clock(5, -1490);
         Assert.Equal(new Clock(4, 10), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_negative_minute_that_wraps_multiple_times()
     {
         var sut = new Clock(6, -4305);
         Assert.Equal(new Clock(6, 15), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_negative_hours_and_minutes()
     {
         var sut = new Clock(-12, -268);
         Assert.Equal(new Clock(7, 32), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_with_negative_hours_and_minutes_that_wrap()
     {
         var sut = new Clock(-54, -11513);
         Assert.Equal(new Clock(18, 7), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_clock_and_zeroed_clock()
     {
         var sut = new Clock(0, 0);
         Assert.Equal(new Clock(24, 0), sut);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Clocks_are_immutable()
     {
         var sut = new Clock(0, 0);

--- a/exercises/collatz-conjecture/CollatzConjectureTests.cs
+++ b/exercises/collatz-conjecture/CollatzConjectureTests.cs
@@ -11,31 +11,31 @@ public class CollatzConjectureTests
         Assert.Equal(0, CollatzConjecture.Steps(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Divide_if_even()
     {
         Assert.Equal(4, CollatzConjecture.Steps(16));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Even_and_odd_steps()
     {
         Assert.Equal(9, CollatzConjecture.Steps(12));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Large_number_of_even_and_odd_steps()
     {
         Assert.Equal(152, CollatzConjecture.Steps(1000000));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Zero_is_an_error()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => CollatzConjecture.Steps(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_value_is_an_error()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => CollatzConjecture.Steps(-15));

--- a/exercises/complex-numbers/ComplexNumbersTests.cs
+++ b/exercises/complex-numbers/ComplexNumbersTests.cs
@@ -12,42 +12,42 @@ public class ComplexNumbersTests
         Assert.Equal(1, sut.Real());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Real_part_of_a_purely_imaginary_number()
     {
         var sut = new ComplexNumber(0, 1);
         Assert.Equal(0, sut.Real());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Real_part_of_a_number_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(1, 2);
         Assert.Equal(1, sut.Real());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Imaginary_part_of_a_purely_real_number()
     {
         var sut = new ComplexNumber(1, 0);
         Assert.Equal(0, sut.Imaginary());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Imaginary_part_of_a_purely_imaginary_number()
     {
         var sut = new ComplexNumber(0, 1);
         Assert.Equal(1, sut.Imaginary());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Imaginary_part_of_a_number_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(1, 2);
         Assert.Equal(2, sut.Imaginary());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Imaginary_unit()
     {
         var sut = new ComplexNumber(0, 1);
@@ -56,7 +56,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Mul(new ComplexNumber(0, 1)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_purely_real_numbers()
     {
         var sut = new ComplexNumber(1, 0);
@@ -65,7 +65,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Add(new ComplexNumber(2, 0)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_purely_imaginary_numbers()
     {
         var sut = new ComplexNumber(0, 1);
@@ -74,7 +74,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Add(new ComplexNumber(0, 2)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_numbers_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(1, 2);
@@ -83,7 +83,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Add(new ComplexNumber(3, 4)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_purely_real_numbers()
     {
         var sut = new ComplexNumber(1, 0);
@@ -92,7 +92,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Sub(new ComplexNumber(2, 0)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_purely_imaginary_numbers()
     {
         var sut = new ComplexNumber(0, 1);
@@ -101,7 +101,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Sub(new ComplexNumber(0, 2)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_numbers_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(1, 2);
@@ -110,7 +110,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Sub(new ComplexNumber(3, 4)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_purely_real_numbers()
     {
         var sut = new ComplexNumber(1, 0);
@@ -119,7 +119,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Mul(new ComplexNumber(2, 0)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_purely_imaginary_numbers()
     {
         var sut = new ComplexNumber(0, 1);
@@ -128,7 +128,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Mul(new ComplexNumber(0, 2)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_numbers_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(1, 2);
@@ -137,7 +137,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Mul(new ComplexNumber(3, 4)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Divide_purely_real_numbers()
     {
         var sut = new ComplexNumber(1, 0);
@@ -146,7 +146,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Div(new ComplexNumber(2, 0)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Divide_purely_imaginary_numbers()
     {
         var sut = new ComplexNumber(0, 1);
@@ -155,7 +155,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Div(new ComplexNumber(0, 2)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Divide_numbers_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(1, 2);
@@ -164,42 +164,42 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Div(new ComplexNumber(3, 4)).Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_positive_purely_real_number()
     {
         var sut = new ComplexNumber(5, 0);
         Assert.Equal(5, sut.Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_negative_purely_real_number()
     {
         var sut = new ComplexNumber(-5, 0);
         Assert.Equal(5, sut.Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_purely_imaginary_number_with_positive_imaginary_part()
     {
         var sut = new ComplexNumber(0, 5);
         Assert.Equal(5, sut.Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_purely_imaginary_number_with_negative_imaginary_part()
     {
         var sut = new ComplexNumber(0, -5);
         Assert.Equal(5, sut.Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_number_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(3, 4);
         Assert.Equal(5, sut.Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Conjugate_a_purely_real_number()
     {
         var sut = new ComplexNumber(5, 0);
@@ -208,7 +208,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Conjugate().Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Conjugate_a_purely_imaginary_number()
     {
         var sut = new ComplexNumber(0, 5);
@@ -217,7 +217,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Conjugate().Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Conjugate_a_number_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(1, 1);
@@ -226,7 +226,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Conjugate().Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Eulers_identity_formula()
     {
         var sut = new ComplexNumber(0, Math.PI);
@@ -235,7 +235,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Exp().Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Exponential_of_0()
     {
         var sut = new ComplexNumber(0, 0);
@@ -244,7 +244,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Exp().Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Exponential_of_a_purely_real_number()
     {
         var sut = new ComplexNumber(1, 0);
@@ -253,7 +253,7 @@ public class ComplexNumbersTests
         Assert.Equal(expected.Imaginary(), sut.Exp().Imaginary(), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Exponential_of_a_number_with_real_and_imaginary_part()
     {
         var sut = new ComplexNumber(Math.Log(2.0), Math.PI);

--- a/exercises/connect/ConnectTests.cs
+++ b/exercises/connect/ConnectTests.cs
@@ -19,7 +19,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.None, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void X_can_win_on_a_1x1_board()
     {
         var board = new[]
@@ -30,7 +30,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.Black, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void O_can_win_on_a_1x1_board()
     {
         var board = new[]
@@ -41,7 +41,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.White, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Only_edges_does_not_make_a_winner()
     {
         var board = new[]
@@ -55,7 +55,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.None, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Illegal_diagonal_does_not_make_a_winner()
     {
         var board = new[]
@@ -70,7 +70,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.None, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Nobody_wins_crossing_adjacent_angles()
     {
         var board = new[]
@@ -85,7 +85,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.None, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void X_wins_crossing_from_left_to_right()
     {
         var board = new[]
@@ -100,7 +100,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.Black, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void O_wins_crossing_from_top_to_bottom()
     {
         var board = new[]
@@ -115,7 +115,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.White, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void X_wins_using_a_convoluted_path()
     {
         var board = new[]
@@ -130,7 +130,7 @@ public class ConnectTests
         Assert.Equal(ConnectWinner.Black, sut.Result());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void X_wins_using_a_spiral_path()
     {
         var board = new[]

--- a/exercises/crypto-square/CryptoSquareTests.cs
+++ b/exercises/crypto-square/CryptoSquareTests.cs
@@ -12,7 +12,7 @@ public class CryptoSquareTests
         Assert.Equal(expected, CryptoSquare.Ciphertext(plaintext));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Lowercase()
     {
         var plaintext = "A";
@@ -20,7 +20,7 @@ public class CryptoSquareTests
         Assert.Equal(expected, CryptoSquare.Ciphertext(plaintext));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Remove_spaces()
     {
         var plaintext = "  b ";
@@ -28,7 +28,7 @@ public class CryptoSquareTests
         Assert.Equal(expected, CryptoSquare.Ciphertext(plaintext));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Remove_punctuation()
     {
         var plaintext = "@1,%!";
@@ -36,7 +36,7 @@ public class CryptoSquareTests
         Assert.Equal(expected, CryptoSquare.Ciphertext(plaintext));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_9_character_plaintext_results_in_3_chunks_of_3_characters()
     {
         var plaintext = "This is fun!";
@@ -44,7 +44,7 @@ public class CryptoSquareTests
         Assert.Equal(expected, CryptoSquare.Ciphertext(plaintext));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_8_character_plaintext_results_in_3_chunks_the_last_one_with_a_trailing_space()
     {
         var plaintext = "Chill out.";
@@ -52,7 +52,7 @@ public class CryptoSquareTests
         Assert.Equal(expected, CryptoSquare.Ciphertext(plaintext));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_54_character_plaintext_results_in_7_chunks_the_last_two_with_trailing_spaces()
     {
         var plaintext = "If man was meant to stay on the ground, god would have given us roots.";

--- a/exercises/custom-set/CustomSetTests.cs
+++ b/exercises/custom-set/CustomSetTests.cs
@@ -11,14 +11,14 @@ public class CustomSetTests
         Assert.True(sut.Empty());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sets_with_elements_are_not_empty()
     {
         var sut = new CustomSet(new[] { 1 });
         Assert.False(sut.Empty());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Nothing_is_contained_in_an_empty_set()
     {
         var element = 1;
@@ -26,7 +26,7 @@ public class CustomSetTests
         Assert.False(sut.Contains(element));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void When_the_element_is_in_the_set()
     {
         var element = 1;
@@ -34,7 +34,7 @@ public class CustomSetTests
         Assert.True(sut.Contains(element));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void When_the_element_is_not_in_the_set()
     {
         var element = 4;
@@ -42,7 +42,7 @@ public class CustomSetTests
         Assert.False(sut.Contains(element));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_set_is_a_subset_of_another_empty_set()
     {
         var set2 = new CustomSet();
@@ -50,7 +50,7 @@ public class CustomSetTests
         Assert.True(sut.Subset(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_set_is_a_subset_of_non_empty_set()
     {
         var set2 = new CustomSet(new[] { 1 });
@@ -58,7 +58,7 @@ public class CustomSetTests
         Assert.True(sut.Subset(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Non_empty_set_is_not_a_subset_of_empty_set()
     {
         var set2 = new CustomSet();
@@ -66,7 +66,7 @@ public class CustomSetTests
         Assert.False(sut.Subset(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_is_a_subset_of_set_with_exact_same_elements()
     {
         var set2 = new CustomSet(new[] { 1, 2, 3 });
@@ -74,7 +74,7 @@ public class CustomSetTests
         Assert.True(sut.Subset(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_is_a_subset_of_larger_set_with_same_elements()
     {
         var set2 = new CustomSet(new[] { 4, 1, 2, 3 });
@@ -82,7 +82,7 @@ public class CustomSetTests
         Assert.True(sut.Subset(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_is_not_a_subset_of_set_that_does_not_contain_its_elements()
     {
         var set2 = new CustomSet(new[] { 4, 1, 3 });
@@ -90,7 +90,7 @@ public class CustomSetTests
         Assert.False(sut.Subset(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_empty_set_is_disjoint_with_itself()
     {
         var set2 = new CustomSet();
@@ -98,7 +98,7 @@ public class CustomSetTests
         Assert.True(sut.Disjoint(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_set_is_disjoint_with_non_empty_set()
     {
         var set2 = new CustomSet(new[] { 1 });
@@ -106,7 +106,7 @@ public class CustomSetTests
         Assert.True(sut.Disjoint(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Non_empty_set_is_disjoint_with_empty_set()
     {
         var set2 = new CustomSet();
@@ -114,7 +114,7 @@ public class CustomSetTests
         Assert.True(sut.Disjoint(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sets_are_not_disjoint_if_they_share_an_element()
     {
         var set2 = new CustomSet(new[] { 2, 3 });
@@ -122,7 +122,7 @@ public class CustomSetTests
         Assert.False(sut.Disjoint(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sets_are_disjoint_if_they_share_no_elements()
     {
         var set2 = new CustomSet(new[] { 3, 4 });
@@ -130,7 +130,7 @@ public class CustomSetTests
         Assert.True(sut.Disjoint(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_sets_are_equal()
     {
         var set2 = new CustomSet();
@@ -138,7 +138,7 @@ public class CustomSetTests
         Assert.True(sut.Equals(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_set_is_not_equal_to_non_empty_set()
     {
         var set2 = new CustomSet(new[] { 1, 2, 3 });
@@ -146,7 +146,7 @@ public class CustomSetTests
         Assert.False(sut.Equals(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Non_empty_set_is_not_equal_to_empty_set()
     {
         var set2 = new CustomSet();
@@ -154,7 +154,7 @@ public class CustomSetTests
         Assert.False(sut.Equals(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sets_with_the_same_elements_are_equal()
     {
         var set2 = new CustomSet(new[] { 2, 1 });
@@ -162,7 +162,7 @@ public class CustomSetTests
         Assert.True(sut.Equals(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sets_with_different_elements_are_not_equal()
     {
         var set2 = new CustomSet(new[] { 1, 2, 4 });
@@ -170,7 +170,7 @@ public class CustomSetTests
         Assert.False(sut.Equals(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_is_not_equal_to_larger_set_with_same_elements()
     {
         var set2 = new CustomSet(new[] { 1, 2, 3, 4 });
@@ -178,7 +178,7 @@ public class CustomSetTests
         Assert.False(sut.Equals(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_to_empty_set()
     {
         var element = 3;
@@ -186,7 +186,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(new[] { 3 }), sut.Add(element));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_to_non_empty_set()
     {
         var element = 3;
@@ -194,7 +194,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(new[] { 1, 2, 3, 4 }), sut.Add(element));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Adding_an_existing_element_does_not_change_the_set()
     {
         var element = 3;
@@ -202,7 +202,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(new[] { 1, 2, 3 }), sut.Add(element));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Intersection_of_two_empty_sets_is_an_empty_set()
     {
         var set2 = new CustomSet();
@@ -210,7 +210,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(), sut.Intersection(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Intersection_of_an_empty_set_and_non_empty_set_is_an_empty_set()
     {
         var set2 = new CustomSet(new[] { 3, 2, 5 });
@@ -218,7 +218,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(), sut.Intersection(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Intersection_of_a_non_empty_set_and_an_empty_set_is_an_empty_set()
     {
         var set2 = new CustomSet();
@@ -226,7 +226,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(), sut.Intersection(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Intersection_of_two_sets_with_no_shared_elements_is_an_empty_set()
     {
         var set2 = new CustomSet(new[] { 4, 5, 6 });
@@ -234,7 +234,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(), sut.Intersection(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Intersection_of_two_sets_with_shared_elements_is_a_set_of_the_shared_elements()
     {
         var set2 = new CustomSet(new[] { 3, 2, 5 });
@@ -242,7 +242,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(new[] { 2, 3 }), sut.Intersection(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Difference_of_two_empty_sets_is_an_empty_set()
     {
         var set2 = new CustomSet();
@@ -250,7 +250,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(), sut.Difference(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Difference_of_empty_set_and_non_empty_set_is_an_empty_set()
     {
         var set2 = new CustomSet(new[] { 3, 2, 5 });
@@ -258,7 +258,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(), sut.Difference(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Difference_of_a_non_empty_set_and_an_empty_set_is_the_non_empty_set()
     {
         var set2 = new CustomSet();
@@ -266,7 +266,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(new[] { 1, 2, 3, 4 }), sut.Difference(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Difference_of_two_non_empty_sets_is_a_set_of_elements_that_are_only_in_the_first_set()
     {
         var set2 = new CustomSet(new[] { 2, 4 });
@@ -274,7 +274,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(new[] { 1, 3 }), sut.Difference(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Union_of_empty_sets_is_an_empty_set()
     {
         var set2 = new CustomSet();
@@ -282,7 +282,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(), sut.Union(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Union_of_an_empty_set_and_non_empty_set_is_the_non_empty_set()
     {
         var set2 = new CustomSet(new[] { 2 });
@@ -290,7 +290,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(new[] { 2 }), sut.Union(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Union_of_a_non_empty_set_and_empty_set_is_the_non_empty_set()
     {
         var set2 = new CustomSet();
@@ -298,7 +298,7 @@ public class CustomSetTests
         Assert.Equal(new CustomSet(new[] { 1, 3 }), sut.Union(set2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Union_of_non_empty_sets_contains_all_unique_elements()
     {
         var set2 = new CustomSet(new[] { 2, 3 });

--- a/exercises/darts/DartsTests.cs
+++ b/exercises/darts/DartsTests.cs
@@ -10,73 +10,73 @@ public class DartsTests
         Assert.Equal(0, Darts.Score(-9, 9));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void On_the_outer_circle()
     {
         Assert.Equal(1, Darts.Score(0, 10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void On_the_middle_circle()
     {
         Assert.Equal(5, Darts.Score(-5, 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void On_the_inner_circle()
     {
         Assert.Equal(10, Darts.Score(0, -1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Exactly_on_centre()
     {
         Assert.Equal(10, Darts.Score(0, 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Near_the_centre()
     {
         Assert.Equal(10, Darts.Score(-0.1, -0.1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_within_the_inner_circle()
     {
         Assert.Equal(10, Darts.Score(0.7, 0.7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_outside_the_inner_circle()
     {
         Assert.Equal(5, Darts.Score(0.8, -0.8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_within_the_middle_circle()
     {
         Assert.Equal(5, Darts.Score(-3.5, 3.5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_outside_the_middle_circle()
     {
         Assert.Equal(1, Darts.Score(-3.6, -3.6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_within_the_outer_circle()
     {
         Assert.Equal(1, Darts.Score(-7, 7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Just_outside_the_outer_circle()
     {
         Assert.Equal(0, Darts.Score(7.1, -7.1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Asymmetric_position_between_the_inner_and_middle_circles()
     {
         Assert.Equal(5, Darts.Score(0.5, -4));

--- a/exercises/diamond/DiamondTests.cs
+++ b/exercises/diamond/DiamondTests.cs
@@ -21,7 +21,7 @@ public class DiamondTests
         Assert.NotEmpty(actual);
     }
 
-    [DiamondProperty(Skip = "Remove to run test")]
+    [DiamondProperty(Skip = "Remove this Skip property to run this test")]
     public void First_row_contains_a(char letter)
     {
         var actual = Diamond.Make(letter);
@@ -31,7 +31,7 @@ public class DiamondTests
         Assert.Equal("A", firstRowCharacters);
     }
 
-    [DiamondProperty(Skip = "Remove to run test")]
+    [DiamondProperty(Skip = "Remove this Skip property to run this test")]
     public void All_rows_must_have_symmetric_contour(char letter)
     {
         var actual = Diamond.Make(letter);
@@ -43,7 +43,7 @@ public class DiamondTests
         });
     }
 
-    [DiamondProperty(Skip = "Remove to run test")]
+    [DiamondProperty(Skip = "Remove this Skip property to run this test")]
     public void Top_of_figure_has_letters_in_correct_order(char letter)
     {
         var actual = Diamond.Make(letter);
@@ -55,7 +55,7 @@ public class DiamondTests
         Assert.Equal(firstNonSpaceLetters, expected);
     }
 
-    [DiamondProperty(Skip = "Remove to run test")]
+    [DiamondProperty(Skip = "Remove this Skip property to run this test")]
     public void Figure_is_symmetric_around_the_horizontal_axis(char letter)
     {
         var actual = Diamond.Make(letter);
@@ -67,7 +67,7 @@ public class DiamondTests
         Assert.Equal(bottom, top);
     }
 
-    [DiamondProperty(Skip = "Remove to run test")]
+    [DiamondProperty(Skip = "Remove this Skip property to run this test")]
     public void Diamond_has_square_shape(char letter)
     {
         var actual = Diamond.Make(letter);
@@ -81,7 +81,7 @@ public class DiamondTests
         });
     }
 
-    [DiamondProperty(Skip = "Remove to run test")]
+    [DiamondProperty(Skip = "Remove this Skip property to run this test")]
     public void All_rows_except_top_and_bottom_have_two_identical_letters(char letter)
     {
         var actual = Diamond.Make(letter);
@@ -96,7 +96,7 @@ public class DiamondTests
         });
     }
 
-    [DiamondProperty(Skip = "Remove to run test")]
+    [DiamondProperty(Skip = "Remove this Skip property to run this test")]
     public void Bottom_left_corner_spaces_are_triangle(char letter)
     {
         var actual = Diamond.Make(letter);

--- a/exercises/difference-of-squares/DifferenceOfSquaresTests.cs
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTests.cs
@@ -10,49 +10,49 @@ public class DifferenceOfSquaresTests
         Assert.Equal(1, DifferenceOfSquares.CalculateSquareOfSum(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Square_of_sum_5()
     {
         Assert.Equal(225, DifferenceOfSquares.CalculateSquareOfSum(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Square_of_sum_100()
     {
         Assert.Equal(25502500, DifferenceOfSquares.CalculateSquareOfSum(100));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sum_of_squares_1()
     {
         Assert.Equal(1, DifferenceOfSquares.CalculateSumOfSquares(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sum_of_squares_5()
     {
         Assert.Equal(55, DifferenceOfSquares.CalculateSumOfSquares(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sum_of_squares_100()
     {
         Assert.Equal(338350, DifferenceOfSquares.CalculateSumOfSquares(100));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Difference_of_squares_1()
     {
         Assert.Equal(0, DifferenceOfSquares.CalculateDifferenceOfSquares(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Difference_of_squares_5()
     {
         Assert.Equal(170, DifferenceOfSquares.CalculateDifferenceOfSquares(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Difference_of_squares_100()
     {
         Assert.Equal(25164150, DifferenceOfSquares.CalculateDifferenceOfSquares(100));

--- a/exercises/diffie-hellman/DiffieHellmanTests.cs
+++ b/exercises/diffie-hellman/DiffieHellmanTests.cs
@@ -17,7 +17,7 @@ public class DiffieHellmanTests
         }
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Private_key_is_random()
     {
         var p = new BigInteger(7919);
@@ -25,7 +25,7 @@ public class DiffieHellmanTests
         Assert.Equal(privateKeys.Distinct().Count(), privateKeys.Length);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_calculate_public_key_using_private_key()
     {
         var p = new BigInteger(23);
@@ -34,7 +34,7 @@ public class DiffieHellmanTests
         Assert.Equal(new BigInteger(8), DiffieHellman.PublicKey(p, g, privateKey));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_calculate_secret_using_other_partys_public_key()
     {
         var p = new BigInteger(23);
@@ -43,7 +43,7 @@ public class DiffieHellmanTests
         Assert.Equal(new BigInteger(2), DiffieHellman.Secret(p, theirPublicKey, myPrivateKey));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Key_exchange()
     {
         var p = new BigInteger(23);

--- a/exercises/dnd-character/DndCharacterTests.cs
+++ b/exercises/dnd-character/DndCharacterTests.cs
@@ -12,97 +12,97 @@ public class DndCharacterTests
         Assert.Equal(-4, DndCharacter.Modifier(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_4_is_minus_3()
     {
         Assert.Equal(-3, DndCharacter.Modifier(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_5_is_minus_3()
     {
         Assert.Equal(-3, DndCharacter.Modifier(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_6_is_minus_2()
     {
         Assert.Equal(-2, DndCharacter.Modifier(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_7_is_minus_2()
     {
         Assert.Equal(-2, DndCharacter.Modifier(7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_8_is_minus_1()
     {
         Assert.Equal(-1, DndCharacter.Modifier(8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_9_is_minus_1()
     {
         Assert.Equal(-1, DndCharacter.Modifier(9));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_10_is_0()
     {
         Assert.Equal(0, DndCharacter.Modifier(10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_11_is_0()
     {
         Assert.Equal(0, DndCharacter.Modifier(11));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_12_is_1()
     {
         Assert.Equal(1, DndCharacter.Modifier(12));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_13_is_1()
     {
         Assert.Equal(1, DndCharacter.Modifier(13));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_14_is_2()
     {
         Assert.Equal(2, DndCharacter.Modifier(14));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_15_is_2()
     {
         Assert.Equal(2, DndCharacter.Modifier(15));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_16_is_3()
     {
         Assert.Equal(3, DndCharacter.Modifier(16));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_17_is_3()
     {
         Assert.Equal(3, DndCharacter.Modifier(17));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ability_modifier_for_score_18_is_4()
     {
         Assert.Equal(4, DndCharacter.Modifier(18));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Random_ability_is_within_range()
     {
         for (var i = 0; i < 10; i++)
@@ -111,7 +111,7 @@ public class DndCharacterTests
         }
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Random_character_is_valid()
     {
         for (var i = 0; i < 10; i++)
@@ -127,7 +127,7 @@ public class DndCharacterTests
         }
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Each_ability_is_only_calculated_once()
     {
         for (var i = 0; i < 10; i++)
@@ -142,7 +142,7 @@ public class DndCharacterTests
         }
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Random_ability_is_distributed_correctly()
     {
         var expectedDistribution = new Dictionary<int, int>

--- a/exercises/dominoes/DominoesTests.cs
+++ b/exercises/dominoes/DominoesTests.cs
@@ -12,77 +12,77 @@ public class DominoesTests
         Assert.True(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Singleton_input_singleton_output()
     {
         var dominoes = new[] { (1, 1) };
         Assert.True(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Singleton_that_cant_be_chained()
     {
         var dominoes = new[] { (1, 2) };
         Assert.False(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_elements()
     {
         var dominoes = new[] { (1, 2), (3, 1), (2, 3) };
         Assert.True(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_reverse_dominoes()
     {
         var dominoes = new[] { (1, 2), (1, 3), (2, 3) };
         Assert.True(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cant_be_chained()
     {
         var dominoes = new[] { (1, 2), (4, 1), (2, 3) };
         Assert.False(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Disconnected_simple()
     {
         var dominoes = new[] { (1, 1), (2, 2) };
         Assert.False(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Disconnected_double_loop()
     {
         var dominoes = new[] { (1, 2), (2, 1), (3, 4), (4, 3) };
         Assert.False(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Disconnected_single_isolated()
     {
         var dominoes = new[] { (1, 2), (2, 3), (3, 1), (4, 4) };
         Assert.False(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Need_backtrack()
     {
         var dominoes = new[] { (1, 2), (2, 3), (3, 1), (2, 4), (2, 4) };
         Assert.True(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Separate_loops()
     {
         var dominoes = new[] { (1, 2), (2, 3), (3, 1), (1, 1), (2, 2), (3, 3) };
         Assert.True(Dominoes.CanChain(dominoes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Nine_elements()
     {
         var dominoes = new[] { (1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6), (2, 3), (3, 4), (5, 6) };

--- a/exercises/dot-dsl/DotDslTests.cs
+++ b/exercises/dot-dsl/DotDslTests.cs
@@ -15,7 +15,7 @@ public class DotDslTests
         Assert.Empty(g.Attrs);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Graph_with_one_node()
     {
         var g = new Graph
@@ -28,7 +28,7 @@ public class DotDslTests
         Assert.Empty(g.Attrs);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Graph_with_one_node_with_keywords()
     {
         var g = new Graph
@@ -41,7 +41,7 @@ public class DotDslTests
         Assert.Empty(g.Attrs);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Graph_with_one_edge()
     {
         var g = new Graph
@@ -54,7 +54,7 @@ public class DotDslTests
         Assert.Empty(g.Attrs);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Graph_with_one_attribute()
     {
         var g = new Graph
@@ -67,7 +67,7 @@ public class DotDslTests
         Assert.Equal(new[] { new Attr("foo", "1") }, g.Attrs);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Graph_with_attributes()
     {
         var g = new Graph

--- a/exercises/error-handling/ErrorHandlingTests.cs
+++ b/exercises/error-handling/ErrorHandlingTests.cs
@@ -13,7 +13,7 @@ public class ErrorHandlingTests
 
     // Read more about nullable types here:
     // https://msdn.microsoft.com/en-us/library/1t3y8s4s.aspx?f=255&MSPPError=-2147217396
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void ReturnNullableType()
     {
         var successfulResult = ErrorHandling.HandleErrorByReturningNullableType("1");
@@ -25,7 +25,7 @@ public class ErrorHandlingTests
 
     // Read more about out parameters here:
     // https://msdn.microsoft.com/en-us/library/t3c3bfhx.aspx?f=255&MSPPError=-2147217396
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void ReturnWithOutParameter()
     {
         int result;
@@ -50,7 +50,7 @@ public class ErrorHandlingTests
 
     // Read more about IDisposable here:
     // https://msdn.microsoft.com/en-us/library/system.idisposable(v=vs.110).aspx
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void DisposableObjectsAreDisposedWhenThrowingAnException()
     {
         var disposableResource = new DisposableResource();

--- a/exercises/etl/EtlTests.cs
+++ b/exercises/etl/EtlTests.cs
@@ -19,7 +19,7 @@ public class EtlTests
         Assert.Equal(expected, Etl.Transform(input));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_score_with_multiple_letters()
     {
         var input = new Dictionary<int, string[]>
@@ -37,7 +37,7 @@ public class EtlTests
         Assert.Equal(expected, Etl.Transform(input));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_scores_with_multiple_letters()
     {
         var input = new Dictionary<int, string[]>
@@ -55,7 +55,7 @@ public class EtlTests
         Assert.Equal(expected, Etl.Transform(input));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_scores_with_differing_numbers_of_letters()
     {
         var input = new Dictionary<int, string[]>

--- a/exercises/flatten-array/FlattenArrayTests.cs
+++ b/exercises/flatten-array/FlattenArrayTests.cs
@@ -17,7 +17,7 @@ public class FlattenArrayTests
         Assert.Equal(expected, FlattenArray.Flatten(array));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Flattens_array_with_just_integers_present()
     {
         var array = new object[]
@@ -30,7 +30,7 @@ public class FlattenArrayTests
         Assert.Equal(expected, FlattenArray.Flatten(array));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_5_level_nesting()
     {
         var array = new object[]
@@ -44,7 +44,7 @@ public class FlattenArrayTests
         Assert.Equal(expected, FlattenArray.Flatten(array));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_6_level_nesting()
     {
         var array = new object[]
@@ -57,7 +57,7 @@ public class FlattenArrayTests
         Assert.Equal(expected, FlattenArray.Flatten(array));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_6_level_nest_list_with_null_values()
     {
         var array = new object[]
@@ -71,7 +71,7 @@ public class FlattenArrayTests
         Assert.Equal(expected, FlattenArray.Flatten(array));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_values_in_nested_list_are_null()
     {
         var array = new object[]

--- a/exercises/food-chain/FoodChainTests.cs
+++ b/exercises/food-chain/FoodChainTests.cs
@@ -13,7 +13,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Spider()
     {
         var expected = 
@@ -24,7 +24,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Bird()
     {
         var expected = 
@@ -36,7 +36,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cat()
     {
         var expected = 
@@ -49,7 +49,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Dog()
     {
         var expected = 
@@ -63,7 +63,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Goat()
     {
         var expected = 
@@ -78,7 +78,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cow()
     {
         var expected = 
@@ -94,7 +94,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Horse()
     {
         var expected = 
@@ -103,7 +103,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_verses()
     {
         var expected = 
@@ -123,7 +123,7 @@ public class FoodChainTests
         Assert.Equal(expected, FoodChain.Recite(1, 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_song()
     {
         var expected = 

--- a/exercises/forth/ForthTests.cs
+++ b/exercises/forth/ForthTests.cs
@@ -11,271 +11,271 @@ public class ForthTests
         Assert.Equal("1 2 3 4 5", Forth.Evaluate(new[] { "1 2 3 4 5" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Addition_can_add_two_numbers()
     {
         Assert.Equal("3", Forth.Evaluate(new[] { "1 2 +" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Addition_errors_if_there_is_nothing_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "+" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Addition_errors_if_there_is_only_one_value_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "1 +" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtraction_can_subtract_two_numbers()
     {
         Assert.Equal("-1", Forth.Evaluate(new[] { "3 4 -" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtraction_errors_if_there_is_nothing_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "-" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtraction_errors_if_there_is_only_one_value_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "1 -" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiplication_can_multiply_two_numbers()
     {
         Assert.Equal("8", Forth.Evaluate(new[] { "2 4 *" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiplication_errors_if_there_is_nothing_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "*" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiplication_errors_if_there_is_only_one_value_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "1 *" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Division_can_divide_two_numbers()
     {
         Assert.Equal("4", Forth.Evaluate(new[] { "12 3 /" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Division_performs_integer_division()
     {
         Assert.Equal("2", Forth.Evaluate(new[] { "8 3 /" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Division_errors_if_dividing_by_zero()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "4 0 /" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Division_errors_if_there_is_nothing_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "/" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Division_errors_if_there_is_only_one_value_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "1 /" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Combined_arithmetic_addition_and_subtraction()
     {
         Assert.Equal("-1", Forth.Evaluate(new[] { "1 2 + 4 -" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Combined_arithmetic_multiplication_and_division()
     {
         Assert.Equal("2", Forth.Evaluate(new[] { "2 4 * 3 /" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Dup_copies_a_value_on_the_stack()
     {
         Assert.Equal("1 1", Forth.Evaluate(new[] { "1 dup" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Dup_copies_the_top_value_on_the_stack()
     {
         Assert.Equal("1 2 2", Forth.Evaluate(new[] { "1 2 dup" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Dup_errors_if_there_is_nothing_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "dup" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Drop_removes_the_top_value_on_the_stack_if_it_is_the_only_one()
     {
         Assert.Equal("", Forth.Evaluate(new[] { "1 drop" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Drop_removes_the_top_value_on_the_stack_if_it_is_not_the_only_one()
     {
         Assert.Equal("1", Forth.Evaluate(new[] { "1 2 drop" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Drop_errors_if_there_is_nothing_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "drop" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Swap_swaps_the_top_two_values_on_the_stack_if_they_are_the_only_ones()
     {
         Assert.Equal("2 1", Forth.Evaluate(new[] { "1 2 swap" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Swap_swaps_the_top_two_values_on_the_stack_if_they_are_not_the_only_ones()
     {
         Assert.Equal("1 3 2", Forth.Evaluate(new[] { "1 2 3 swap" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Swap_errors_if_there_is_nothing_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "swap" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Swap_errors_if_there_is_only_one_value_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "1 swap" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Over_copies_the_second_element_if_there_are_only_two()
     {
         Assert.Equal("1 2 1", Forth.Evaluate(new[] { "1 2 over" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Over_copies_the_second_element_if_there_are_more_than_two()
     {
         Assert.Equal("1 2 3 2", Forth.Evaluate(new[] { "1 2 3 over" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Over_errors_if_there_is_nothing_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "over" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Over_errors_if_there_is_only_one_value_on_the_stack()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "1 over" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_can_consist_of_built_in_words()
     {
         Assert.Equal("1 1 1", Forth.Evaluate(new[] { ": dup-twice dup dup ;", "1 dup-twice" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_execute_in_the_right_order()
     {
         Assert.Equal("1 2 3", Forth.Evaluate(new[] { ": countup 1 2 3 ;", "countup" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_can_override_other_user_defined_words()
     {
         Assert.Equal("1 1 1", Forth.Evaluate(new[] { ": foo dup ;", ": foo dup dup ;", "1 foo" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_can_override_built_in_words()
     {
         Assert.Equal("1 1", Forth.Evaluate(new[] { ": swap dup ;", "1 swap" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_can_override_built_in_operators()
     {
         Assert.Equal("12", Forth.Evaluate(new[] { ": + * ;", "3 4 +" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_can_use_different_words_with_the_same_name()
     {
         Assert.Equal("5 6", Forth.Evaluate(new[] { ": foo 5 ;", ": bar foo ;", ": foo 6 ;", "bar foo" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_can_define_word_that_uses_word_with_the_same_name()
     {
         Assert.Equal("11", Forth.Evaluate(new[] { ": foo 10 ;", ": foo foo 1 + ;", "foo" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_cannot_redefine_numbers()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { ": 1 2 ;" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void User_defined_words_errors_if_executing_a_non_existent_word()
     {
         Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "foo" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Case_insensitivity_dup_is_case_insensitive()
     {
         Assert.Equal("1 1 1 1", Forth.Evaluate(new[] { "1 DUP Dup dup" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Case_insensitivity_drop_is_case_insensitive()
     {
         Assert.Equal("1", Forth.Evaluate(new[] { "1 2 3 4 DROP Drop drop" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Case_insensitivity_swap_is_case_insensitive()
     {
         Assert.Equal("2 3 4 1", Forth.Evaluate(new[] { "1 2 SWAP 3 Swap 4 swap" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Case_insensitivity_over_is_case_insensitive()
     {
         Assert.Equal("1 2 1 2 1", Forth.Evaluate(new[] { "1 2 OVER Over over" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Case_insensitivity_user_defined_words_are_case_insensitive()
     {
         Assert.Equal("1 1 1 1", Forth.Evaluate(new[] { ": foo dup ;", "1 FOO Foo foo" }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Case_insensitivity_definitions_are_case_insensitive()
     {
         Assert.Equal("1 1 1 1", Forth.Evaluate(new[] { ": SWAP DUP Dup dup ;", "1 swap" }));

--- a/exercises/gigasecond/GigasecondTests.cs
+++ b/exercises/gigasecond/GigasecondTests.cs
@@ -11,25 +11,25 @@ public class GigasecondTests
         Assert.Equal(new DateTime(2043, 1, 1, 1, 46, 40), Gigasecond.Add(new DateTime(2011, 4, 25)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_test_for_date_only_specification_of_time()
     {
         Assert.Equal(new DateTime(2009, 2, 19, 1, 46, 40), Gigasecond.Add(new DateTime(1977, 6, 13)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_test_for_date_only_specification_of_time()
     {
         Assert.Equal(new DateTime(1991, 3, 27, 1, 46, 40), Gigasecond.Add(new DateTime(1959, 7, 19)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_time_specified()
     {
         Assert.Equal(new DateTime(2046, 10, 2, 23, 46, 40), Gigasecond.Add(new DateTime(2015, 1, 24, 22, 0, 0)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_time_with_day_roll_over()
     {
         Assert.Equal(new DateTime(2046, 10, 3, 1, 46, 39), Gigasecond.Add(new DateTime(2015, 1, 24, 23, 59, 59)));

--- a/exercises/go-counting/GoCountingTests.cs
+++ b/exercises/go-counting/GoCountingTests.cs
@@ -23,7 +23,7 @@ public class GoCountingTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void White_center_territory_on_5x5_board()
     {
         var coordinate = (2, 3);
@@ -40,7 +40,7 @@ public class GoCountingTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Open_corner_territory_on_5x5_board()
     {
         var coordinate = (1, 4);
@@ -57,7 +57,7 @@ public class GoCountingTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_stone_and_not_a_territory_on_5x5_board()
     {
         var coordinate = (1, 1);
@@ -74,7 +74,7 @@ public class GoCountingTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_because_x_is_too_low_for_5x5_board()
     {
         var coordinate = (-1, 1);
@@ -88,7 +88,7 @@ public class GoCountingTests
         Assert.Throws<ArgumentException>(() => sut.Territory(coordinate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_because_x_is_too_high_for_5x5_board()
     {
         var coordinate = (5, 1);
@@ -102,7 +102,7 @@ public class GoCountingTests
         Assert.Throws<ArgumentException>(() => sut.Territory(coordinate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_because_y_is_too_low_for_5x5_board()
     {
         var coordinate = (1, -1);
@@ -116,7 +116,7 @@ public class GoCountingTests
         Assert.Throws<ArgumentException>(() => sut.Territory(coordinate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_because_y_is_too_high_for_5x5_board()
     {
         var coordinate = (1, 5);
@@ -130,7 +130,7 @@ public class GoCountingTests
         Assert.Throws<ArgumentException>(() => sut.Territory(coordinate));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_territory_is_the_whole_board()
     {
         var board = " ";
@@ -148,7 +148,7 @@ public class GoCountingTests
         Assert.Equal(expected[Owner.None], actual[Owner.None]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_territory_rectangular_board()
     {
         var board = 
@@ -168,7 +168,7 @@ public class GoCountingTests
         Assert.Equal(expected[Owner.None], actual[Owner.None]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_region_rectangular_board()
     {
         var board = " B ";

--- a/exercises/grade-school/GradeSchoolTests.cs
+++ b/exercises/grade-school/GradeSchoolTests.cs
@@ -14,7 +14,7 @@ public class GradeSchoolTests
         Assert.Equal(expected, sut.Roster());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Adding_more_student_adds_them_to_the_sorted_roster()
     {
         var sut = new GradeSchool();
@@ -25,7 +25,7 @@ public class GradeSchoolTests
         Assert.Equal(expected, sut.Roster());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Adding_students_to_different_grades_adds_them_to_the_same_sorted_roster()
     {
         var sut = new GradeSchool();
@@ -35,7 +35,7 @@ public class GradeSchoolTests
         Assert.Equal(expected, sut.Roster());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Roster_returns_an_empty_list_if_there_are_no_students_enrolled()
     {
         var sut = new GradeSchool();
@@ -43,7 +43,7 @@ public class GradeSchoolTests
         Assert.Empty(sut.Roster());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Student_names_with_grades_are_displayed_in_the_same_sorted_roster()
     {
         var sut = new GradeSchool();
@@ -58,7 +58,7 @@ public class GradeSchoolTests
         Assert.Equal(expected, sut.Roster());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Grade_returns_the_students_in_that_grade_in_alphabetical_order()
     {
         var sut = new GradeSchool();
@@ -69,7 +69,7 @@ public class GradeSchoolTests
         Assert.Equal(expected, sut.Grade(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Grade_returns_an_empty_list_if_there_are_no_students_in_that_grade()
     {
         var sut = new GradeSchool();

--- a/exercises/grains/GrainsTests.cs
+++ b/exercises/grains/GrainsTests.cs
@@ -11,61 +11,61 @@ public class GrainsTests
         Assert.Equal(1UL, Grains.Square(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_2()
     {
         Assert.Equal(2UL, Grains.Square(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_3()
     {
         Assert.Equal(4UL, Grains.Square(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_4()
     {
         Assert.Equal(8UL, Grains.Square(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_16()
     {
         Assert.Equal(32768UL, Grains.Square(16));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_32()
     {
         Assert.Equal(2147483648UL, Grains.Square(32));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_64()
     {
         Assert.Equal(9223372036854775808UL, Grains.Square(64));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Square_0_raises_an_exception()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => Grains.Square(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_square_raises_an_exception()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => Grains.Square(-1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Square_greater_than_64_raises_an_exception()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => Grains.Square(65));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Returns_the_total_number_of_grains_on_the_board()
     {
         Assert.Equal(18446744073709551615UL, Grains.Total());

--- a/exercises/grep/GrepTests.cs
+++ b/exercises/grep/GrepTests.cs
@@ -16,7 +16,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_one_match_print_line_numbers_flag()
     {
         var pattern = "Forbidden";
@@ -26,7 +26,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_one_match_case_insensitive_flag()
     {
         var pattern = "FORBIDDEN";
@@ -36,7 +36,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_one_match_print_file_names_flag()
     {
         var pattern = "Forbidden";
@@ -46,7 +46,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_one_match_match_entire_lines_flag()
     {
         var pattern = "With loss of Eden, till one greater Man";
@@ -56,7 +56,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_one_match_multiple_flags()
     {
         var pattern = "OF ATREUS, Agamemnon, KIng of MEN.";
@@ -66,7 +66,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_several_matches_no_flags()
     {
         var pattern = "may";
@@ -79,7 +79,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_several_matches_print_line_numbers_flag()
     {
         var pattern = "may";
@@ -92,7 +92,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_several_matches_match_entire_lines_flag()
     {
         var pattern = "may";
@@ -102,7 +102,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_several_matches_case_insensitive_flag()
     {
         var pattern = "ACHILLES";
@@ -114,7 +114,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_several_matches_inverted_flag()
     {
         var pattern = "Of";
@@ -129,7 +129,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_no_matches_various_flags()
     {
         var pattern = "Gandalf";
@@ -139,7 +139,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_one_match_file_flag_takes_precedence_over_line_flag()
     {
         var pattern = "ten";
@@ -149,7 +149,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_file_several_matches_inverted_and_match_entire_lines_flags()
     {
         var pattern = "Illustrious into Ades premature,";
@@ -167,7 +167,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_one_match_no_flags()
     {
         var pattern = "Agamemnon";
@@ -177,7 +177,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_several_matches_no_flags()
     {
         var pattern = "may";
@@ -190,7 +190,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_several_matches_print_line_numbers_flag()
     {
         var pattern = "that";
@@ -204,7 +204,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_one_match_print_file_names_flag()
     {
         var pattern = "who";
@@ -216,7 +216,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_several_matches_case_insensitive_flag()
     {
         var pattern = "TO";
@@ -236,7 +236,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_several_matches_inverted_flag()
     {
         var pattern = "a";
@@ -249,7 +249,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_one_match_match_entire_lines_flag()
     {
         var pattern = "But I beseech your grace that I may know";
@@ -259,7 +259,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_one_match_multiple_flags()
     {
         var pattern = "WITH LOSS OF EDEN, TILL ONE GREATER MAN";
@@ -269,7 +269,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_no_matches_various_flags()
     {
         var pattern = "Frodo";
@@ -279,7 +279,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_several_matches_file_flag_takes_precedence_over_line_number_flag()
     {
         var pattern = "who";
@@ -291,7 +291,7 @@ public class GrepTests : IDisposable
         Assert.Equal(expected, Grep.Match(pattern, flags, files));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_files_several_matches_inverted_and_match_entire_lines_flags()
     {
         var pattern = "Illustrious into Ades premature,";

--- a/exercises/hamming/HammingTests.cs
+++ b/exercises/hamming/HammingTests.cs
@@ -11,49 +11,49 @@ public class HammingTests
         Assert.Equal(0, Hamming.Distance("", ""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_letter_identical_strands()
     {
         Assert.Equal(0, Hamming.Distance("A", "A"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_letter_different_strands()
     {
         Assert.Equal(1, Hamming.Distance("G", "T"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Long_identical_strands()
     {
         Assert.Equal(0, Hamming.Distance("GGACTGAAATCTG", "GGACTGAAATCTG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Long_different_strands()
     {
         Assert.Equal(9, Hamming.Distance("GGACGGATTCTG", "AGGACGGATTCT"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Disallow_first_strand_longer()
     {
         Assert.Throws<ArgumentException>(() => Hamming.Distance("AATG", "AAA"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Disallow_second_strand_longer()
     {
         Assert.Throws<ArgumentException>(() => Hamming.Distance("ATA", "AGTG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Disallow_left_empty_strand()
     {
         Assert.Throws<ArgumentException>(() => Hamming.Distance("", "G"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Disallow_right_empty_strand()
     {
         Assert.Throws<ArgumentException>(() => Hamming.Distance("G", ""));

--- a/exercises/hangman/HangmanTests.cs
+++ b/exercises/hangman/HangmanTests.cs
@@ -21,7 +21,7 @@ public class HangmanTests : ReactiveTest
         Assert.Equal("___", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Initial_state_has_9_remaining_guesses()
     {
         var hangman = new Hangman("foo");
@@ -33,7 +33,7 @@ public class HangmanTests : ReactiveTest
         Assert.Equal(9, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Initial_state_has_no_guessed_chars()
     {
         var hangman = new Hangman("foo");
@@ -45,7 +45,7 @@ public class HangmanTests : ReactiveTest
         Assert.Equal(new HashSet<char>().ToImmutableHashSet(), actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Guess_changes_state()
     {
         var hangman = new Hangman("foo");
@@ -60,7 +60,7 @@ public class HangmanTests : ReactiveTest
         Assert.NotEqual(initial, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Wrong_guess_decrements_remaining_guesses()
     {
         var hangman = new Hangman("foo");
@@ -75,7 +75,7 @@ public class HangmanTests : ReactiveTest
         Assert.Equal(initial.RemainingGuesses - 1, actual.RemainingGuesses);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void After_10_incorrect_guesses_the_game_is_over()
     {
         var scheduler = new TestScheduler();
@@ -112,7 +112,7 @@ public class HangmanTests : ReactiveTest
         ReactiveAssert.AreElementsEqual(expected, testableObserver.Messages);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Correctly_guessing_a_letter_unmasks_it()
     {
         var scheduler = new TestScheduler();
@@ -138,7 +138,7 @@ public class HangmanTests : ReactiveTest
         ReactiveAssert.AreElementsEqual(expected, testableObserver.Messages);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Guessing_a_correct_letter_twice_counts_as_a_failure()
     {
         var scheduler = new TestScheduler();
@@ -164,7 +164,7 @@ public class HangmanTests : ReactiveTest
         ReactiveAssert.AreElementsEqual(expected, testableObserver.Messages);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Getting_all_the_letters_right_makes_for_a_win()
     {
         var scheduler = new TestScheduler();
@@ -197,7 +197,7 @@ public class HangmanTests : ReactiveTest
     }
 
     // Advanced mode on>
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_player_sees_the_same_game_already_started()
     {
         var scheduler = new TestScheduler();
@@ -231,7 +231,7 @@ public class HangmanTests : ReactiveTest
     }
 
     // Expert mode on>
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_players_see_the_same_game_already_started()
     {
         var scheduler = new TestScheduler();
@@ -266,7 +266,7 @@ public class HangmanTests : ReactiveTest
         ReactiveAssert.AreElementsEqual(expected, player3.Messages);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Player_joins_after_other_players_quit()
     {
         var scheduler = new TestScheduler();

--- a/exercises/hexadecimal/HexadecimalTests.cs
+++ b/exercises/hexadecimal/HexadecimalTests.cs
@@ -2,61 +2,61 @@ using Xunit;
 
 public class HexadecimalTest
 {
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_1_is_decimal_1()
     {
         Assert.Equal(1, Hexadecimal.ToDecimal("1"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_c_is_decimal_12()
     {
         Assert.Equal(12, Hexadecimal.ToDecimal("c"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_10_is_decimal_16()
     {
         Assert.Equal(16, Hexadecimal.ToDecimal("10"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_af_is_decimal_175()
     {
         Assert.Equal(175, Hexadecimal.ToDecimal("af"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_100_is_decimal_256()
     {
         Assert.Equal(256, Hexadecimal.ToDecimal("100"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_19ace_is_decimal_105166()
     {
         Assert.Equal(105166, Hexadecimal.ToDecimal("19ace"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_carrot_is_decimal_0()
     {
         Assert.Equal(0, Hexadecimal.ToDecimal("carrot"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_000000_is_decimal_0()
     {
         Assert.Equal(0, Hexadecimal.ToDecimal("000000"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_ffffff_is_decimal_16777215()
     {
         Assert.Equal(16777215, Hexadecimal.ToDecimal("ffffff"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexadecimal_ffff00_is_decimal_16776960()
     {
         Assert.Equal(16776960, Hexadecimal.ToDecimal("ffff00"));

--- a/exercises/high-scores/HighScoresTests.cs
+++ b/exercises/high-scores/HighScoresTests.cs
@@ -12,49 +12,49 @@ public class HighScoresTests
         Assert.Equal(new List<int> { 30, 50, 20, 70 }, sut.Scores());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Latest_score()
     {
         var sut = new HighScores(new List<int> { 100, 0, 90, 30 });
         Assert.Equal(30, sut.Latest());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Personal_best()
     {
         var sut = new HighScores(new List<int> { 40, 100, 70 });
         Assert.Equal(100, sut.PersonalBest());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Personal_top_three_from_a_list_of_scores()
     {
         var sut = new HighScores(new List<int> { 10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70 });
         Assert.Equal(new List<int> { 100, 90, 70 }, sut.PersonalTopThree());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Personal_top_highest_to_lowest()
     {
         var sut = new HighScores(new List<int> { 20, 10, 30 });
         Assert.Equal(new List<int> { 30, 20, 10 }, sut.PersonalTopThree());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Personal_top_when_there_is_a_tie()
     {
         var sut = new HighScores(new List<int> { 40, 20, 40, 30 });
         Assert.Equal(new List<int> { 40, 40, 30 }, sut.PersonalTopThree());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Personal_top_when_there_are_less_than_3()
     {
         var sut = new HighScores(new List<int> { 30, 70 });
         Assert.Equal(new List<int> { 70, 30 }, sut.PersonalTopThree());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Personal_top_when_there_is_only_one()
     {
         var sut = new HighScores(new List<int> { 40 });

--- a/exercises/house/HouseTests.cs
+++ b/exercises/house/HouseTests.cs
@@ -11,84 +11,84 @@ public class HouseTests
         Assert.Equal(expected, House.Recite(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_two_the_malt_that_lay()
     {
         var expected = "This is the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_three_the_rat_that_ate()
     {
         var expected = "This is the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_four_the_cat_that_killed()
     {
         var expected = "This is the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_five_the_dog_that_worried()
     {
         var expected = "This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_six_the_cow_with_the_crumpled_horn()
     {
         var expected = "This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_seven_the_maiden_all_forlorn()
     {
         var expected = "This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_eight_the_man_all_tattered_and_torn()
     {
         var expected = "This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_nine_the_priest_all_shaven_and_shorn()
     {
         var expected = "This is the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(9));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_10_the_rooster_that_crowed_in_the_morn()
     {
         var expected = "This is the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_11_the_farmer_sowing_his_corn()
     {
         var expected = "This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(11));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Verse_12_the_horse_and_the_hound_and_the_horn()
     {
         var expected = "This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.";
         Assert.Equal(expected, House.Recite(12));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_verses()
     {
         var expected = 
@@ -100,7 +100,7 @@ public class HouseTests
         Assert.Equal(expected, House.Recite(4, 8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_rhyme()
     {
         var expected = 

--- a/exercises/isbn-verifier/IsbnVerifierTests.cs
+++ b/exercises/isbn-verifier/IsbnVerifierTests.cs
@@ -10,97 +10,97 @@ public class IsbnVerifierTests
         Assert.True(IsbnVerifier.IsValid("3-598-21508-8"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_isbn_check_digit()
     {
         Assert.False(IsbnVerifier.IsValid("3-598-21508-9"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_isbn_number_with_a_check_digit_of_10()
     {
         Assert.True(IsbnVerifier.IsValid("3-598-21507-X"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Check_digit_is_a_character_other_than_x()
     {
         Assert.False(IsbnVerifier.IsValid("3-598-21507-A"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_character_in_isbn()
     {
         Assert.False(IsbnVerifier.IsValid("3-598-P1581-X"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void X_is_only_valid_as_a_check_digit()
     {
         Assert.False(IsbnVerifier.IsValid("3-598-2X507-9"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_isbn_without_separating_dashes()
     {
         Assert.True(IsbnVerifier.IsValid("3598215088"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isbn_without_separating_dashes_and_x_as_check_digit()
     {
         Assert.True(IsbnVerifier.IsValid("359821507X"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isbn_without_check_digit_and_dashes()
     {
         Assert.False(IsbnVerifier.IsValid("359821507"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Too_long_isbn_and_no_dashes()
     {
         Assert.False(IsbnVerifier.IsValid("3598215078X"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Too_short_isbn()
     {
         Assert.False(IsbnVerifier.IsValid("00"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isbn_without_check_digit()
     {
         Assert.False(IsbnVerifier.IsValid("3-598-21507"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Check_digit_of_x_should_not_be_used_for_0()
     {
         Assert.False(IsbnVerifier.IsValid("3-598-21515-X"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_isbn()
     {
         Assert.False(IsbnVerifier.IsValid(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Input_is_9_characters()
     {
         Assert.False(IsbnVerifier.IsValid("134456729"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_characters_are_not_ignored()
     {
         Assert.False(IsbnVerifier.IsValid("3132P34035"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Input_is_too_long_but_contains_a_valid_isbn()
     {
         Assert.False(IsbnVerifier.IsValid("98245726788"));

--- a/exercises/isogram/IsogramTests.cs
+++ b/exercises/isogram/IsogramTests.cs
@@ -10,73 +10,73 @@ public class IsogramTests
         Assert.True(Isogram.IsIsogram(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isogram_with_only_lower_case_characters()
     {
         Assert.True(Isogram.IsIsogram("isogram"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_with_one_duplicated_character()
     {
         Assert.False(Isogram.IsIsogram("eleven"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_with_one_duplicated_character_from_the_end_of_the_alphabet()
     {
         Assert.False(Isogram.IsIsogram("zzyzx"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Longest_reported_english_isogram()
     {
         Assert.True(Isogram.IsIsogram("subdermatoglyphic"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_with_duplicated_character_in_mixed_case()
     {
         Assert.False(Isogram.IsIsogram("Alphabet"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_with_duplicated_character_in_mixed_case_lowercase_first()
     {
         Assert.False(Isogram.IsIsogram("alphAbet"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hypothetical_isogrammic_word_with_hyphen()
     {
         Assert.True(Isogram.IsIsogram("thumbscrew-japingly"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hypothetical_word_with_duplicated_character_following_hyphen()
     {
         Assert.False(Isogram.IsIsogram("thumbscrew-jappingly"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isogram_with_duplicated_hyphen()
     {
         Assert.True(Isogram.IsIsogram("six-year-old"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Made_up_name_that_is_an_isogram()
     {
         Assert.True(Isogram.IsIsogram("Emily Jung Schwartzkopf"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Duplicated_character_in_the_middle()
     {
         Assert.False(Isogram.IsIsogram("accentor"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Same_first_and_last_characters()
     {
         Assert.False(Isogram.IsIsogram("angola"));

--- a/exercises/kindergarten-garden/KindergartenGardenTests.cs
+++ b/exercises/kindergarten-garden/KindergartenGardenTests.cs
@@ -11,56 +11,56 @@ public class KindergartenGardenTests
         Assert.Equal(new[] { Plant.Radishes, Plant.Clover, Plant.Grass, Plant.Grass }, sut.Plants("Alice"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Partial_garden_different_garden_with_single_student()
     {
         var sut = new KindergartenGarden("VC\nRC");
         Assert.Equal(new[] { Plant.Violets, Plant.Clover, Plant.Radishes, Plant.Clover }, sut.Plants("Alice"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Partial_garden_garden_with_two_students()
     {
         var sut = new KindergartenGarden("VVCG\nVVRC");
         Assert.Equal(new[] { Plant.Clover, Plant.Grass, Plant.Radishes, Plant.Clover }, sut.Plants("Bob"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Partial_garden_multiple_students_for_the_same_garden_with_three_students_second_students_garden()
     {
         var sut = new KindergartenGarden("VVCCGG\nVVCCGG");
         Assert.Equal(new[] { Plant.Clover, Plant.Clover, Plant.Clover, Plant.Clover }, sut.Plants("Bob"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Partial_garden_multiple_students_for_the_same_garden_with_three_students_third_students_garden()
     {
         var sut = new KindergartenGarden("VVCCGG\nVVCCGG");
         Assert.Equal(new[] { Plant.Grass, Plant.Grass, Plant.Grass, Plant.Grass }, sut.Plants("Charlie"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_garden_first_students_garden()
     {
         var sut = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
         Assert.Equal(new[] { Plant.Violets, Plant.Radishes, Plant.Violets, Plant.Radishes }, sut.Plants("Alice"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_garden_second_students_garden()
     {
         var sut = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
         Assert.Equal(new[] { Plant.Clover, Plant.Grass, Plant.Clover, Plant.Clover }, sut.Plants("Bob"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_garden_second_to_last_students_garden()
     {
         var sut = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
         Assert.Equal(new[] { Plant.Grass, Plant.Clover, Plant.Clover, Plant.Grass }, sut.Plants("Kincaid"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_garden_last_students_garden()
     {
         var sut = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");

--- a/exercises/largest-series-product/LargestSeriesProductTests.cs
+++ b/exercises/largest-series-product/LargestSeriesProductTests.cs
@@ -11,85 +11,85 @@ public class LargestSeriesProductTests
         Assert.Equal(18, LargestSeriesProduct.GetLargestProduct("29", 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_the_largest_product_of_2_with_numbers_in_order()
     {
         Assert.Equal(72, LargestSeriesProduct.GetLargestProduct("0123456789", 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_the_largest_product_of_2()
     {
         Assert.Equal(48, LargestSeriesProduct.GetLargestProduct("576802143", 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_the_largest_product_of_3_with_numbers_in_order()
     {
         Assert.Equal(504, LargestSeriesProduct.GetLargestProduct("0123456789", 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_the_largest_product_of_3()
     {
         Assert.Equal(270, LargestSeriesProduct.GetLargestProduct("1027839564", 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_the_largest_product_of_5_with_numbers_in_order()
     {
         Assert.Equal(15120, LargestSeriesProduct.GetLargestProduct("0123456789", 5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_get_the_largest_product_of_a_big_number()
     {
         Assert.Equal(23520, LargestSeriesProduct.GetLargestProduct("73167176531330624919225119674426574742355349194934", 6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reports_zero_if_the_only_digits_are_zero()
     {
         Assert.Equal(0, LargestSeriesProduct.GetLargestProduct("0000", 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reports_zero_if_all_spans_include_zero()
     {
         Assert.Equal(0, LargestSeriesProduct.GetLargestProduct("99099", 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rejects_span_longer_than_string_length()
     {
         Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct("123", 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reports_1_for_empty_string_and_empty_product_0_span_()
     {
         Assert.Equal(1, LargestSeriesProduct.GetLargestProduct("", 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reports_1_for_nonempty_string_and_empty_product_0_span_()
     {
         Assert.Equal(1, LargestSeriesProduct.GetLargestProduct("123", 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rejects_empty_string_and_nonzero_span()
     {
         Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct("", 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rejects_invalid_character_in_digits()
     {
         Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct("1234a5", 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rejects_negative_span()
     {
         Assert.Throws<ArgumentException>(() => LargestSeriesProduct.GetLargestProduct("12345", -1));

--- a/exercises/leap/LeapTests.cs
+++ b/exercises/leap/LeapTests.cs
@@ -10,49 +10,49 @@ public class LeapTests
         Assert.False(Leap.IsLeapYear(2015));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Year_divisible_by_2_not_divisible_by_4_in_common_year()
     {
         Assert.False(Leap.IsLeapYear(1970));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Year_divisible_by_4_not_divisible_by_100_in_leap_year()
     {
         Assert.True(Leap.IsLeapYear(1996));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Year_divisible_by_4_and_5_is_still_a_leap_year()
     {
         Assert.True(Leap.IsLeapYear(1960));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Year_divisible_by_100_not_divisible_by_400_in_common_year()
     {
         Assert.False(Leap.IsLeapYear(2100));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Year_divisible_by_100_but_not_by_3_is_still_not_a_leap_year()
     {
         Assert.False(Leap.IsLeapYear(1900));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Year_divisible_by_400_in_leap_year()
     {
         Assert.True(Leap.IsLeapYear(2000));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Year_divisible_by_400_but_not_by_125_is_still_a_leap_year()
     {
         Assert.True(Leap.IsLeapYear(2400));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Year_divisible_by_200_not_divisible_by_400_in_common_year()
     {
         Assert.False(Leap.IsLeapYear(1800));

--- a/exercises/ledger/LedgerTests.cs
+++ b/exercises/ledger/LedgerTests.cs
@@ -14,7 +14,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_entry()
     {
         var currency = "USD";
@@ -30,7 +30,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Credit_and_debit()
     {
         var currency = "USD";
@@ -48,7 +48,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_entries_on_same_date_ordered_by_description()
     {
         var currency = "USD";
@@ -66,7 +66,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Final_order_tie_breaker_is_change()
     {
         var currency = "USD";
@@ -86,7 +86,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Overlong_descriptions()
     {
         var currency = "USD";
@@ -102,7 +102,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Euros()
     {
         var currency = "EUR";
@@ -118,7 +118,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Dutch_locale()
     {
         var currency = "USD";
@@ -134,7 +134,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Dutch_negative_number_with_3_digits_before_decimal_point()
     {
         var currency = "USD";
@@ -150,7 +150,7 @@ public class LedgerTests
         Assert.Equal(expected, Ledger.Format(currency, locale, entries));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void American_negative_number_with_3_digits_before_decimal_point()
     {
         var currency = "USD";

--- a/exercises/linked-list/LinkedListTests.cs
+++ b/exercises/linked-list/LinkedListTests.cs
@@ -12,7 +12,7 @@ public class DequeTests
         Assert.Equal(10, deque.Pop());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Push_and_shift_are_first_in_first_out_order()
     {
         var deque = new Deque<int>();
@@ -22,7 +22,7 @@ public class DequeTests
         Assert.Equal(20, deque.Shift());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unshift_and_shift_are_last_in_first_out_order()
     {
         var deque = new Deque<int>();
@@ -32,7 +32,7 @@ public class DequeTests
         Assert.Equal(10, deque.Shift());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unshift_and_pop_are_last_in_last_out_order()
     {
         var deque = new Deque<int>();
@@ -42,7 +42,7 @@ public class DequeTests
         Assert.Equal(20, deque.Pop());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Push_and_pop_can_handle_multiple_values()
     {
         var deque = new Deque<int>();
@@ -54,7 +54,7 @@ public class DequeTests
         Assert.Equal(10, deque.Pop());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unshift_and_shift_can_handle_multiple_values()
     {
         var deque = new Deque<int>();
@@ -66,7 +66,7 @@ public class DequeTests
         Assert.Equal(10, deque.Shift());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_methods_of_manipulating_the_deque_can_be_used_together()
     {
         var deque = new Deque<int>();

--- a/exercises/list-ops/ListOpsTests.cs
+++ b/exercises/list-ops/ListOpsTests.cs
@@ -14,7 +14,7 @@ public class ListOpsTests
         Assert.Empty(ListOps.Append(list1, list2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Append_entries_to_a_list_and_return_the_new_list_list_to_empty_list()
     {
         var list1 = new List<int>();
@@ -23,7 +23,7 @@ public class ListOpsTests
         Assert.Equal(expected, ListOps.Append(list1, list2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Append_entries_to_a_list_and_return_the_new_list_non_empty_lists()
     {
         var list1 = new List<int> { 1, 2 };
@@ -32,14 +32,14 @@ public class ListOpsTests
         Assert.Equal(expected, ListOps.Append(list1, list2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Concatenate_a_list_of_lists_empty_list()
     {
         var lists = new List<List<int>>();
         Assert.Empty(ListOps.Concat(lists));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Concatenate_a_list_of_lists_list_of_lists()
     {
         var lists = new List<List<int>> { new List<int> { 1, 2 }, new List<int> { 3 }, new List<int>(), new List<int> { 4, 5, 6 } };
@@ -47,7 +47,7 @@ public class ListOpsTests
         Assert.Equal(expected, ListOps.Concat(lists));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Concatenate_a_list_of_lists_list_of_nested_lists()
     {
         var lists = new List<List<List<int>>> { new List<List<int>> { new List<int> { 1 }, new List<int> { 2 } }, new List<List<int>> { new List<int> { 3 } }, new List<List<int>> { new List<int>() }, new List<List<int>> { new List<int> { 4, 5, 6 } } };
@@ -55,7 +55,7 @@ public class ListOpsTests
         Assert.Equal(expected, ListOps.Concat(lists));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Filter_list_returning_only_values_that_satisfy_the_filter_function_empty_list()
     {
         var list = new List<int>();
@@ -63,7 +63,7 @@ public class ListOpsTests
         Assert.Empty(ListOps.Filter(list, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Filter_list_returning_only_values_that_satisfy_the_filter_function_non_empty_list()
     {
         var list = new List<int> { 1, 2, 3, 5 };
@@ -72,21 +72,21 @@ public class ListOpsTests
         Assert.Equal(expected, ListOps.Filter(list, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Returns_the_length_of_a_list_empty_list()
     {
         var list = new List<int>();
         Assert.Equal(0, ListOps.Length(list));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Returns_the_length_of_a_list_non_empty_list()
     {
         var list = new List<int> { 1, 2, 3, 4 };
         Assert.Equal(4, ListOps.Length(list));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Return_a_list_of_elements_whose_values_equal_the_list_value_transformed_by_the_mapping_function_empty_list()
     {
         var list = new List<int>();
@@ -94,7 +94,7 @@ public class ListOpsTests
         Assert.Empty(ListOps.Map(list, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Return_a_list_of_elements_whose_values_equal_the_list_value_transformed_by_the_mapping_function_non_empty_list()
     {
         var list = new List<int> { 1, 3, 5, 7 };
@@ -103,7 +103,7 @@ public class ListOpsTests
         Assert.Equal(expected, ListOps.Map(list, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Folds_reduces_the_given_list_from_the_left_with_a_function_empty_list()
     {
         var list = new List<int>();
@@ -112,7 +112,7 @@ public class ListOpsTests
         Assert.Equal(2, ListOps.Foldl(list, initial, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Folds_reduces_the_given_list_from_the_left_with_a_function_direction_independent_function_applied_to_non_empty_list()
     {
         var list = new List<int> { 1, 2, 3, 4 };
@@ -121,7 +121,7 @@ public class ListOpsTests
         Assert.Equal(15, ListOps.Foldl(list, initial, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Folds_reduces_the_given_list_from_the_left_with_a_function_direction_dependent_function_applied_to_non_empty_list()
     {
         var list = new List<int> { 2, 5 };
@@ -130,7 +130,7 @@ public class ListOpsTests
         Assert.Equal(0, ListOps.Foldl(list, initial, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Folds_reduces_the_given_list_from_the_right_with_a_function_empty_list()
     {
         var list = new List<int>();
@@ -139,7 +139,7 @@ public class ListOpsTests
         Assert.Equal(2, ListOps.Foldr(list, initial, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Folds_reduces_the_given_list_from_the_right_with_a_function_direction_independent_function_applied_to_non_empty_list()
     {
         var list = new List<int> { 1, 2, 3, 4 };
@@ -148,7 +148,7 @@ public class ListOpsTests
         Assert.Equal(15, ListOps.Foldr(list, initial, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Folds_reduces_the_given_list_from_the_right_with_a_function_direction_dependent_function_applied_to_non_empty_list()
     {
         var list = new List<int> { 2, 5 };
@@ -157,14 +157,14 @@ public class ListOpsTests
         Assert.Equal(2, ListOps.Foldr(list, initial, function));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reverse_the_elements_of_the_list_empty_list()
     {
         var list = new List<int>();
         Assert.Empty(ListOps.Reverse(list));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reverse_the_elements_of_the_list_non_empty_list()
     {
         var list = new List<int> { 1, 3, 5, 7 };
@@ -172,7 +172,7 @@ public class ListOpsTests
         Assert.Equal(expected, ListOps.Reverse(list));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reverse_the_elements_of_the_list_list_of_lists_is_not_flattened()
     {
         var list = new List<List<int>> { new List<int> { 1, 2 }, new List<int> { 3 }, new List<int>(), new List<int> { 4, 5, 6 } };

--- a/exercises/luhn/LuhnTests.cs
+++ b/exercises/luhn/LuhnTests.cs
@@ -10,103 +10,103 @@ public class LuhnTests
         Assert.False(Luhn.IsValid("1"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_single_zero_is_invalid()
     {
         Assert.False(Luhn.IsValid("0"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_simple_valid_sin_that_remains_valid_if_reversed()
     {
         Assert.True(Luhn.IsValid("059"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_simple_valid_sin_that_becomes_invalid_if_reversed()
     {
         Assert.True(Luhn.IsValid("59"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_valid_canadian_sin()
     {
         Assert.True(Luhn.IsValid("055 444 285"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_canadian_sin()
     {
         Assert.False(Luhn.IsValid("055 444 286"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_credit_card()
     {
         Assert.False(Luhn.IsValid("8273 1232 7352 0569"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_long_number_with_an_even_remainder()
     {
         Assert.False(Luhn.IsValid("1 2345 6789 1234 5678 9012"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_number_with_an_even_number_of_digits()
     {
         Assert.True(Luhn.IsValid("095 245 88"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_number_with_an_odd_number_of_spaces()
     {
         Assert.True(Luhn.IsValid("234 567 891 234"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_strings_with_a_non_digit_added_at_the_end_become_invalid()
     {
         Assert.False(Luhn.IsValid("059a"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_strings_with_punctuation_included_become_invalid()
     {
         Assert.False(Luhn.IsValid("055-444-285"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_strings_with_symbols_included_become_invalid()
     {
         Assert.False(Luhn.IsValid("055# 444$ 285"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_zero_with_space_is_invalid()
     {
         Assert.False(Luhn.IsValid(" 0"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void More_than_a_single_zero_is_valid()
     {
         Assert.True(Luhn.IsValid("0000 0"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Input_digit_9_is_correctly_converted_to_output_digit_9()
     {
         Assert.True(Luhn.IsValid("091"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Using_ascii_value_for_non_doubled_non_digit_isnt_allowed()
     {
         Assert.False(Luhn.IsValid("055b 444 285"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Using_ascii_value_for_doubled_non_digit_isnt_allowed()
     {
         Assert.False(Luhn.IsValid(":9"));

--- a/exercises/matching-brackets/MatchingBracketsTests.cs
+++ b/exercises/matching-brackets/MatchingBracketsTests.cs
@@ -11,112 +11,112 @@ public class MatchingBracketsTests
         Assert.True(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_string()
     {
         var value = "";
         Assert.True(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unpaired_brackets()
     {
         var value = "[[";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Wrong_ordered_brackets()
     {
         var value = "}{";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Wrong_closing_bracket()
     {
         var value = "{]";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Paired_with_whitespace()
     {
         var value = "{ }";
         Assert.True(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Partially_paired_brackets()
     {
         var value = "{[])";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Simple_nested_brackets()
     {
         var value = "{[]}";
         Assert.True(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Several_paired_brackets()
     {
         var value = "{}[]";
         Assert.True(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Paired_and_nested_brackets()
     {
         var value = "([{}({}[])])";
         Assert.True(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unopened_closing_brackets()
     {
         var value = "{[)][]}";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unpaired_and_nested_brackets()
     {
         var value = "([{])";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Paired_and_wrong_nested_brackets()
     {
         var value = "[({]})";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Paired_and_incomplete_brackets()
     {
         var value = "{}[";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Too_many_closing_brackets()
     {
         var value = "[]]";
         Assert.False(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Math_expression()
     {
         var value = "(((185 + 223.85) * 15) - 543)/2";
         Assert.True(MatchingBrackets.IsPaired(value));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Complex_latex_expression()
     {
         var value = "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \\end{array}\\right)";

--- a/exercises/matrix/MatrixTests.cs
+++ b/exercises/matrix/MatrixTests.cs
@@ -11,49 +11,49 @@ public class MatrixTests
         Assert.Equal(new[] { 1 }, sut.Row(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_extract_row()
     {
         var sut = new Matrix("1 2\n3 4");
         Assert.Equal(new[] { 3, 4 }, sut.Row(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Extract_row_where_numbers_have_different_widths()
     {
         var sut = new Matrix("1 2\n10 20");
         Assert.Equal(new[] { 10, 20 }, sut.Row(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_extract_row_from_non_square_matrix_with_no_corresponding_column()
     {
         var sut = new Matrix("1 2 3\n4 5 6\n7 8 9\n8 7 6");
         Assert.Equal(new[] { 8, 7, 6 }, sut.Row(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Extract_column_from_one_number_matrix()
     {
         var sut = new Matrix("1");
         Assert.Equal(new[] { 1 }, sut.Column(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_extract_column()
     {
         var sut = new Matrix("1 2 3\n4 5 6\n7 8 9");
         Assert.Equal(new[] { 3, 6, 9 }, sut.Column(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_extract_column_from_non_square_matrix_with_no_corresponding_row()
     {
         var sut = new Matrix("1 2 3 4\n5 6 7 8\n9 8 7 6");
         Assert.Equal(new[] { 4, 8, 6 }, sut.Column(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Extract_column_where_numbers_have_different_widths()
     {
         var sut = new Matrix("89 1903 3\n18 3 1\n9 4 800");

--- a/exercises/meetup/MeetupTests.cs
+++ b/exercises/meetup/MeetupTests.cs
@@ -13,7 +13,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Monteenth_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
@@ -21,7 +21,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Monteenth_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
@@ -29,7 +29,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tuesteenth_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -37,7 +37,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tuesteenth_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -45,7 +45,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tuesteenth_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
@@ -53,7 +53,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Wednesteenth_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
@@ -61,7 +61,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Wednesteenth_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
@@ -69,7 +69,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Wednesteenth_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
@@ -77,7 +77,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Thursteenth_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
@@ -85,7 +85,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Thursteenth_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
@@ -93,7 +93,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Thursteenth_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
@@ -101,7 +101,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Friteenth_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -109,7 +109,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Friteenth_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
@@ -117,7 +117,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Friteenth_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
@@ -125,7 +125,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Saturteenth_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
@@ -133,7 +133,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Saturteenth_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -141,7 +141,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Saturteenth_of_october_2013()
     {
         var sut = new Meetup(10, 2013);
@@ -149,7 +149,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sunteenth_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
@@ -157,7 +157,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sunteenth_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
@@ -165,7 +165,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sunteenth_of_october_2013()
     {
         var sut = new Meetup(10, 2013);
@@ -173,7 +173,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Teenth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -181,7 +181,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -189,7 +189,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
@@ -197,7 +197,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
@@ -205,7 +205,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
@@ -213,7 +213,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
@@ -221,7 +221,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
@@ -229,7 +229,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_thursday_of_october_2013()
     {
         var sut = new Meetup(10, 2013);
@@ -237,7 +237,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_friday_of_november_2013()
     {
         var sut = new Meetup(11, 2013);
@@ -245,7 +245,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_friday_of_december_2013()
     {
         var sut = new Meetup(12, 2013);
@@ -253,7 +253,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
@@ -261,7 +261,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
@@ -269,7 +269,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -277,7 +277,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -285,7 +285,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.First));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -293,7 +293,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -301,7 +301,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
@@ -309,7 +309,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
@@ -317,7 +317,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
@@ -325,7 +325,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
@@ -333,7 +333,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
@@ -341,7 +341,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_thursday_of_october_2013()
     {
         var sut = new Meetup(10, 2013);
@@ -349,7 +349,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_friday_of_november_2013()
     {
         var sut = new Meetup(11, 2013);
@@ -357,7 +357,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_friday_of_december_2013()
     {
         var sut = new Meetup(12, 2013);
@@ -365,7 +365,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
@@ -373,7 +373,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
@@ -381,7 +381,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -389,7 +389,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -397,7 +397,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Second));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -405,7 +405,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -413,7 +413,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
@@ -421,7 +421,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
@@ -429,7 +429,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
@@ -437,7 +437,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
@@ -445,7 +445,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
@@ -453,7 +453,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_thursday_of_october_2013()
     {
         var sut = new Meetup(10, 2013);
@@ -461,7 +461,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_friday_of_november_2013()
     {
         var sut = new Meetup(11, 2013);
@@ -469,7 +469,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_friday_of_december_2013()
     {
         var sut = new Meetup(12, 2013);
@@ -477,7 +477,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
@@ -485,7 +485,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
@@ -493,7 +493,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -501,7 +501,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -509,7 +509,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Third));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -517,7 +517,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -525,7 +525,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
@@ -533,7 +533,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
@@ -541,7 +541,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
@@ -549,7 +549,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
@@ -557,7 +557,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
@@ -565,7 +565,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_thursday_of_october_2013()
     {
         var sut = new Meetup(10, 2013);
@@ -573,7 +573,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_friday_of_november_2013()
     {
         var sut = new Meetup(11, 2013);
@@ -581,7 +581,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_friday_of_december_2013()
     {
         var sut = new Meetup(12, 2013);
@@ -589,7 +589,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
@@ -597,7 +597,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
@@ -605,7 +605,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -613,7 +613,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -621,7 +621,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Fourth));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_monday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -629,7 +629,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_monday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -637,7 +637,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Monday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_tuesday_of_may_2013()
     {
         var sut = new Meetup(5, 2013);
@@ -645,7 +645,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_tuesday_of_june_2013()
     {
         var sut = new Meetup(6, 2013);
@@ -653,7 +653,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Tuesday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_wednesday_of_july_2013()
     {
         var sut = new Meetup(7, 2013);
@@ -661,7 +661,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_wednesday_of_august_2013()
     {
         var sut = new Meetup(8, 2013);
@@ -669,7 +669,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_thursday_of_september_2013()
     {
         var sut = new Meetup(9, 2013);
@@ -677,7 +677,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_thursday_of_october_2013()
     {
         var sut = new Meetup(10, 2013);
@@ -685,7 +685,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Thursday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_friday_of_november_2013()
     {
         var sut = new Meetup(11, 2013);
@@ -693,7 +693,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_friday_of_december_2013()
     {
         var sut = new Meetup(12, 2013);
@@ -701,7 +701,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Friday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_saturday_of_january_2013()
     {
         var sut = new Meetup(1, 2013);
@@ -709,7 +709,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_saturday_of_february_2013()
     {
         var sut = new Meetup(2, 2013);
@@ -717,7 +717,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Saturday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_sunday_of_march_2013()
     {
         var sut = new Meetup(3, 2013);
@@ -725,7 +725,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_sunday_of_april_2013()
     {
         var sut = new Meetup(4, 2013);
@@ -733,7 +733,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_wednesday_of_february_2012()
     {
         var sut = new Meetup(2, 2012);
@@ -741,7 +741,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_wednesday_of_december_2014()
     {
         var sut = new Meetup(12, 2014);
@@ -749,7 +749,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Wednesday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Last_sunday_of_february_2015()
     {
         var sut = new Meetup(2, 2015);
@@ -757,7 +757,7 @@ public class MeetupTests
         Assert.Equal(expected, sut.Day(DayOfWeek.Sunday, Schedule.Last));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_friday_of_december_2012()
     {
         var sut = new Meetup(12, 2012);

--- a/exercises/minesweeper/MinesweeperTests.cs
+++ b/exercises/minesweeper/MinesweeperTests.cs
@@ -13,7 +13,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_columns()
     {
         var minefield = new[]
@@ -27,7 +27,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_mines()
     {
         var minefield = new[]
@@ -45,7 +45,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Minefield_with_only_mines()
     {
         var minefield = new[]
@@ -63,7 +63,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Mine_surrounded_by_spaces()
     {
         var minefield = new[]
@@ -81,7 +81,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Space_surrounded_by_mines()
     {
         var minefield = new[]
@@ -99,7 +99,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Horizontal_line()
     {
         var minefield = new[]
@@ -113,7 +113,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Horizontal_line_mines_at_edges()
     {
         var minefield = new[]
@@ -127,7 +127,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Vertical_line()
     {
         var minefield = new[]
@@ -149,7 +149,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Vertical_line_mines_at_edges()
     {
         var minefield = new[]
@@ -171,7 +171,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cross()
     {
         var minefield = new[]
@@ -193,7 +193,7 @@ public class MinesweeperTests
         Assert.Equal(expected, Minesweeper.Annotate(minefield));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Large_minefield()
     {
         var minefield = new[]

--- a/exercises/nth-prime/NthPrimeTests.cs
+++ b/exercises/nth-prime/NthPrimeTests.cs
@@ -11,25 +11,25 @@ public class NthPrimeTests
         Assert.Equal(2, NthPrime.Prime(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_prime()
     {
         Assert.Equal(3, NthPrime.Prime(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sixth_prime()
     {
         Assert.Equal(13, NthPrime.Prime(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Big_prime()
     {
         Assert.Equal(104743, NthPrime.Prime(10001));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void There_is_no_zeroth_prime()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => NthPrime.Prime(0));

--- a/exercises/nucleotide-count/NucleotideCountTests.cs
+++ b/exercises/nucleotide-count/NucleotideCountTests.cs
@@ -19,7 +19,7 @@ public class NucleotideCountTests
         Assert.Equal(expected, NucleotideCount.Count(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_count_one_nucleotide_in_single_character_input()
     {
         var expected = new Dictionary<char, int>
@@ -32,7 +32,7 @@ public class NucleotideCountTests
         Assert.Equal(expected, NucleotideCount.Count("G"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Strand_with_repeated_nucleotide()
     {
         var expected = new Dictionary<char, int>
@@ -45,7 +45,7 @@ public class NucleotideCountTests
         Assert.Equal(expected, NucleotideCount.Count("GGGGGGG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Strand_with_multiple_nucleotides()
     {
         var expected = new Dictionary<char, int>
@@ -58,7 +58,7 @@ public class NucleotideCountTests
         Assert.Equal(expected, NucleotideCount.Count("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Strand_with_invalid_nucleotides()
     {
         Assert.Throws<ArgumentException>(() => NucleotideCount.Count("AGXXACT"));

--- a/exercises/ocr-numbers/OcrNumbersTests.cs
+++ b/exercises/ocr-numbers/OcrNumbersTests.cs
@@ -17,7 +17,7 @@ public class OcrNumbersTests
         Assert.Equal("0", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_1()
     {
         var rows = 
@@ -29,7 +29,7 @@ public class OcrNumbersTests
         Assert.Equal("1", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unreadable_but_correctly_sized_inputs_return_()
     {
         var rows = 
@@ -41,7 +41,7 @@ public class OcrNumbersTests
         Assert.Equal("?", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Input_with_a_number_of_lines_that_is_not_a_multiple_of_four_raises_an_error()
     {
         var rows = 
@@ -51,7 +51,7 @@ public class OcrNumbersTests
         Assert.Throws<ArgumentException>(() => OcrNumbers.Convert(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Input_with_a_number_of_columns_that_is_not_a_multiple_of_three_raises_an_error()
     {
         var rows = 
@@ -62,7 +62,7 @@ public class OcrNumbersTests
         Assert.Throws<ArgumentException>(() => OcrNumbers.Convert(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_110101100()
     {
         var rows = 
@@ -74,7 +74,7 @@ public class OcrNumbersTests
         Assert.Equal("110101100", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Garbled_numbers_in_a_string_are_replaced_with_()
     {
         var rows = 
@@ -86,7 +86,7 @@ public class OcrNumbersTests
         Assert.Equal("11?10?1?0", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_2()
     {
         var rows = 
@@ -98,7 +98,7 @@ public class OcrNumbersTests
         Assert.Equal("2", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_3()
     {
         var rows = 
@@ -110,7 +110,7 @@ public class OcrNumbersTests
         Assert.Equal("3", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_4()
     {
         var rows = 
@@ -122,7 +122,7 @@ public class OcrNumbersTests
         Assert.Equal("4", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_5()
     {
         var rows = 
@@ -134,7 +134,7 @@ public class OcrNumbersTests
         Assert.Equal("5", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_6()
     {
         var rows = 
@@ -146,7 +146,7 @@ public class OcrNumbersTests
         Assert.Equal("6", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_7()
     {
         var rows = 
@@ -158,7 +158,7 @@ public class OcrNumbersTests
         Assert.Equal("7", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_8()
     {
         var rows = 
@@ -170,7 +170,7 @@ public class OcrNumbersTests
         Assert.Equal("8", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_9()
     {
         var rows = 
@@ -182,7 +182,7 @@ public class OcrNumbersTests
         Assert.Equal("9", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recognizes_string_of_decimal_numbers()
     {
         var rows = 
@@ -194,7 +194,7 @@ public class OcrNumbersTests
         Assert.Equal("1234567890", actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Numbers_separated_by_empty_lines_are_recognized_lines_are_joined_by_commas_()
     {
         var rows = 

--- a/exercises/octal/OctalTests.cs
+++ b/exercises/octal/OctalTests.cs
@@ -8,79 +8,79 @@ public class OctalTest
         Assert.Equal(1, Octal.ToDecimal("1"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_10_is_decimal_8()
     {
         Assert.Equal(8, Octal.ToDecimal("10"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_17_is_decimal_15()
     {
         Assert.Equal(15, Octal.ToDecimal("17"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_11_is_decimal_9()
     {
         Assert.Equal(9, Octal.ToDecimal("11"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_130_is_decimal_88()
     {
         Assert.Equal(88, Octal.ToDecimal("130"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_2047_is_decimal_1063()
     {
         Assert.Equal(1063, Octal.ToDecimal("2047"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_7777_is_decimal_4095()
     {
         Assert.Equal(4095, Octal.ToDecimal("7777"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_1234567_is_decimal_342391()
     {
         Assert.Equal(342391, Octal.ToDecimal("1234567"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_011_is_decimal_9()
     {
         Assert.Equal(9, Octal.ToDecimal("011"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_carrot_is_decimal_0()
     {
         Assert.Equal(0, Octal.ToDecimal("carrot"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_8_is_decimal_0()
     {
         Assert.Equal(0, Octal.ToDecimal("8"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_9_is_decimal_0()
     {
         Assert.Equal(0, Octal.ToDecimal("9"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_6789_is_decimal_0()
     {
         Assert.Equal(0, Octal.ToDecimal("6789"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octal_abc1z_is_decimal_0()
     {
         Assert.Equal(0, Octal.ToDecimal("abc1z"));

--- a/exercises/palindrome-products/PalindromeProductsTests.cs
+++ b/exercises/palindrome-products/PalindromeProductsTests.cs
@@ -14,7 +14,7 @@ public class PalindromeProductsTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Finds_the_largest_palindrome_from_single_digit_factors()
     {
         var actual = PalindromeProducts.Largest(1, 9);
@@ -23,7 +23,7 @@ public class PalindromeProductsTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_the_smallest_palindrome_from_double_digit_factors()
     {
         var actual = PalindromeProducts.Smallest(10, 99);
@@ -32,7 +32,7 @@ public class PalindromeProductsTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_the_largest_palindrome_from_double_digit_factors()
     {
         var actual = PalindromeProducts.Largest(10, 99);
@@ -41,7 +41,7 @@ public class PalindromeProductsTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_smallest_palindrome_from_triple_digit_factors()
     {
         var actual = PalindromeProducts.Smallest(100, 999);
@@ -50,7 +50,7 @@ public class PalindromeProductsTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_the_largest_palindrome_from_triple_digit_factors()
     {
         var actual = PalindromeProducts.Largest(100, 999);
@@ -59,7 +59,7 @@ public class PalindromeProductsTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_smallest_palindrome_from_four_digit_factors()
     {
         var actual = PalindromeProducts.Smallest(1000, 9999);
@@ -68,7 +68,7 @@ public class PalindromeProductsTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_the_largest_palindrome_from_four_digit_factors()
     {
         var actual = PalindromeProducts.Largest(1000, 9999);
@@ -77,25 +77,25 @@ public class PalindromeProductsTests
         Assert.Equal(expected.Item2, actual.Item2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_result_for_smallest_if_no_palindrome_in_the_range()
     {
         Assert.Throws<ArgumentException>(() => PalindromeProducts.Smallest(1002, 1003));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_result_for_largest_if_no_palindrome_in_the_range()
     {
         Assert.Throws<ArgumentException>(() => PalindromeProducts.Largest(15, 15));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Error_result_for_smallest_if_min_is_more_than_max()
     {
         Assert.Throws<ArgumentException>(() => PalindromeProducts.Smallest(10000, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Error_result_for_largest_if_min_is_more_than_max()
     {
         Assert.Throws<ArgumentException>(() => PalindromeProducts.Largest(2, 1));

--- a/exercises/pangram/PangramTests.cs
+++ b/exercises/pangram/PangramTests.cs
@@ -10,55 +10,55 @@ public class PangramTests
         Assert.False(Pangram.IsPangram(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Perfect_lower_case()
     {
         Assert.True(Pangram.IsPangram("abcdefghijklmnopqrstuvwxyz"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Only_lower_case()
     {
         Assert.True(Pangram.IsPangram("the quick brown fox jumps over the lazy dog"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Missing_the_letter_x()
     {
         Assert.False(Pangram.IsPangram("a quick movement of the enemy will jeopardize five gunboats"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Missing_the_letter_h()
     {
         Assert.False(Pangram.IsPangram("five boxing wizards jump quickly at it"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void With_underscores()
     {
         Assert.True(Pangram.IsPangram("the_quick_brown_fox_jumps_over_the_lazy_dog"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void With_numbers()
     {
         Assert.True(Pangram.IsPangram("the 1 quick brown fox jumps over the 2 lazy dogs"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Missing_letters_replaced_by_numbers()
     {
         Assert.False(Pangram.IsPangram("7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Mixed_case_and_punctuation()
     {
         Assert.True(Pangram.IsPangram("\"Five quacking Zephyrs jolt my wax bed.\""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Case_insensitive()
     {
         Assert.False(Pangram.IsPangram("the quick brown fox jumps over with lazy FX"));

--- a/exercises/parallel-letter-frequency/ParallelLetterFrequencyTests.cs
+++ b/exercises/parallel-letter-frequency/ParallelLetterFrequencyTests.cs
@@ -46,7 +46,7 @@ public class ParallelLetterFrequencyTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_letter()
     {
         var input = new[] { "a" };
@@ -58,7 +58,7 @@ public class ParallelLetterFrequencyTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Case_insensitivity()
     {
         var input = new[] { "aA" };
@@ -70,7 +70,7 @@ public class ParallelLetterFrequencyTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Many_empty_texts_still_mean_no_letters()
     {
         var input = Enumerable.Repeat("  ", 10000);
@@ -79,7 +79,7 @@ public class ParallelLetterFrequencyTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Many_times_the_same_text_gives_a_predictable_result()
     {
         var input = Enumerable.Repeat("abc", 1000);
@@ -93,7 +93,7 @@ public class ParallelLetterFrequencyTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Punctuation_doesnt_count()
     {
         var input = new[] { OdeAnDieFreude };
@@ -101,7 +101,7 @@ public class ParallelLetterFrequencyTests
         Assert.False(actual.ContainsKey(','));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Numbers_dont_count()
     {
         var input = new[] { "Testing, 1, 2, 3" };
@@ -109,7 +109,7 @@ public class ParallelLetterFrequencyTests
         Assert.False(actual.ContainsKey('1'));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_three_anthems_together()
     {
         var input = new[] { OdeAnDieFreude, Wilhelmus, StarSpangledBanner };

--- a/exercises/pascals-triangle/PascalsTriangleTests.cs
+++ b/exercises/pascals-triangle/PascalsTriangleTests.cs
@@ -10,7 +10,7 @@ public class PascalsTriangleTests
         Assert.Empty(PascalsTriangle.Calculate(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_row()
     {
         var expected = new[]
@@ -20,7 +20,7 @@ public class PascalsTriangleTests
         Assert.Equal(expected, PascalsTriangle.Calculate(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_rows()
     {
         var expected = new[]
@@ -31,7 +31,7 @@ public class PascalsTriangleTests
         Assert.Equal(expected, PascalsTriangle.Calculate(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_rows()
     {
         var expected = new[]
@@ -43,7 +43,7 @@ public class PascalsTriangleTests
         Assert.Equal(expected, PascalsTriangle.Calculate(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_rows()
     {
         var expected = new[]
@@ -56,7 +56,7 @@ public class PascalsTriangleTests
         Assert.Equal(expected, PascalsTriangle.Calculate(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Five_rows()
     {
         var expected = new[]
@@ -70,7 +70,7 @@ public class PascalsTriangleTests
         Assert.Equal(expected, PascalsTriangle.Calculate(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Six_rows()
     {
         var expected = new[]
@@ -85,7 +85,7 @@ public class PascalsTriangleTests
         Assert.Equal(expected, PascalsTriangle.Calculate(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ten_rows()
     {
         var expected = new[]

--- a/exercises/perfect-numbers/PerfectNumbersTests.cs
+++ b/exercises/perfect-numbers/PerfectNumbersTests.cs
@@ -11,73 +11,73 @@ public class PerfectNumbersTests
         Assert.Equal(Classification.Perfect, PerfectNumbers.Classify(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Medium_perfect_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Perfect, PerfectNumbers.Classify(28));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Large_perfect_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Perfect, PerfectNumbers.Classify(33550336));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Smallest_abundant_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Abundant, PerfectNumbers.Classify(12));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Medium_abundant_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Abundant, PerfectNumbers.Classify(30));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Large_abundant_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Abundant, PerfectNumbers.Classify(33550335));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Smallest_prime_deficient_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Deficient, PerfectNumbers.Classify(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Smallest_non_prime_deficient_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Deficient, PerfectNumbers.Classify(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Medium_deficient_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Deficient, PerfectNumbers.Classify(32));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Large_deficient_number_is_classified_correctly()
     {
         Assert.Equal(Classification.Deficient, PerfectNumbers.Classify(33550337));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Edge_case_no_factors_other_than_itself_is_classified_correctly()
     {
         Assert.Equal(Classification.Deficient, PerfectNumbers.Classify(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Zero_is_rejected_not_a_natural_number_()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => PerfectNumbers.Classify(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Negative_integer_is_rejected_not_a_natural_number_()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => PerfectNumbers.Classify(-1));

--- a/exercises/phone-number/PhoneNumberTests.cs
+++ b/exercises/phone-number/PhoneNumberTests.cs
@@ -12,119 +12,119 @@ public class PhoneNumberTests
         Assert.Equal("2234567890", PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cleans_numbers_with_dots()
     {
         var phrase = "223.456.7890";
         Assert.Equal("2234567890", PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cleans_numbers_with_multiple_spaces()
     {
         var phrase = "223 456   7890   ";
         Assert.Equal("2234567890", PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_when_9_digits()
     {
         var phrase = "123456789";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_when_11_digits_does_not_start_with_a_1()
     {
         var phrase = "22234567890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_when_11_digits_and_starting_with_1()
     {
         var phrase = "12234567890";
         Assert.Equal("2234567890", PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valid_when_11_digits_and_starting_with_1_even_with_punctuation()
     {
         var phrase = "+1 (223) 456-7890";
         Assert.Equal("2234567890", PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_when_more_than_11_digits()
     {
         var phrase = "321234567890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_with_letters()
     {
         var phrase = "123-abc-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_with_punctuations()
     {
         var phrase = "123-@:!-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_if_area_code_starts_with_0()
     {
         var phrase = "(023) 456-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_if_area_code_starts_with_1()
     {
         var phrase = "(123) 456-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_if_exchange_code_starts_with_0()
     {
         var phrase = "(223) 056-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_if_exchange_code_starts_with_1()
     {
         var phrase = "(223) 156-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_if_area_code_starts_with_0_on_valid_11_digit_number()
     {
         var phrase = "1 (023) 456-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_if_area_code_starts_with_1_on_valid_11_digit_number()
     {
         var phrase = "1 (123) 456-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_if_exchange_code_starts_with_0_on_valid_11_digit_number()
     {
         var phrase = "1 (223) 056-7890";
         Assert.Throws<ArgumentException>(() => PhoneNumber.Clean(phrase));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number()
     {
         var phrase = "1 (223) 156-7890";

--- a/exercises/pig-latin/PigLatinTests.cs
+++ b/exercises/pig-latin/PigLatinTests.cs
@@ -10,127 +10,127 @@ public class PigLatinTests
         Assert.Equal("appleay", PigLatin.Translate("apple"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_e()
     {
         Assert.Equal("earay", PigLatin.Translate("ear"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_i()
     {
         Assert.Equal("iglooay", PigLatin.Translate("igloo"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_o()
     {
         Assert.Equal("objectay", PigLatin.Translate("object"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_u()
     {
         Assert.Equal("underay", PigLatin.Translate("under"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_a_vowel_and_followed_by_a_qu()
     {
         Assert.Equal("equalay", PigLatin.Translate("equal"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_p()
     {
         Assert.Equal("igpay", PigLatin.Translate("pig"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_k()
     {
         Assert.Equal("oalakay", PigLatin.Translate("koala"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_x()
     {
         Assert.Equal("enonxay", PigLatin.Translate("xenon"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_q_without_a_following_u()
     {
         Assert.Equal("atqay", PigLatin.Translate("qat"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_ch()
     {
         Assert.Equal("airchay", PigLatin.Translate("chair"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_qu()
     {
         Assert.Equal("eenquay", PigLatin.Translate("queen"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_qu_and_a_preceding_consonant()
     {
         Assert.Equal("aresquay", PigLatin.Translate("square"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_th()
     {
         Assert.Equal("erapythay", PigLatin.Translate("therapy"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_thr()
     {
         Assert.Equal("ushthray", PigLatin.Translate("thrush"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_sch()
     {
         Assert.Equal("oolschay", PigLatin.Translate("school"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_yt()
     {
         Assert.Equal("yttriaay", PigLatin.Translate("yttria"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Word_beginning_with_xr()
     {
         Assert.Equal("xrayay", PigLatin.Translate("xray"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Y_is_treated_like_a_consonant_at_the_beginning_of_a_word()
     {
         Assert.Equal("ellowyay", PigLatin.Translate("yellow"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Y_is_treated_like_a_vowel_at_the_end_of_a_consonant_cluster()
     {
         Assert.Equal("ythmrhay", PigLatin.Translate("rhythm"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Y_as_second_letter_in_two_letter_word()
     {
         Assert.Equal("ymay", PigLatin.Translate("my"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_whole_phrase()
     {
         Assert.Equal("ickquay astfay unray", PigLatin.Translate("quick fast run"));

--- a/exercises/poker/PokerTests.cs
+++ b/exercises/poker/PokerTests.cs
@@ -13,7 +13,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Highest_card_out_of_all_hands_wins()
     {
         var hands = new[] { "4D 5S 6S 8D 3C", "2S 4C 7S 9H 10H", "3S 4S 5D 6H JH" };
@@ -22,7 +22,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_tie_has_multiple_winners()
     {
         var hands = new[] { "4D 5S 6S 8D 3C", "2S 4C 7S 9H 10H", "3S 4S 5D 6H JH", "3H 4H 5C 6C JD" };
@@ -31,7 +31,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_hands_with_the_same_high_cards_tie_compares_next_highest_ranked_down_to_last_card()
     {
         var hands = new[] { "3S 5H 6S 8D 7H", "2S 5D 6D 8C 7S" };
@@ -40,7 +40,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_pair_beats_high_card()
     {
         var hands = new[] { "4S 5H 6C 8D KH", "2S 4H 6S 4D JH" };
@@ -49,7 +49,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Highest_pair_wins()
     {
         var hands = new[] { "4S 2H 6S 2D JH", "2S 4H 6C 4D JD" };
@@ -58,7 +58,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_pairs_beats_one_pair()
     {
         var hands = new[] { "2S 8H 6S 8D JH", "4S 5H 4C 8C 5C" };
@@ -67,7 +67,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_have_two_pairs_highest_ranked_pair_wins()
     {
         var hands = new[] { "2S 8H 2D 8D 3H", "4S 5H 4C 8S 5D" };
@@ -76,7 +76,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_have_two_pairs_with_the_same_highest_ranked_pair_tie_goes_to_low_pair()
     {
         var hands = new[] { "2S QS 2C QD JH", "JD QH JS 8D QC" };
@@ -85,7 +85,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_have_two_identically_ranked_pairs_tie_goes_to_remaining_card_kicker_()
     {
         var hands = new[] { "JD QH JS 8D QC", "JS QS JC 2D QD" };
@@ -94,7 +94,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_of_a_kind_beats_two_pair()
     {
         var hands = new[] { "2S 8H 2H 8D JH", "4S 5H 4C 8S 4H" };
@@ -103,7 +103,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_have_three_of_a_kind_tie_goes_to_highest_ranked_triplet()
     {
         var hands = new[] { "2S 2H 2C 8D JH", "4S AH AS 8C AD" };
@@ -112,7 +112,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void With_multiple_decks_two_players_can_have_same_three_of_a_kind_ties_go_to_highest_remaining_cards()
     {
         var hands = new[] { "4S AH AS 7C AD", "4S AH AS 8C AD" };
@@ -121,7 +121,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_straight_beats_three_of_a_kind()
     {
         var hands = new[] { "4S 5H 4C 8D 4H", "3S 4D 2S 6D 5C" };
@@ -130,7 +130,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Aces_can_end_a_straight_10_j_q_k_a_()
     {
         var hands = new[] { "4S 5H 4C 8D 4H", "10D JH QS KD AC" };
@@ -139,7 +139,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Aces_can_start_a_straight_a_2_3_4_5_()
     {
         var hands = new[] { "4S 5H 4C 8D 4H", "4D AH 3S 2D 5C" };
@@ -148,7 +148,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_with_a_straight_tie_goes_to_highest_ranked_card()
     {
         var hands = new[] { "4S 6C 7S 8D 5H", "5S 7H 8S 9D 6H" };
@@ -157,7 +157,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Even_though_an_ace_is_usually_high_a_5_high_straight_is_the_lowest_scoring_straight()
     {
         var hands = new[] { "2H 3C 4D 5D 6H", "4S AH 3S 2D 5H" };
@@ -166,7 +166,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Flush_beats_a_straight()
     {
         var hands = new[] { "4C 6H 7D 8D 5H", "2S 4S 5S 6S 7S" };
@@ -175,7 +175,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_have_a_flush_tie_goes_to_high_card_down_to_the_last_one_if_necessary()
     {
         var hands = new[] { "4H 7H 8H 9H 6H", "2S 4S 5S 6S 7S" };
@@ -184,7 +184,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_house_beats_a_flush()
     {
         var hands = new[] { "3H 6H 7H 8H 5H", "4S 5H 4C 5D 4H" };
@@ -193,7 +193,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_have_a_full_house_tie_goes_to_highest_ranked_triplet()
     {
         var hands = new[] { "4H 4S 4D 9S 9D", "5H 5S 5D 8S 8D" };
@@ -202,7 +202,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void With_multiple_decks_both_hands_have_a_full_house_with_the_same_triplet_tie_goes_to_the_pair()
     {
         var hands = new[] { "5H 5S 5D 9S 9D", "5H 5S 5D 8S 8D" };
@@ -211,7 +211,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_of_a_kind_beats_a_full_house()
     {
         var hands = new[] { "4S 5H 4D 5D 4H", "3S 3H 2S 3D 3C" };
@@ -220,7 +220,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_have_four_of_a_kind_tie_goes_to_high_quad()
     {
         var hands = new[] { "2S 2H 2C 8D 2D", "4S 5H 5S 5D 5C" };
@@ -229,7 +229,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void With_multiple_decks_both_hands_with_identical_four_of_a_kind_tie_determined_by_kicker()
     {
         var hands = new[] { "3S 3H 2S 3D 3C", "3S 3H 4S 3D 3C" };
@@ -238,7 +238,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Straight_flush_beats_four_of_a_kind()
     {
         var hands = new[] { "4S 5H 5S 5D 5C", "7S 8S 9S 6S 10S" };
@@ -247,7 +247,7 @@ public class PokerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_hands_have_straight_flush_tie_goes_to_highest_ranked_card()
     {
         var hands = new[] { "4H 6H 7H 8H 5H", "5S 7S 8S 9S 6S" };

--- a/exercises/pov/PovTests.cs
+++ b/exercises/pov/PovTests.cs
@@ -14,7 +14,7 @@ public class PovTests
         Assert.Equal(expected, Pov.FromPov(tree, from));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_reroot_a_tree_with_a_parent_and_one_sibling()
     {
         var tree = new Tree("parent", new Tree("x"), new Tree("sibling"));
@@ -23,7 +23,7 @@ public class PovTests
         Assert.Equal(expected, Pov.FromPov(tree, from));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_reroot_a_tree_with_a_parent_and_many_siblings()
     {
         var tree = new Tree("parent", new Tree("a"), new Tree("x"), new Tree("b"), new Tree("c"));
@@ -32,7 +32,7 @@ public class PovTests
         Assert.Equal(expected, Pov.FromPov(tree, from));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_reroot_a_tree_with_new_root_deeply_nested_in_tree()
     {
         var tree = new Tree("level-0", new Tree("level-1", new Tree("level-2", new Tree("level-3", new Tree("x")))));
@@ -41,7 +41,7 @@ public class PovTests
         Assert.Equal(expected, Pov.FromPov(tree, from));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Moves_children_of_the_new_root_to_same_level_as_former_parent()
     {
         var tree = new Tree("parent", new Tree("x", new Tree("kid-0"), new Tree("kid-1")));
@@ -50,7 +50,7 @@ public class PovTests
         Assert.Equal(expected, Pov.FromPov(tree, from));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_reroot_a_complex_tree_with_cousins()
     {
         var tree = new Tree("grandparent", new Tree("parent", new Tree("x", new Tree("kid-0"), new Tree("kid-1")), new Tree("sibling-0"), new Tree("sibling-1")), new Tree("uncle", new Tree("cousin-0"), new Tree("cousin-1")));
@@ -59,7 +59,7 @@ public class PovTests
         Assert.Equal(expected, Pov.FromPov(tree, from));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Errors_if_target_does_not_exist_in_a_singleton_tree()
     {
         var tree = new Tree("x");
@@ -67,7 +67,7 @@ public class PovTests
         Assert.Throws<ArgumentException>(() => Pov.FromPov(tree, from));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Errors_if_target_does_not_exist_in_a_large_tree()
     {
         var tree = new Tree("parent", new Tree("x", new Tree("kid-0"), new Tree("kid-1")), new Tree("sibling-0"), new Tree("sibling-1"));
@@ -75,7 +75,7 @@ public class PovTests
         Assert.Throws<ArgumentException>(() => Pov.FromPov(tree, from));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_path_to_parent()
     {
         var from = "x";
@@ -85,7 +85,7 @@ public class PovTests
         Assert.Equal(expected, Pov.PathTo(from, to, tree));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_path_to_sibling()
     {
         var from = "x";
@@ -95,7 +95,7 @@ public class PovTests
         Assert.Equal(expected, Pov.PathTo(from, to, tree));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_path_to_cousin()
     {
         var from = "x";
@@ -105,7 +105,7 @@ public class PovTests
         Assert.Equal(expected, Pov.PathTo(from, to, tree));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_path_not_involving_root()
     {
         var from = "x";
@@ -115,7 +115,7 @@ public class PovTests
         Assert.Equal(expected, Pov.PathTo(from, to, tree));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_find_path_from_nodes_other_than_x()
     {
         var from = "a";
@@ -125,7 +125,7 @@ public class PovTests
         Assert.Equal(expected, Pov.PathTo(from, to, tree));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Errors_if_destination_does_not_exist()
     {
         var from = "x";
@@ -134,7 +134,7 @@ public class PovTests
         Assert.Throws<ArgumentException>(() => Pov.PathTo(from, to, tree));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Errors_if_source_does_not_exist()
     {
         var from = "nonexistent";

--- a/exercises/prime-factors/PrimeFactorsTests.cs
+++ b/exercises/prime-factors/PrimeFactorsTests.cs
@@ -10,37 +10,37 @@ public class PrimeFactorsTests
         Assert.Empty(PrimeFactors.Factors(1L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Prime_number()
     {
         Assert.Equal(new[] { 2L }, PrimeFactors.Factors(2L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Square_of_a_prime()
     {
         Assert.Equal(new[] { 3L, 3L }, PrimeFactors.Factors(9L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cube_of_a_prime()
     {
         Assert.Equal(new[] { 2L, 2L, 2L }, PrimeFactors.Factors(8L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Product_of_primes_and_non_primes()
     {
         Assert.Equal(new[] { 2L, 2L, 3L }, PrimeFactors.Factors(12L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Product_of_primes()
     {
         Assert.Equal(new[] { 5L, 17L, 23L, 461L }, PrimeFactors.Factors(901255L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Factors_include_a_large_prime()
     {
         Assert.Equal(new[] { 11L, 9539L, 894119L }, PrimeFactors.Factors(93819012551L));

--- a/exercises/protein-translation/ProteinTranslationTests.cs
+++ b/exercises/protein-translation/ProteinTranslationTests.cs
@@ -10,133 +10,133 @@ public class ProteinTranslationTests
         Assert.Equal(new[] { "Methionine" }, ProteinTranslation.Proteins("AUG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Phenylalanine_rna_sequence_1()
     {
         Assert.Equal(new[] { "Phenylalanine" }, ProteinTranslation.Proteins("UUU"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Phenylalanine_rna_sequence_2()
     {
         Assert.Equal(new[] { "Phenylalanine" }, ProteinTranslation.Proteins("UUC"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Leucine_rna_sequence_1()
     {
         Assert.Equal(new[] { "Leucine" }, ProteinTranslation.Proteins("UUA"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Leucine_rna_sequence_2()
     {
         Assert.Equal(new[] { "Leucine" }, ProteinTranslation.Proteins("UUG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Serine_rna_sequence_1()
     {
         Assert.Equal(new[] { "Serine" }, ProteinTranslation.Proteins("UCU"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Serine_rna_sequence_2()
     {
         Assert.Equal(new[] { "Serine" }, ProteinTranslation.Proteins("UCC"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Serine_rna_sequence_3()
     {
         Assert.Equal(new[] { "Serine" }, ProteinTranslation.Proteins("UCA"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Serine_rna_sequence_4()
     {
         Assert.Equal(new[] { "Serine" }, ProteinTranslation.Proteins("UCG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tyrosine_rna_sequence_1()
     {
         Assert.Equal(new[] { "Tyrosine" }, ProteinTranslation.Proteins("UAU"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tyrosine_rna_sequence_2()
     {
         Assert.Equal(new[] { "Tyrosine" }, ProteinTranslation.Proteins("UAC"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cysteine_rna_sequence_1()
     {
         Assert.Equal(new[] { "Cysteine" }, ProteinTranslation.Proteins("UGU"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cysteine_rna_sequence_2()
     {
         Assert.Equal(new[] { "Cysteine" }, ProteinTranslation.Proteins("UGC"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tryptophan_rna_sequence()
     {
         Assert.Equal(new[] { "Tryptophan" }, ProteinTranslation.Proteins("UGG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Stop_codon_rna_sequence_1()
     {
         Assert.Empty(ProteinTranslation.Proteins("UAA"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Stop_codon_rna_sequence_2()
     {
         Assert.Empty(ProteinTranslation.Proteins("UAG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Stop_codon_rna_sequence_3()
     {
         Assert.Empty(ProteinTranslation.Proteins("UGA"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Translate_rna_strand_into_correct_protein_list()
     {
         Assert.Equal(new[] { "Methionine", "Phenylalanine", "Tryptophan" }, ProteinTranslation.Proteins("AUGUUUUGG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Translation_stops_if_stop_codon_at_beginning_of_sequence()
     {
         Assert.Empty(ProteinTranslation.Proteins("UAGUGG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Translation_stops_if_stop_codon_at_end_of_two_codon_sequence()
     {
         Assert.Equal(new[] { "Tryptophan" }, ProteinTranslation.Proteins("UGGUAG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Translation_stops_if_stop_codon_at_end_of_three_codon_sequence()
     {
         Assert.Equal(new[] { "Methionine", "Phenylalanine" }, ProteinTranslation.Proteins("AUGUUUUAA"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Translation_stops_if_stop_codon_in_middle_of_three_codon_sequence()
     {
         Assert.Equal(new[] { "Tryptophan" }, ProteinTranslation.Proteins("UGGUAGUGG"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Translation_stops_if_stop_codon_in_middle_of_six_codon_sequence()
     {
         Assert.Equal(new[] { "Tryptophan", "Cysteine", "Tyrosine" }, ProteinTranslation.Proteins("UGGUGUUAUUAAUGGUUU"));

--- a/exercises/proverb/ProverbTests.cs
+++ b/exercises/proverb/ProverbTests.cs
@@ -13,7 +13,7 @@ public class ProverbTests
         Assert.Equal(expected, Proverb.Recite(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_piece()
     {
         var strings = new[]
@@ -27,7 +27,7 @@ public class ProverbTests
         Assert.Equal(expected, Proverb.Recite(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_pieces()
     {
         var strings = new[]
@@ -43,7 +43,7 @@ public class ProverbTests
         Assert.Equal(expected, Proverb.Recite(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_pieces()
     {
         var strings = new[]
@@ -61,7 +61,7 @@ public class ProverbTests
         Assert.Equal(expected, Proverb.Recite(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_proverb()
     {
         var strings = new[]
@@ -87,7 +87,7 @@ public class ProverbTests
         Assert.Equal(expected, Proverb.Recite(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_pieces_modernized()
     {
         var strings = new[]

--- a/exercises/pythagorean-triplet/PythagoreanTripletTests.cs
+++ b/exercises/pythagorean-triplet/PythagoreanTripletTests.cs
@@ -14,7 +14,7 @@ public class PythagoreanTripletTests
         }, PythagoreanTriplet.TripletsWithSum(12));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Triplets_whose_sum_is_108()
     {
         Assert.Equal(new[]
@@ -23,7 +23,7 @@ public class PythagoreanTripletTests
         }, PythagoreanTriplet.TripletsWithSum(108));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Triplets_whose_sum_is_1000()
     {
         Assert.Equal(new[]
@@ -32,13 +32,13 @@ public class PythagoreanTripletTests
         }, PythagoreanTriplet.TripletsWithSum(1000));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_matching_triplets_for_1001()
     {
         Assert.Equal(Array.Empty<(int, int, int)>(), PythagoreanTriplet.TripletsWithSum(1001));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Returns_all_matching_triplets()
     {
         Assert.Equal(new[]
@@ -48,7 +48,7 @@ public class PythagoreanTripletTests
         }, PythagoreanTriplet.TripletsWithSum(90));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Several_matching_triplets()
     {
         Assert.Equal(new[]
@@ -64,7 +64,7 @@ public class PythagoreanTripletTests
         }, PythagoreanTriplet.TripletsWithSum(840));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Triplets_for_large_number()
     {
         Assert.Equal(new[]

--- a/exercises/queen-attack/QueenAttackTests.cs
+++ b/exercises/queen-attack/QueenAttackTests.cs
@@ -11,31 +11,31 @@ public class QueenAttackTests
         var actual = QueenAttack.Create(2, 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Queen_must_have_positive_row()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => QueenAttack.Create(-2, 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Queen_must_have_row_on_board()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => QueenAttack.Create(8, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Queen_must_have_positive_column()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => QueenAttack.Create(2, -2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Queen_must_have_column_on_board()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => QueenAttack.Create(4, 8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_not_attack()
     {
         var whiteQueen = QueenAttack.Create(2,4);
@@ -43,7 +43,7 @@ public class QueenAttackTests
         Assert.False(QueenAttack.CanAttack(whiteQueen, blackQueen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_attack_on_same_row()
     {
         var whiteQueen = QueenAttack.Create(2,4);
@@ -51,7 +51,7 @@ public class QueenAttackTests
         Assert.True(QueenAttack.CanAttack(whiteQueen, blackQueen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_attack_on_same_column()
     {
         var whiteQueen = QueenAttack.Create(4,5);
@@ -59,7 +59,7 @@ public class QueenAttackTests
         Assert.True(QueenAttack.CanAttack(whiteQueen, blackQueen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_attack_on_first_diagonal()
     {
         var whiteQueen = QueenAttack.Create(2,2);
@@ -67,7 +67,7 @@ public class QueenAttackTests
         Assert.True(QueenAttack.CanAttack(whiteQueen, blackQueen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_attack_on_second_diagonal()
     {
         var whiteQueen = QueenAttack.Create(2,2);
@@ -75,7 +75,7 @@ public class QueenAttackTests
         Assert.True(QueenAttack.CanAttack(whiteQueen, blackQueen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_attack_on_third_diagonal()
     {
         var whiteQueen = QueenAttack.Create(2,2);
@@ -83,7 +83,7 @@ public class QueenAttackTests
         Assert.True(QueenAttack.CanAttack(whiteQueen, blackQueen));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_attack_on_fourth_diagonal()
     {
         var whiteQueen = QueenAttack.Create(1,7);

--- a/exercises/rail-fence-cipher/RailFenceCipherTests.cs
+++ b/exercises/rail-fence-cipher/RailFenceCipherTests.cs
@@ -13,7 +13,7 @@ public class RailFenceCipherTests
         Assert.Equal(expected, sut.Encode(msg));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_with_three_rails()
     {
         var msg = "WEAREDISCOVEREDFLEEATONCE";
@@ -22,7 +22,7 @@ public class RailFenceCipherTests
         Assert.Equal(expected, sut.Encode(msg));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_with_ending_in_the_middle()
     {
         var msg = "EXERCISES";
@@ -31,7 +31,7 @@ public class RailFenceCipherTests
         Assert.Equal(expected, sut.Encode(msg));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_with_three_rails()
     {
         var msg = "TEITELHDVLSNHDTISEIIEA";
@@ -40,7 +40,7 @@ public class RailFenceCipherTests
         Assert.Equal(expected, sut.Decode(msg));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_with_five_rails()
     {
         var msg = "EIEXMSMESAORIWSCE";
@@ -49,7 +49,7 @@ public class RailFenceCipherTests
         Assert.Equal(expected, sut.Decode(msg));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Decode_with_six_rails()
     {
         var msg = "133714114238148966225439541018335470986172518171757571896261";

--- a/exercises/raindrops/RaindropsTests.cs
+++ b/exercises/raindrops/RaindropsTests.cs
@@ -10,103 +10,103 @@ public class RaindropsTests
         Assert.Equal("1", Raindrops.Convert(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_3_is_pling()
     {
         Assert.Equal("Pling", Raindrops.Convert(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_5_is_plang()
     {
         Assert.Equal("Plang", Raindrops.Convert(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_7_is_plong()
     {
         Assert.Equal("Plong", Raindrops.Convert(7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_6_is_pling_as_it_has_a_factor_3()
     {
         Assert.Equal("Pling", Raindrops.Convert(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_2_to_the_power_3_does_not_make_a_raindrop_sound_as_3_is_the_exponent_not_the_base()
     {
         Assert.Equal("8", Raindrops.Convert(8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_9_is_pling_as_it_has_a_factor_3()
     {
         Assert.Equal("Pling", Raindrops.Convert(9));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_10_is_plang_as_it_has_a_factor_5()
     {
         Assert.Equal("Plang", Raindrops.Convert(10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_14_is_plong_as_it_has_a_factor_of_7()
     {
         Assert.Equal("Plong", Raindrops.Convert(14));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_15_is_plingplang_as_it_has_factors_3_and_5()
     {
         Assert.Equal("PlingPlang", Raindrops.Convert(15));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_21_is_plingplong_as_it_has_factors_3_and_7()
     {
         Assert.Equal("PlingPlong", Raindrops.Convert(21));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_25_is_plang_as_it_has_a_factor_5()
     {
         Assert.Equal("Plang", Raindrops.Convert(25));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_27_is_pling_as_it_has_a_factor_3()
     {
         Assert.Equal("Pling", Raindrops.Convert(27));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_35_is_plangplong_as_it_has_factors_5_and_7()
     {
         Assert.Equal("PlangPlong", Raindrops.Convert(35));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_49_is_plong_as_it_has_a_factor_7()
     {
         Assert.Equal("Plong", Raindrops.Convert(49));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_52_is_52()
     {
         Assert.Equal("52", Raindrops.Convert(52));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_105_is_plingplangplong_as_it_has_factors_3_5_and_7()
     {
         Assert.Equal("PlingPlangPlong", Raindrops.Convert(105));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_sound_for_3125_is_plang_as_it_has_a_factor_5()
     {
         Assert.Equal("Plang", Raindrops.Convert(3125));

--- a/exercises/rational-numbers/RationalNumbersTests.cs
+++ b/exercises/rational-numbers/RationalNumbersTests.cs
@@ -10,223 +10,223 @@ public class RationalNumbersTests
         Assert.Equal(new RationalNumber(7, 6), new RationalNumber(1, 2) + (new RationalNumber(2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_a_positive_rational_number_and_a_negative_rational_number()
     {
         Assert.Equal(new RationalNumber(-1, 6), new RationalNumber(1, 2) + (new RationalNumber(-2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_two_negative_rational_numbers()
     {
         Assert.Equal(new RationalNumber(-7, 6), new RationalNumber(-1, 2) + (new RationalNumber(-2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_a_rational_number_to_its_additive_inverse()
     {
         Assert.Equal(new RationalNumber(0, 1), new RationalNumber(1, 2) + (new RationalNumber(-1, 2)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_two_positive_rational_numbers()
     {
         Assert.Equal(new RationalNumber(-1, 6), new RationalNumber(1, 2) - (new RationalNumber(2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_a_positive_rational_number_and_a_negative_rational_number()
     {
         Assert.Equal(new RationalNumber(7, 6), new RationalNumber(1, 2) - (new RationalNumber(-2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_two_negative_rational_numbers()
     {
         Assert.Equal(new RationalNumber(1, 6), new RationalNumber(-1, 2) - (new RationalNumber(-2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtract_a_rational_number_from_itself()
     {
         Assert.Equal(new RationalNumber(0, 1), new RationalNumber(1, 2) - (new RationalNumber(1, 2)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_two_positive_rational_numbers()
     {
         Assert.Equal(new RationalNumber(1, 3), new RationalNumber(1, 2) * (new RationalNumber(2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_a_negative_rational_number_by_a_positive_rational_number()
     {
         Assert.Equal(new RationalNumber(-1, 3), new RationalNumber(-1, 2) * (new RationalNumber(2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_two_negative_rational_numbers()
     {
         Assert.Equal(new RationalNumber(1, 3), new RationalNumber(-1, 2) * (new RationalNumber(-2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_a_rational_number_by_its_reciprocal()
     {
         Assert.Equal(new RationalNumber(1, 1), new RationalNumber(1, 2) * (new RationalNumber(2, 1)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_a_rational_number_by_1()
     {
         Assert.Equal(new RationalNumber(1, 2), new RationalNumber(1, 2) * (new RationalNumber(1, 1)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiply_a_rational_number_by_0()
     {
         Assert.Equal(new RationalNumber(0, 1), new RationalNumber(1, 2) * (new RationalNumber(0, 1)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Divide_two_positive_rational_numbers()
     {
         Assert.Equal(new RationalNumber(3, 4), new RationalNumber(1, 2) / (new RationalNumber(2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Divide_a_positive_rational_number_by_a_negative_rational_number()
     {
         Assert.Equal(new RationalNumber(-3, 4), new RationalNumber(1, 2) / (new RationalNumber(-2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Divide_two_negative_rational_numbers()
     {
         Assert.Equal(new RationalNumber(3, 4), new RationalNumber(-1, 2) / (new RationalNumber(-2, 3)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Divide_a_rational_number_by_1()
     {
         Assert.Equal(new RationalNumber(1, 2), new RationalNumber(1, 2) / (new RationalNumber(1, 1)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_positive_rational_number()
     {
         Assert.Equal(new RationalNumber(1, 2), new RationalNumber(1, 2).Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_positive_rational_number_with_negative_numerator_and_denominator()
     {
         Assert.Equal(new RationalNumber(1, 2), new RationalNumber(-1, -2).Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_negative_rational_number()
     {
         Assert.Equal(new RationalNumber(1, 2), new RationalNumber(-1, 2).Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_a_negative_rational_number_with_negative_denominator()
     {
         Assert.Equal(new RationalNumber(1, 2), new RationalNumber(1, -2).Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Absolute_value_of_zero()
     {
         Assert.Equal(new RationalNumber(0, 1), new RationalNumber(0, 1).Abs());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_a_positive_rational_number_to_a_positive_integer_power()
     {
         Assert.Equal(new RationalNumber(1, 8), new RationalNumber(1, 2).Exprational(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_a_negative_rational_number_to_a_positive_integer_power()
     {
         Assert.Equal(new RationalNumber(-1, 8), new RationalNumber(-1, 2).Exprational(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_zero_to_an_integer_power()
     {
         Assert.Equal(new RationalNumber(0, 1), new RationalNumber(0, 1).Exprational(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_one_to_an_integer_power()
     {
         Assert.Equal(new RationalNumber(1, 1), new RationalNumber(1, 1).Exprational(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_a_positive_rational_number_to_the_power_of_zero()
     {
         Assert.Equal(new RationalNumber(1, 1), new RationalNumber(1, 2).Exprational(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_a_negative_rational_number_to_the_power_of_zero()
     {
         Assert.Equal(new RationalNumber(1, 1), new RationalNumber(-1, 2).Exprational(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_a_real_number_to_a_positive_rational_number()
     {
         Assert.Equal(16, 8.Expreal(new RationalNumber(4, 3)), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_a_real_number_to_a_negative_rational_number()
     {
         Assert.Equal(0.33333334, 9.Expreal(new RationalNumber(-1, 2)), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Raise_a_real_number_to_a_zero_rational_number()
     {
         Assert.Equal(1, 2.Expreal(new RationalNumber(0, 1)), precision: 7);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reduce_a_positive_rational_number_to_lowest_terms()
     {
         Assert.Equal(new RationalNumber(1, 2), new RationalNumber(2, 4).Reduce());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reduce_a_negative_rational_number_to_lowest_terms()
     {
         Assert.Equal(new RationalNumber(-2, 3), new RationalNumber(-4, 6).Reduce());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reduce_a_rational_number_with_a_negative_denominator_to_lowest_terms()
     {
         Assert.Equal(new RationalNumber(-1, 3), new RationalNumber(3, -9).Reduce());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reduce_zero_to_lowest_terms()
     {
         Assert.Equal(new RationalNumber(0, 1), new RationalNumber(0, 6).Reduce());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reduce_an_integer_to_lowest_terms()
     {
         Assert.Equal(new RationalNumber(-2, 1), new RationalNumber(-14, 7).Reduce());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reduce_one_to_lowest_terms()
     {
         Assert.Equal(new RationalNumber(1, 1), new RationalNumber(13, 13).Reduce());

--- a/exercises/react/ReactTests.cs
+++ b/exercises/react/ReactTests.cs
@@ -14,7 +14,7 @@ public class ReactTests
         Assert.Equal(10, input.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void An_input_cells_value_can_be_set()
     {
         var sut = new Reactor();
@@ -23,7 +23,7 @@ public class ReactTests
         Assert.Equal(20, input.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Compute_cells_calculate_initial_value()
     {
         var sut = new Reactor();
@@ -32,7 +32,7 @@ public class ReactTests
         Assert.Equal(2, output.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Compute_cells_take_inputs_in_the_right_order()
     {
         var sut = new Reactor();
@@ -42,7 +42,7 @@ public class ReactTests
         Assert.Equal(21, output.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Compute_cells_update_value_when_dependencies_are_changed()
     {
         var sut = new Reactor();
@@ -52,7 +52,7 @@ public class ReactTests
         Assert.Equal(4, output.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Compute_cells_can_depend_on_other_compute_cells()
     {
         var sut = new Reactor();
@@ -65,7 +65,7 @@ public class ReactTests
         Assert.Equal(96, output.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Compute_cells_fire_callbacks()
     {
         var sut = new Reactor();
@@ -78,7 +78,7 @@ public class ReactTests
         Fake.ClearRecordedCalls(callback1);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Callback_cells_only_fire_on_change()
     {
         var sut = new Reactor();
@@ -93,7 +93,7 @@ public class ReactTests
         Fake.ClearRecordedCalls(callback1);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Callbacks_do_not_report_already_reported_values()
     {
         var sut = new Reactor();
@@ -109,7 +109,7 @@ public class ReactTests
         Fake.ClearRecordedCalls(callback1);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Callbacks_can_fire_from_multiple_cells()
     {
         var sut = new Reactor();
@@ -127,7 +127,7 @@ public class ReactTests
         Fake.ClearRecordedCalls(callback2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Callbacks_can_be_added_and_removed()
     {
         var sut = new Reactor();
@@ -149,7 +149,7 @@ public class ReactTests
         A.CallTo(() => callback1.Invoke(A<object>._, A<int>._)).MustNotHaveHappened();
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Removing_a_callback_multiple_times_doesnt_interfere_with_other_callbacks()
     {
         var sut = new Reactor();
@@ -166,7 +166,7 @@ public class ReactTests
         A.CallTo(() => callback1.Invoke(A<object>._, A<int>._)).MustNotHaveHappened();
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Callbacks_should_only_be_called_once_even_if_multiple_dependencies_change()
     {
         var sut = new Reactor();
@@ -182,7 +182,7 @@ public class ReactTests
         Fake.ClearRecordedCalls(callback1);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Callbacks_should_not_be_called_if_dependencies_change_but_output_value_doesnt_change()
     {
         var sut = new Reactor();

--- a/exercises/rectangles/RectanglesTests.cs
+++ b/exercises/rectangles/RectanglesTests.cs
@@ -12,7 +12,7 @@ public class RectanglesTests
         Assert.Equal(0, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_columns()
     {
         var strings = new[]
@@ -22,7 +22,7 @@ public class RectanglesTests
         Assert.Equal(0, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_rectangles()
     {
         var strings = new[]
@@ -32,7 +32,7 @@ public class RectanglesTests
         Assert.Equal(0, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_rectangle()
     {
         var strings = new[]
@@ -44,7 +44,7 @@ public class RectanglesTests
         Assert.Equal(1, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_rectangles_without_shared_parts()
     {
         var strings = new[]
@@ -58,7 +58,7 @@ public class RectanglesTests
         Assert.Equal(2, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Five_rectangles_with_shared_parts()
     {
         var strings = new[]
@@ -72,7 +72,7 @@ public class RectanglesTests
         Assert.Equal(5, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rectangle_of_height_1_is_counted()
     {
         var strings = new[]
@@ -83,7 +83,7 @@ public class RectanglesTests
         Assert.Equal(1, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rectangle_of_width_1_is_counted()
     {
         var strings = new[]
@@ -95,7 +95,7 @@ public class RectanglesTests
         Assert.Equal(1, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_1x1_square_is_counted()
     {
         var strings = new[]
@@ -106,7 +106,7 @@ public class RectanglesTests
         Assert.Equal(1, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Only_complete_rectangles_are_counted()
     {
         var strings = new[]
@@ -120,7 +120,7 @@ public class RectanglesTests
         Assert.Equal(1, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rectangles_can_be_of_different_sizes()
     {
         var strings = new[]
@@ -134,7 +134,7 @@ public class RectanglesTests
         Assert.Equal(3, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Corner_is_required_for_a_rectangle_to_be_complete()
     {
         var strings = new[]
@@ -148,7 +148,7 @@ public class RectanglesTests
         Assert.Equal(2, Rectangles.Count(strings));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Large_input_with_many_rectangles()
     {
         var strings = new[]

--- a/exercises/resistor-color/ResistorColorTests.cs
+++ b/exercises/resistor-color/ResistorColorTests.cs
@@ -10,19 +10,19 @@ public class ResistorColorTests
         Assert.Equal(0, ResistorColor.ColorCode("black"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void White()
     {
         Assert.Equal(9, ResistorColor.ColorCode("white"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Orange()
     {
         Assert.Equal(3, ResistorColor.ColorCode("orange"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Colors()
     {
         Assert.Equal(new[] { "black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white" }, ResistorColor.Colors());

--- a/exercises/rest-api/RestApiTests.cs
+++ b/exercises/rest-api/RestApiTests.cs
@@ -15,7 +15,7 @@ public class RestApiTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Add_user()
     {
         var url = "/add";
@@ -27,7 +27,7 @@ public class RestApiTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Get_single_user()
     {
         var url = "/users";
@@ -39,7 +39,7 @@ public class RestApiTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Both_users_have_0_balance()
     {
         var url = "/iou";
@@ -51,7 +51,7 @@ public class RestApiTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Borrower_has_negative_balance()
     {
         var url = "/iou";
@@ -63,7 +63,7 @@ public class RestApiTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Lender_has_negative_balance()
     {
         var url = "/iou";
@@ -75,7 +75,7 @@ public class RestApiTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Lender_owes_borrower()
     {
         var url = "/iou";
@@ -87,7 +87,7 @@ public class RestApiTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Lender_owes_borrower_less_than_new_loan()
     {
         var url = "/iou";
@@ -99,7 +99,7 @@ public class RestApiTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Lender_owes_borrower_same_as_new_loan()
     {
         var url = "/iou";

--- a/exercises/reverse-string/ReverseStringTests.cs
+++ b/exercises/reverse-string/ReverseStringTests.cs
@@ -10,31 +10,31 @@ public class ReverseStringTests
         Assert.Equal("", ReverseString.Reverse(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_word()
     {
         Assert.Equal("tobor", ReverseString.Reverse("robot"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_capitalized_word()
     {
         Assert.Equal("nemaR", ReverseString.Reverse("Ramen"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_sentence_with_punctuation()
     {
         Assert.Equal("!yrgnuh m'I", ReverseString.Reverse("I'm hungry!"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_palindrome()
     {
         Assert.Equal("racecar", ReverseString.Reverse("racecar"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void An_even_sized_word()
     {
         Assert.Equal("reward", ReverseString.Reverse("drawer"));

--- a/exercises/rna-transcription/RnaTranscriptionTests.cs
+++ b/exercises/rna-transcription/RnaTranscriptionTests.cs
@@ -10,31 +10,31 @@ public class RnaTranscriptionTests
         Assert.Equal("", RnaTranscription.ToRna(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rna_complement_of_cytosine_is_guanine()
     {
         Assert.Equal("G", RnaTranscription.ToRna("C"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rna_complement_of_guanine_is_cytosine()
     {
         Assert.Equal("C", RnaTranscription.ToRna("G"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rna_complement_of_thymine_is_adenine()
     {
         Assert.Equal("A", RnaTranscription.ToRna("T"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rna_complement_of_adenine_is_uracil()
     {
         Assert.Equal("U", RnaTranscription.ToRna("A"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rna_complement()
     {
         Assert.Equal("UGCACCAGAAUU", RnaTranscription.ToRna("ACGTGGTCTTAA"));

--- a/exercises/robot-name/RobotNameTests.cs
+++ b/exercises/robot-name/RobotNameTests.cs
@@ -11,20 +11,20 @@ public class RobotNameTests
         Assert.Matches(@"^[A-Z]{2}\d{3}$", robot.Name);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Name_is_the_same_each_time()
     {
         Assert.Equal(robot.Name, robot.Name);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Different_robots_have_different_names()
     {
         var robot2 = new Robot();
         Assert.NotEqual(robot2.Name, robot.Name);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_reset_the_name()
     {
         var originalName = robot.Name;
@@ -32,14 +32,14 @@ public class RobotNameTests
         Assert.NotEqual(originalName, robot.Name);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void After_reset_the_name_is_valid()
     {
         robot.Reset();
         Assert.Matches(@"^[A-Z]{2}\d{3}$", robot.Name);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Robot_names_are_unique()
     {
         var names = new HashSet<string>();

--- a/exercises/robot-simulator/RobotSimulatorTests.cs
+++ b/exercises/robot-simulator/RobotSimulatorTests.cs
@@ -13,7 +13,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Create_robot_at_negative_position_facing_south()
     {
         var sut = new RobotSimulator(Direction.South, -1, -1);
@@ -22,7 +22,7 @@ public class RobotSimulatorTests
         Assert.Equal(-1, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotating_clockwise_changes_north_to_east()
     {
         var sut = new RobotSimulator(Direction.North, 0, 0);
@@ -32,7 +32,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotating_clockwise_changes_east_to_south()
     {
         var sut = new RobotSimulator(Direction.East, 0, 0);
@@ -42,7 +42,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotating_clockwise_changes_south_to_west()
     {
         var sut = new RobotSimulator(Direction.South, 0, 0);
@@ -52,7 +52,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotating_clockwise_changes_west_to_north()
     {
         var sut = new RobotSimulator(Direction.West, 0, 0);
@@ -62,7 +62,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotating_counter_clockwise_changes_north_to_west()
     {
         var sut = new RobotSimulator(Direction.North, 0, 0);
@@ -72,7 +72,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotating_counter_clockwise_changes_west_to_south()
     {
         var sut = new RobotSimulator(Direction.West, 0, 0);
@@ -82,7 +82,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotating_counter_clockwise_changes_south_to_east()
     {
         var sut = new RobotSimulator(Direction.South, 0, 0);
@@ -92,7 +92,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotating_counter_clockwise_changes_east_to_north()
     {
         var sut = new RobotSimulator(Direction.East, 0, 0);
@@ -102,7 +102,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Moving_forward_one_facing_north_increments_y()
     {
         var sut = new RobotSimulator(Direction.North, 0, 0);
@@ -112,7 +112,7 @@ public class RobotSimulatorTests
         Assert.Equal(1, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Moving_forward_one_facing_south_decrements_y()
     {
         var sut = new RobotSimulator(Direction.South, 0, 0);
@@ -122,7 +122,7 @@ public class RobotSimulatorTests
         Assert.Equal(-1, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Moving_forward_one_facing_east_increments_x()
     {
         var sut = new RobotSimulator(Direction.East, 0, 0);
@@ -132,7 +132,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Moving_forward_one_facing_west_decrements_x()
     {
         var sut = new RobotSimulator(Direction.West, 0, 0);
@@ -142,7 +142,7 @@ public class RobotSimulatorTests
         Assert.Equal(0, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Follow_series_of_instructions_moving_east_and_north_from_readme()
     {
         var sut = new RobotSimulator(Direction.North, 7, 3);
@@ -152,7 +152,7 @@ public class RobotSimulatorTests
         Assert.Equal(4, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Follow_series_of_instructions_moving_west_and_north()
     {
         var sut = new RobotSimulator(Direction.North, 0, 0);
@@ -162,7 +162,7 @@ public class RobotSimulatorTests
         Assert.Equal(1, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Follow_series_of_instructions_moving_west_and_south()
     {
         var sut = new RobotSimulator(Direction.East, 2, -7);
@@ -172,7 +172,7 @@ public class RobotSimulatorTests
         Assert.Equal(-8, sut.Y);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Follow_series_of_instructions_moving_east_and_north()
     {
         var sut = new RobotSimulator(Direction.South, 8, 4);

--- a/exercises/roman-numerals/RomanNumeralsTests.cs
+++ b/exercises/roman-numerals/RomanNumeralsTests.cs
@@ -10,109 +10,109 @@ public class RomanNumeralsTests
         Assert.Equal("I", 1.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_2_is_two_is()
     {
         Assert.Equal("II", 2.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_3_is_three_is()
     {
         Assert.Equal("III", 3.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_4_being_5_1_is_iv()
     {
         Assert.Equal("IV", 4.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_5_is_a_single_v()
     {
         Assert.Equal("V", 5.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_6_being_5_1_is_vi()
     {
         Assert.Equal("VI", 6.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_9_being_10_1_is_ix()
     {
         Assert.Equal("IX", 9.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_20_is_two_xs()
     {
         Assert.Equal("XXVII", 27.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_48_is_not_50_2_but_rather_40_8()
     {
         Assert.Equal("XLVIII", 48.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_49_is_not_40_5_4_but_rather_50_10_10_1()
     {
         Assert.Equal("XLIX", 49.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_50_is_a_single_l()
     {
         Assert.Equal("LIX", 59.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_90_being_100_10_is_xc()
     {
         Assert.Equal("XCIII", 93.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_100_is_a_single_c()
     {
         Assert.Equal("CXLI", 141.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_60_being_50_10_is_lx()
     {
         Assert.Equal("CLXIII", 163.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_400_being_500_100_is_cd()
     {
         Assert.Equal("CDII", 402.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_500_is_a_single_d()
     {
         Assert.Equal("DLXXV", 575.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_900_being_1000_100_is_cm()
     {
         Assert.Equal("CMXI", 911.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_1000_is_a_single_m()
     {
         Assert.Equal("MXXIV", 1024.ToRoman());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Number_3000_is_three_ms()
     {
         Assert.Equal("MMM", 3000.ToRoman());

--- a/exercises/rotational-cipher/RotationalCipherTests.cs
+++ b/exercises/rotational-cipher/RotationalCipherTests.cs
@@ -10,55 +10,55 @@ public class RotationalCipherTests
         Assert.Equal("a", RotationalCipher.Rotate("a", 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_a_by_1()
     {
         Assert.Equal("b", RotationalCipher.Rotate("a", 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_a_by_26_same_output_as_input()
     {
         Assert.Equal("a", RotationalCipher.Rotate("a", 26));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_m_by_13()
     {
         Assert.Equal("z", RotationalCipher.Rotate("m", 13));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_n_by_13_with_wrap_around_alphabet()
     {
         Assert.Equal("a", RotationalCipher.Rotate("n", 13));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_capital_letters()
     {
         Assert.Equal("TRL", RotationalCipher.Rotate("OMG", 5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_spaces()
     {
         Assert.Equal("T R L", RotationalCipher.Rotate("O M G", 5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_numbers()
     {
         Assert.Equal("Xiwxmrk 1 2 3 xiwxmrk", RotationalCipher.Rotate("Testing 1 2 3 testing", 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_punctuation()
     {
         Assert.Equal("Gzo'n zvo, Bmviyhv!", RotationalCipher.Rotate("Let's eat, Grandma!", 21));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rotate_all_letters()
     {
         Assert.Equal("Gur dhvpx oebja sbk whzcf bire gur ynml qbt.", RotationalCipher.Rotate("The quick brown fox jumps over the lazy dog.", 13));

--- a/exercises/run-length-encoding/RunLengthEncodingTests.cs
+++ b/exercises/run-length-encoding/RunLengthEncodingTests.cs
@@ -10,73 +10,73 @@ public class RunLengthEncodingTests
         Assert.Equal("", RunLengthEncoding.Encode(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_encode_a_string_single_characters_only_are_encoded_without_count()
     {
         Assert.Equal("XYZ", RunLengthEncoding.Encode("XYZ"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_encode_a_string_string_with_no_single_characters()
     {
         Assert.Equal("2A3B4C", RunLengthEncoding.Encode("AABBBCCCC"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_encode_a_string_single_characters_mixed_with_repeated_characters()
     {
         Assert.Equal("12WB12W3B24WB", RunLengthEncoding.Encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_encode_a_string_multiple_whitespace_mixed_in_string()
     {
         Assert.Equal("2 hs2q q2w2 ", RunLengthEncoding.Encode("  hsqq qww  "));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_encode_a_string_lowercase_characters()
     {
         Assert.Equal("2a3b4c", RunLengthEncoding.Encode("aabbbcccc"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_decode_a_string_empty_string()
     {
         Assert.Equal("", RunLengthEncoding.Decode(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_decode_a_string_single_characters_only()
     {
         Assert.Equal("XYZ", RunLengthEncoding.Decode("XYZ"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_decode_a_string_string_with_no_single_characters()
     {
         Assert.Equal("AABBBCCCC", RunLengthEncoding.Decode("2A3B4C"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_decode_a_string_single_characters_with_repeated_characters()
     {
         Assert.Equal("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB", RunLengthEncoding.Decode("12WB12W3B24WB"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_decode_a_string_multiple_whitespace_mixed_in_string()
     {
         Assert.Equal("  hsqq qww  ", RunLengthEncoding.Decode("2 hs2q q2w2 "));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Run_length_decode_a_string_lower_case_string()
     {
         Assert.Equal("aabbbcccc", RunLengthEncoding.Decode("2a3b4c"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Encode_and_then_decode_encode_followed_by_decode_gives_original_string()
     {
         Assert.Equal("zzz ZZ  zZ", RunLengthEncoding.Decode(RunLengthEncoding.Encode("zzz ZZ  zZ")));

--- a/exercises/saddle-points/SaddlePointsTests.cs
+++ b/exercises/saddle-points/SaddlePointsTests.cs
@@ -19,7 +19,7 @@ public class SaddlePointsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_identify_that_empty_matrix_has_no_saddle_points()
     {
         var matrix = new int[,] { };
@@ -27,7 +27,7 @@ public class SaddlePointsTests
         Assert.Empty(actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_identify_lack_of_saddle_points_when_there_are_none()
     {
         var matrix = new[,]
@@ -40,7 +40,7 @@ public class SaddlePointsTests
         Assert.Empty(actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_identify_multiple_saddle_points_in_a_column()
     {
         var matrix = new[,]
@@ -54,7 +54,7 @@ public class SaddlePointsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_identify_multiple_saddle_points_in_a_row()
     {
         var matrix = new[,]
@@ -68,7 +68,7 @@ public class SaddlePointsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_identify_saddle_point_in_bottom_right_corner()
     {
         var matrix = new[,]
@@ -82,7 +82,7 @@ public class SaddlePointsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_identify_saddle_points_in_a_non_square_matrix()
     {
         var matrix = new[,]
@@ -95,7 +95,7 @@ public class SaddlePointsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_identify_that_saddle_points_in_a_single_column_matrix_are_those_with_the_minimum_value()
     {
         var matrix = new[,]
@@ -110,7 +110,7 @@ public class SaddlePointsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Can_identify_that_saddle_points_in_a_single_row_matrix_are_those_with_the_maximum_value()
     {
         var matrix = new[,]

--- a/exercises/say/SayTests.cs
+++ b/exercises/say/SayTests.cs
@@ -11,85 +11,85 @@ public class SayTests
         Assert.Equal("zero", Say.InEnglish(0L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One()
     {
         Assert.Equal("one", Say.InEnglish(1L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourteen()
     {
         Assert.Equal("fourteen", Say.InEnglish(14L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Twenty()
     {
         Assert.Equal("twenty", Say.InEnglish(20L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Twenty_two()
     {
         Assert.Equal("twenty-two", Say.InEnglish(22L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_hundred()
     {
         Assert.Equal("one hundred", Say.InEnglish(100L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_hundred_twenty_three()
     {
         Assert.Equal("one hundred twenty-three", Say.InEnglish(123L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_thousand()
     {
         Assert.Equal("one thousand", Say.InEnglish(1000L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_thousand_two_hundred_thirty_four()
     {
         Assert.Equal("one thousand two hundred thirty-four", Say.InEnglish(1234L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_million()
     {
         Assert.Equal("one million", Say.InEnglish(1000000L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_million_two_thousand_three_hundred_forty_five()
     {
         Assert.Equal("one million two thousand three hundred forty-five", Say.InEnglish(1002345L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_billion()
     {
         Assert.Equal("one billion", Say.InEnglish(1000000000L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_big_number()
     {
         Assert.Equal("nine hundred eighty-seven billion six hundred fifty-four million three hundred twenty-one thousand one hundred twenty-three", Say.InEnglish(987654321123L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Numbers_below_zero_are_out_of_range()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => Say.InEnglish(-1L));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Numbers_above_999_999_999_999_are_out_of_range()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => Say.InEnglish(1000000000000L));

--- a/exercises/scale-generator/ScaleGeneratorTests.cs
+++ b/exercises/scale-generator/ScaleGeneratorTests.cs
@@ -11,112 +11,112 @@ public class ScaleGeneratorTests
         Assert.Equal(expected, ScaleGenerator.Chromatic("C"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Chromatic_scale_with_flats()
     {
         var expected = new[] { "F", "Gb", "G", "Ab", "A", "Bb", "B", "C", "Db", "D", "Eb", "E" };
         Assert.Equal(expected, ScaleGenerator.Chromatic("F"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Simple_major_scale()
     {
         var expected = new[] { "C", "D", "E", "F", "G", "A", "B" };
         Assert.Equal(expected, ScaleGenerator.Interval("C", "MMmMMMm"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Major_scale_with_sharps()
     {
         var expected = new[] { "G", "A", "B", "C", "D", "E", "F#" };
         Assert.Equal(expected, ScaleGenerator.Interval("G", "MMmMMMm"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Major_scale_with_flats()
     {
         var expected = new[] { "F", "G", "A", "Bb", "C", "D", "E" };
         Assert.Equal(expected, ScaleGenerator.Interval("F", "MMmMMMm"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Minor_scale_with_sharps()
     {
         var expected = new[] { "F#", "G#", "A", "B", "C#", "D", "E" };
         Assert.Equal(expected, ScaleGenerator.Interval("f#", "MmMMmMM"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Minor_scale_with_flats()
     {
         var expected = new[] { "Bb", "C", "Db", "Eb", "F", "Gb", "Ab" };
         Assert.Equal(expected, ScaleGenerator.Interval("bb", "MmMMmMM"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Dorian_mode()
     {
         var expected = new[] { "D", "E", "F", "G", "A", "B", "C" };
         Assert.Equal(expected, ScaleGenerator.Interval("d", "MmMMMmM"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Mixolydian_mode()
     {
         var expected = new[] { "Eb", "F", "G", "Ab", "Bb", "C", "Db" };
         Assert.Equal(expected, ScaleGenerator.Interval("Eb", "MMmMMmM"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Lydian_mode()
     {
         var expected = new[] { "A", "B", "C#", "D#", "E", "F#", "G#" };
         Assert.Equal(expected, ScaleGenerator.Interval("a", "MMMmMMm"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Phrygian_mode()
     {
         var expected = new[] { "E", "F", "G", "A", "B", "C", "D" };
         Assert.Equal(expected, ScaleGenerator.Interval("e", "mMMMmMM"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Locrian_mode()
     {
         var expected = new[] { "G", "Ab", "Bb", "C", "Db", "Eb", "F" };
         Assert.Equal(expected, ScaleGenerator.Interval("g", "mMMmMMM"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Harmonic_minor()
     {
         var expected = new[] { "D", "E", "F", "G", "A", "Bb", "Db" };
         Assert.Equal(expected, ScaleGenerator.Interval("d", "MmMMmAm"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Octatonic()
     {
         var expected = new[] { "C", "D", "D#", "F", "F#", "G#", "A", "B" };
         Assert.Equal(expected, ScaleGenerator.Interval("C", "MmMmMmMm"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Hexatonic()
     {
         var expected = new[] { "Db", "Eb", "F", "G", "A", "B" };
         Assert.Equal(expected, ScaleGenerator.Interval("Db", "MMMMMM"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Pentatonic()
     {
         var expected = new[] { "A", "B", "C#", "E", "F#" };
         Assert.Equal(expected, ScaleGenerator.Interval("A", "MMAMA"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Enigmatic()
     {
         var expected = new[] { "G", "G#", "B", "C#", "D#", "F", "F#" };

--- a/exercises/scrabble-score/ScrabbleScoreTests.cs
+++ b/exercises/scrabble-score/ScrabbleScoreTests.cs
@@ -10,61 +10,61 @@ public class ScrabbleScoreTests
         Assert.Equal(1, ScrabbleScore.Score("a"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Uppercase_letter()
     {
         Assert.Equal(1, ScrabbleScore.Score("A"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Valuable_letter()
     {
         Assert.Equal(4, ScrabbleScore.Score("f"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Short_word()
     {
         Assert.Equal(2, ScrabbleScore.Score("at"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Short_valuable_word()
     {
         Assert.Equal(12, ScrabbleScore.Score("zoo"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Medium_word()
     {
         Assert.Equal(6, ScrabbleScore.Score("street"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Medium_valuable_word()
     {
         Assert.Equal(22, ScrabbleScore.Score("quirky"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Long_mixed_case_word()
     {
         Assert.Equal(41, ScrabbleScore.Score("OxyphenButazone"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void English_like_word()
     {
         Assert.Equal(8, ScrabbleScore.Score("pinata"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_input()
     {
         Assert.Equal(0, ScrabbleScore.Score(""));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Entire_alphabet_available()
     {
         Assert.Equal(87, ScrabbleScore.Score("abcdefghijklmnopqrstuvwxyz"));

--- a/exercises/secret-handshake/SecretHandshakeTests.cs
+++ b/exercises/secret-handshake/SecretHandshakeTests.cs
@@ -10,61 +10,61 @@ public class SecretHandshakeTests
         Assert.Equal(new[] { "wink" }, SecretHandshake.Commands(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Double_blink_for_10()
     {
         Assert.Equal(new[] { "double blink" }, SecretHandshake.Commands(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Close_your_eyes_for_100()
     {
         Assert.Equal(new[] { "close your eyes" }, SecretHandshake.Commands(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Jump_for_1000()
     {
         Assert.Equal(new[] { "jump" }, SecretHandshake.Commands(8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Combine_two_actions()
     {
         Assert.Equal(new[] { "wink", "double blink" }, SecretHandshake.Commands(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reverse_two_actions()
     {
         Assert.Equal(new[] { "double blink", "wink" }, SecretHandshake.Commands(19));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reversing_one_action_gives_the_same_action()
     {
         Assert.Equal(new[] { "jump" }, SecretHandshake.Commands(24));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reversing_no_actions_still_gives_no_actions()
     {
         Assert.Empty(SecretHandshake.Commands(16));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_possible_actions()
     {
         Assert.Equal(new[] { "wink", "double blink", "close your eyes", "jump" }, SecretHandshake.Commands(15));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reverse_all_possible_actions()
     {
         Assert.Equal(new[] { "jump", "close your eyes", "double blink", "wink" }, SecretHandshake.Commands(31));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Do_nothing_for_zero()
     {
         Assert.Empty(SecretHandshake.Commands(0));

--- a/exercises/series/SeriesTests.cs
+++ b/exercises/series/SeriesTests.cs
@@ -12,60 +12,60 @@ public class SeriesTests
         Assert.Equal(expected, Series.Slices("1", 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Slices_of_one_from_two()
     {
         var expected = new[] { "1", "2" };
         Assert.Equal(expected, Series.Slices("12", 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Slices_of_two()
     {
         var expected = new[] { "35" };
         Assert.Equal(expected, Series.Slices("35", 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Slices_of_two_overlap()
     {
         var expected = new[] { "91", "14", "42" };
         Assert.Equal(expected, Series.Slices("9142", 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Slices_can_include_duplicates()
     {
         var expected = new[] { "777", "777", "777", "777" };
         Assert.Equal(expected, Series.Slices("777777", 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Slices_of_a_long_series()
     {
         var expected = new[] { "91849", "18493", "84939", "49390", "93904", "39042", "90424", "04243" };
         Assert.Equal(expected, Series.Slices("918493904243", 5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Slice_length_is_too_large()
     {
         Assert.Throws<ArgumentException>(() => Series.Slices("12345", 6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Slice_length_cannot_be_zero()
     {
         Assert.Throws<ArgumentException>(() => Series.Slices("12345", 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Slice_length_cannot_be_negative()
     {
         Assert.Throws<ArgumentException>(() => Series.Slices("123", -1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_series_is_invalid()
     {
         Assert.Throws<ArgumentException>(() => Series.Slices("", 1));

--- a/exercises/sgf-parsing/SgfParsingTests.cs
+++ b/exercises/sgf-parsing/SgfParsingTests.cs
@@ -13,21 +13,21 @@ public class SgfParsingTests
         Assert.Throws<ArgumentException>(() => SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tree_with_no_nodes()
     {
         var encoded = "()";
         Assert.Throws<ArgumentException>(() => SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Node_without_tree()
     {
         var encoded = ";";
         Assert.Throws<ArgumentException>(() => SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Node_without_properties()
     {
         var encoded = "(;)";
@@ -35,7 +35,7 @@ public class SgfParsingTests
         Assert.Equal(expected, SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_node_tree()
     {
         var encoded = "(;A[B])";
@@ -43,7 +43,7 @@ public class SgfParsingTests
         Assert.Equal(expected, SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_properties()
     {
         var encoded = "(;A[b]C[d])";
@@ -51,28 +51,28 @@ public class SgfParsingTests
         Assert.Equal(expected, SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Properties_without_delimiter()
     {
         var encoded = "(;A)";
         Assert.Throws<ArgumentException>(() => SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_lowercase_property()
     {
         var encoded = "(;a[b])";
         Assert.Throws<ArgumentException>(() => SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Upper_and_lowercase_property()
     {
         var encoded = "(;Aa[b])";
         Assert.Throws<ArgumentException>(() => SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_nodes()
     {
         var encoded = "(;A[B];B[C])";
@@ -80,7 +80,7 @@ public class SgfParsingTests
         Assert.Equal(expected, SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_child_trees()
     {
         var encoded = "(;A[B](;B[C])(;C[D]))";
@@ -88,7 +88,7 @@ public class SgfParsingTests
         Assert.Equal(expected, SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_property_values()
     {
         var encoded = "(;A[b][c][d])";
@@ -96,7 +96,7 @@ public class SgfParsingTests
         Assert.Equal(expected, SgfParser.ParseTree(encoded));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Escaped_property()
     {
         var encoded = "(;A[\\]b\\nc\\nd\\t\\te \\n\\]])";

--- a/exercises/sieve/SieveTests.cs
+++ b/exercises/sieve/SieveTests.cs
@@ -11,28 +11,28 @@ public class SieveTests
         Assert.Throws<ArgumentOutOfRangeException>(() => Sieve.Primes(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_first_prime()
     {
         var expected = new[] { 2 };
         Assert.Equal(expected, Sieve.Primes(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_primes_up_to_10()
     {
         var expected = new[] { 2, 3, 5, 7 };
         Assert.Equal(expected, Sieve.Primes(10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Limit_is_prime()
     {
         var expected = new[] { 2, 3, 5, 7, 11, 13 };
         Assert.Equal(expected, Sieve.Primes(13));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Find_primes_up_to_1000()
     {
         var expected = new[] { 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997 };

--- a/exercises/simple-cipher/SimpleCipherTests.cs
+++ b/exercises/simple-cipher/SimpleCipherTests.cs
@@ -12,77 +12,77 @@ public class SimpleCipherTests
         Assert.Equal(sut.Key.Substring(0, 10), sut.Encode("aaaaaaaaaa"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Random_key_cipher_can_decode()
     {
         var sut = new SimpleCipher();
         Assert.Equal("aaaaaaaaaa", sut.Decode(sut.Key.Substring(0, 10)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Random_key_cipher_is_reversible_i_e_if_you_apply_decode_in_a_encoded_result_you_must_see_the_same_plaintext_encode_parameter_as_a_result_of_the_decode_method()
     {
         var sut = new SimpleCipher();
         Assert.Equal("abcdefghij", sut.Decode(sut.Encode("abcdefghij")));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Random_key_cipher_key_is_made_only_of_lowercase_letters()
     {
         var sut = new SimpleCipher();
         Assert.Matches("^[a-z]+$", sut.Key);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substitution_cipher_can_encode()
     {
         var sut = new SimpleCipher("abcdefghij");
         Assert.Equal("abcdefghij", sut.Encode("aaaaaaaaaa"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substitution_cipher_can_decode()
     {
         var sut = new SimpleCipher("abcdefghij");
         Assert.Equal("aaaaaaaaaa", sut.Decode("abcdefghij"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substitution_cipher_is_reversible_i_e_if_you_apply_decode_in_a_encoded_result_you_must_see_the_same_plaintext_encode_parameter_as_a_result_of_the_decode_method()
     {
         var sut = new SimpleCipher("abcdefghij");
         Assert.Equal("abcdefghij", sut.Decode(sut.Encode("abcdefghij")));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substitution_cipher_can_double_shift_encode()
     {
         var sut = new SimpleCipher("iamapandabear");
         Assert.Equal("qayaeaagaciai", sut.Encode("iamapandabear"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substitution_cipher_can_wrap_on_encode()
     {
         var sut = new SimpleCipher("abcdefghij");
         Assert.Equal("zabcdefghi", sut.Encode("zzzzzzzzzz"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substitution_cipher_can_wrap_on_decode()
     {
         var sut = new SimpleCipher("abcdefghij");
         Assert.Equal("zzzzzzzzzz", sut.Decode("zabcdefghi"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substitution_cipher_can_encode_messages_longer_than_the_key()
     {
         var sut = new SimpleCipher("abc");
         Assert.Equal("iboaqcnecbfcr", sut.Encode("iamapandabear"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substitution_cipher_can_decode_messages_longer_than_the_key()
     {
         var sut = new SimpleCipher("abc");

--- a/exercises/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/simple-linked-list/SimpleLinkedListTests.cs
@@ -10,42 +10,42 @@ public class SimpleLinkedListTests
         Assert.Equal(1, list.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_item_list_has_no_next_item()
     {
         var list = new SimpleLinkedList<int>(1);
         Assert.Null(list.Next);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_item_list_first_value()
     {
         var list = new SimpleLinkedList<int>(2).Add(1);
         Assert.Equal(2, list.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_item_list_second_value()
     {
         var list = new SimpleLinkedList<int>(2).Add(1);
         Assert.Equal(1, list.Next.Value);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_item_list_second_item_has_no_next()
     {
         var list = new SimpleLinkedList<int>(2).Add(1);
         Assert.Null(list.Next.Next);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Implements_enumerable()
     {
         var values = new SimpleLinkedList<int>(2).Add(1);
         Assert.Equal(new[] { 2, 1 }, values);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void From_enumerable()
     {
         var list = new SimpleLinkedList<int>(new[] { 11, 7, 5, 3, 2 });
@@ -56,7 +56,7 @@ public class SimpleLinkedListTests
         Assert.Equal(2, list.Next.Next.Next.Next.Value);
     }
 
-    [Theory(Skip = "Remove to run test")]
+    [Theory(Skip = "Remove this Skip property to run this test")]
     [InlineData(1)]
     [InlineData(2)]
     [InlineData(10)]
@@ -69,7 +69,7 @@ public class SimpleLinkedListTests
         Assert.Equal(values.Reverse(), reversed);
     }
 
-    [Theory(Skip = "Remove to run test")]
+    [Theory(Skip = "Remove this Skip property to run this test")]
     [InlineData(1)]
     [InlineData(2)]
     [InlineData(10)]

--- a/exercises/space-age/SpaceAgeTests.cs
+++ b/exercises/space-age/SpaceAgeTests.cs
@@ -11,49 +11,49 @@ public class SpaceAgeTests
         Assert.Equal(31.69, sut.OnEarth(), precision: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Age_on_mercury()
     {
         var sut = new SpaceAge(2134835688);
         Assert.Equal(280.88, sut.OnMercury(), precision: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Age_on_venus()
     {
         var sut = new SpaceAge(189839836);
         Assert.Equal(9.78, sut.OnVenus(), precision: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Age_on_mars()
     {
         var sut = new SpaceAge(2129871239);
         Assert.Equal(35.88, sut.OnMars(), precision: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Age_on_jupiter()
     {
         var sut = new SpaceAge(901876382);
         Assert.Equal(2.41, sut.OnJupiter(), precision: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Age_on_saturn()
     {
         var sut = new SpaceAge(2000000000);
         Assert.Equal(2.15, sut.OnSaturn(), precision: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Age_on_uranus()
     {
         var sut = new SpaceAge(1210123456);
         Assert.Equal(0.46, sut.OnUranus(), precision: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Age_on_neptune()
     {
         var sut = new SpaceAge(1821023456);

--- a/exercises/spiral-matrix/SpiralMatrixTests.cs
+++ b/exercises/spiral-matrix/SpiralMatrixTests.cs
@@ -10,7 +10,7 @@ public class SpiralMatrixTests
         Assert.Empty(SpiralMatrix.GetMatrix(0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trivial_spiral()
     {
         var expected = new[,]
@@ -20,7 +20,7 @@ public class SpiralMatrixTests
         Assert.Equal(expected, SpiralMatrix.GetMatrix(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Spiral_of_size_2()
     {
         var expected = new[,]
@@ -31,7 +31,7 @@ public class SpiralMatrixTests
         Assert.Equal(expected, SpiralMatrix.GetMatrix(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Spiral_of_size_3()
     {
         var expected = new[,]
@@ -43,7 +43,7 @@ public class SpiralMatrixTests
         Assert.Equal(expected, SpiralMatrix.GetMatrix(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Spiral_of_size_4()
     {
         var expected = new[,]
@@ -56,7 +56,7 @@ public class SpiralMatrixTests
         Assert.Equal(expected, SpiralMatrix.GetMatrix(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Spiral_of_size_5()
     {
         var expected = new[,]

--- a/exercises/strain/StrainTests.cs
+++ b/exercises/strain/StrainTests.cs
@@ -10,32 +10,32 @@ public class StrainTests
         Assert.Equal(new LinkedList<int>(), new LinkedList<int>().Keep(x => x < 10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Keep_everything()
     {
         Assert.Equal(new HashSet<int> { 1, 2, 3 }, new HashSet<int> { 1, 2, 3 }.Keep(x => x < 10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Keep_first_and_last()
     {
         Assert.Equal(new[] { 1, 3 }, new[] { 1, 2, 3 }.Keep(x => x % 2 != 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Keep_neither_first_nor_last()
     {
         Assert.Equal(new List<int> { 2, 4 }, new List<int> { 1, 2, 3, 4, 5 }.Keep(x => x % 2 == 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Keep_strings()
     {
         var words = "apple zebra banana zombies cherimoya zelot".Split(' ');
         Assert.Equal("zebra zombies zelot".Split(' '), words.Keep(x => x.StartsWith("z")));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Keep_arrays()
     {
         var actual = new[]
@@ -52,38 +52,38 @@ public class StrainTests
         Assert.Equal(expected, actual.Keep(x => x.Contains(5)));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_discard()
     {
         Assert.Equal(new LinkedList<int>(), new LinkedList<int>().Discard(x => x < 10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Discard_nothing()
     {
         Assert.Equal(new HashSet<int> { 1, 2, 3 }, new HashSet<int> { 1, 2, 3 }.Discard(x => x > 10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Discard_first_and_last()
     {
         Assert.Equal(new[] { 2 }, new[] { 1, 2, 3 }.Discard(x => x % 2 != 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Discard_neither_first_nor_last()
     {
         Assert.Equal(new List<int> { 1, 3, 5 }, new List<int> { 1, 2, 3, 4, 5 }.Discard(x => x % 2 == 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Discard_strings()
     {
         var words = "apple zebra banana zombies cherimoya zelot".Split(' ');
         Assert.Equal("apple banana cherimoya".Split(' '), words.Discard(x => x.StartsWith("z")));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Discard_arrays()
     {
         var actual = new[]

--- a/exercises/sublist/SublistTests.cs
+++ b/exercises/sublist/SublistTests.cs
@@ -11,97 +11,97 @@ public class SublistTests
         Assert.Equal(SublistType.Equal, Sublist.Classify(new List<int>(), new List<int>()));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_list_within_non_empty_list()
     {
         Assert.Equal(SublistType.Sublist, Sublist.Classify(new List<int>(), new List<int> { 1, 2, 3 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Non_empty_list_contains_empty_list()
     {
         Assert.Equal(SublistType.Superlist, Sublist.Classify(new List<int> { 1, 2, 3 }, new List<int>()));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void List_equals_itself()
     {
         Assert.Equal(SublistType.Equal, Sublist.Classify(new List<int> { 1, 2, 3 }, new List<int> { 1, 2, 3 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Different_lists()
     {
         Assert.Equal(SublistType.Unequal, Sublist.Classify(new List<int> { 1, 2, 3 }, new List<int> { 2, 3, 4 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void False_start()
     {
         Assert.Equal(SublistType.Sublist, Sublist.Classify(new List<int> { 1, 2, 5 }, new List<int> { 0, 1, 2, 3, 1, 2, 5, 6 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Consecutive()
     {
         Assert.Equal(SublistType.Sublist, Sublist.Classify(new List<int> { 1, 1, 2 }, new List<int> { 0, 1, 1, 1, 2, 1, 2 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sublist_at_start()
     {
         Assert.Equal(SublistType.Sublist, Sublist.Classify(new List<int> { 0, 1, 2 }, new List<int> { 0, 1, 2, 3, 4, 5 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sublist_in_middle()
     {
         Assert.Equal(SublistType.Sublist, Sublist.Classify(new List<int> { 2, 3, 4 }, new List<int> { 0, 1, 2, 3, 4, 5 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sublist_at_end()
     {
         Assert.Equal(SublistType.Sublist, Sublist.Classify(new List<int> { 3, 4, 5 }, new List<int> { 0, 1, 2, 3, 4, 5 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void At_start_of_superlist()
     {
         Assert.Equal(SublistType.Superlist, Sublist.Classify(new List<int> { 0, 1, 2, 3, 4, 5 }, new List<int> { 0, 1, 2 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void In_middle_of_superlist()
     {
         Assert.Equal(SublistType.Superlist, Sublist.Classify(new List<int> { 0, 1, 2, 3, 4, 5 }, new List<int> { 2, 3 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void At_end_of_superlist()
     {
         Assert.Equal(SublistType.Superlist, Sublist.Classify(new List<int> { 0, 1, 2, 3, 4, 5 }, new List<int> { 3, 4, 5 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_list_missing_element_from_second_list()
     {
         Assert.Equal(SublistType.Unequal, Sublist.Classify(new List<int> { 1, 3 }, new List<int> { 1, 2, 3 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_list_missing_element_from_first_list()
     {
         Assert.Equal(SublistType.Unequal, Sublist.Classify(new List<int> { 1, 2, 3 }, new List<int> { 1, 3 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Order_matters_to_a_list()
     {
         Assert.Equal(SublistType.Unequal, Sublist.Classify(new List<int> { 1, 2, 3 }, new List<int> { 3, 2, 1 }));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Same_digits_but_different_numbers()
     {
         Assert.Equal(SublistType.Unequal, Sublist.Classify(new List<int> { 1, 0, 1 }, new List<int> { 10, 1 }));

--- a/exercises/sum-of-multiples/SumOfMultiplesTests.cs
+++ b/exercises/sum-of-multiples/SumOfMultiplesTests.cs
@@ -11,91 +11,91 @@ public class SumOfMultiplesTests
         Assert.Equal(0, SumOfMultiples.Sum(new[] { 3, 5 }, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_factor_has_multiples_within_limit()
     {
         Assert.Equal(3, SumOfMultiples.Sum(new[] { 3, 5 }, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void More_than_one_multiple_within_limit()
     {
         Assert.Equal(9, SumOfMultiples.Sum(new[] { 3 }, 7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void More_than_one_factor_with_multiples_within_limit()
     {
         Assert.Equal(23, SumOfMultiples.Sum(new[] { 3, 5 }, 10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Each_multiple_is_only_counted_once()
     {
         Assert.Equal(2318, SumOfMultiples.Sum(new[] { 3, 5 }, 100));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_much_larger_limit()
     {
         Assert.Equal(233168, SumOfMultiples.Sum(new[] { 3, 5 }, 1000));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_factors()
     {
         Assert.Equal(51, SumOfMultiples.Sum(new[] { 7, 13, 17 }, 20));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Factors_not_relatively_prime()
     {
         Assert.Equal(30, SumOfMultiples.Sum(new[] { 4, 6 }, 15));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Some_pairs_of_factors_relatively_prime_and_some_not()
     {
         Assert.Equal(4419, SumOfMultiples.Sum(new[] { 5, 6, 8 }, 150));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_factor_is_a_multiple_of_another()
     {
         Assert.Equal(275, SumOfMultiples.Sum(new[] { 5, 25 }, 51));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Much_larger_factors()
     {
         Assert.Equal(2203160, SumOfMultiples.Sum(new[] { 43, 47 }, 10000));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void All_numbers_are_multiples_of_1()
     {
         Assert.Equal(4950, SumOfMultiples.Sum(new[] { 1 }, 100));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_factors_means_an_empty_sum()
     {
         Assert.Equal(0, SumOfMultiples.Sum(Array.Empty<int>(), 10000));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_only_multiple_of_0_is_0()
     {
         Assert.Equal(0, SumOfMultiples.Sum(new[] { 0 }, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void The_factor_0_does_not_affect_the_sum_of_multiples_of_other_factors()
     {
         Assert.Equal(3, SumOfMultiples.Sum(new[] { 3, 0 }, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Solutions_using_include_exclude_must_extend_to_cardinality_greater_than_3()
     {
         Assert.Equal(39614537, SumOfMultiples.Sum(new[] { 2, 3, 5, 7, 11 }, 10000));

--- a/exercises/tournament/TournamentTests.cs
+++ b/exercises/tournament/TournamentTests.cs
@@ -15,7 +15,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_win_is_three_points_a_loss_is_zero_points()
     {
         var rows = "Allegoric Alaskans;Blithering Badgers;win";
@@ -26,7 +26,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_win_can_also_be_expressed_as_a_loss()
     {
         var rows = "Blithering Badgers;Allegoric Alaskans;loss";
@@ -37,7 +37,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_different_team_can_win()
     {
         var rows = "Blithering Badgers;Allegoric Alaskans;win";
@@ -48,7 +48,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_draw_is_one_point_each()
     {
         var rows = "Allegoric Alaskans;Blithering Badgers;draw";
@@ -59,7 +59,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void There_can_be_more_than_one_match()
     {
         var rows = 
@@ -72,7 +72,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void There_can_be_more_than_one_winner()
     {
         var rows = 
@@ -85,7 +85,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void There_can_be_more_than_two_teams()
     {
         var rows = 
@@ -100,7 +100,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Typical_input()
     {
         var rows = 
@@ -119,7 +119,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Incomplete_competition_not_all_pairs_have_played_()
     {
         var rows = 
@@ -136,7 +136,7 @@ public class TournamentTests
         Assert.Equal(expected, RunTally(rows));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ties_broken_alphabetically()
     {
         var rows = 

--- a/exercises/transpose/TransposeTests.cs
+++ b/exercises/transpose/TransposeTests.cs
@@ -12,7 +12,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_characters_in_a_row()
     {
         var lines = "A1";
@@ -22,7 +22,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_characters_in_a_column()
     {
         var lines = 
@@ -32,7 +32,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Simple()
     {
         var lines = 
@@ -45,7 +45,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Single_line()
     {
         var lines = "Single line.";
@@ -65,7 +65,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void First_line_longer_than_second_line()
     {
         var lines = 
@@ -91,7 +91,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_line_longer_than_first_line()
     {
         var lines = 
@@ -117,7 +117,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Mixed_line_length()
     {
         var lines = 
@@ -146,7 +146,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Square()
     {
         var lines = 
@@ -164,7 +164,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Rectangle()
     {
         var lines = 
@@ -184,7 +184,7 @@ public class TransposeTests
         Assert.Equal(expected, Transpose.String(lines));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Triangle()
     {
         var lines = 

--- a/exercises/tree-building/TreeBuildingTests.cs
+++ b/exercises/tree-building/TreeBuildingTests.cs
@@ -16,7 +16,7 @@ public class TreeBuildingTests
         AssertTreeIsLeaf(tree, id: 0);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_nodes_in_order()
     {
         var records = new[]
@@ -33,7 +33,7 @@ public class TreeBuildingTests
         AssertTreeIsLeaf(tree.Children[1], id: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_nodes_in_reverse_order()
     {
         var records = new[]
@@ -50,7 +50,7 @@ public class TreeBuildingTests
         AssertTreeIsLeaf(tree.Children[1], id: 2);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void More_than_two_children()
     {
         var records = new[]
@@ -69,7 +69,7 @@ public class TreeBuildingTests
         AssertTreeIsLeaf(tree.Children[2], id: 3);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Binary_tree()
     {
         var records = new[]
@@ -95,7 +95,7 @@ public class TreeBuildingTests
         AssertTreeIsLeaf(tree.Children[1].Children[1], id: 6);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unbalanced_tree()
     {
         var records = new[]
@@ -121,7 +121,7 @@ public class TreeBuildingTests
         AssertTreeIsLeaf(tree.Children[1].Children[2], id: 6);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Empty_input()
     {
         var records = new TreeBuildingRecord[0];
@@ -129,7 +129,7 @@ public class TreeBuildingTests
         Assert.Throws<ArgumentException>(() => TreeBuilder.BuildTree(records));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Root_node_has_parent()
     {
         var records = new[]
@@ -141,7 +141,7 @@ public class TreeBuildingTests
         Assert.Throws<ArgumentException>(() => TreeBuilder.BuildTree(records));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_root_node()
     {
         var records = new[]
@@ -153,7 +153,7 @@ public class TreeBuildingTests
     }
 
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Non_continuous()
     {
         var records = new[]
@@ -167,7 +167,7 @@ public class TreeBuildingTests
         Assert.Throws<ArgumentException>(() => TreeBuilder.BuildTree(records));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cycle_directly()
     {
         var records = new[]
@@ -184,7 +184,7 @@ public class TreeBuildingTests
         Assert.Throws<ArgumentException>(() => TreeBuilder.BuildTree(records));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cycle_indirectly()
     {
         var records = new[]
@@ -201,7 +201,7 @@ public class TreeBuildingTests
         Assert.Throws<ArgumentException>(() => TreeBuilder.BuildTree(records));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Higher_id_parent_of_lower_id()
     {
         var records = new[]

--- a/exercises/triangle/TriangleTests.cs
+++ b/exercises/triangle/TriangleTests.cs
@@ -10,109 +10,109 @@ public class TriangleTests
         Assert.True(Triangle.IsEquilateral(2, 2, 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Equilateral_triangle_any_side_is_unequal()
     {
         Assert.False(Triangle.IsEquilateral(2, 3, 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Equilateral_triangle_no_sides_are_equal()
     {
         Assert.False(Triangle.IsEquilateral(5, 4, 6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Equilateral_triangle_all_zero_sides_is_not_a_triangle()
     {
         Assert.False(Triangle.IsEquilateral(0, 0, 0));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Equilateral_triangle_sides_may_be_floats()
     {
         Assert.True(Triangle.IsEquilateral(0.5, 0.5, 0.5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_last_two_sides_are_equal()
     {
         Assert.True(Triangle.IsIsosceles(3, 4, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_first_two_sides_are_equal()
     {
         Assert.True(Triangle.IsIsosceles(4, 4, 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_first_and_last_sides_are_equal()
     {
         Assert.True(Triangle.IsIsosceles(4, 3, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_equilateral_triangles_are_also_isosceles()
     {
         Assert.True(Triangle.IsIsosceles(4, 4, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_no_sides_are_equal()
     {
         Assert.False(Triangle.IsIsosceles(2, 3, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_first_triangle_inequality_violation()
     {
         Assert.False(Triangle.IsIsosceles(1, 1, 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_second_triangle_inequality_violation()
     {
         Assert.False(Triangle.IsIsosceles(1, 3, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_third_triangle_inequality_violation()
     {
         Assert.False(Triangle.IsIsosceles(3, 1, 1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Isosceles_triangle_sides_may_be_floats()
     {
         Assert.True(Triangle.IsIsosceles(0.5, 0.4, 0.5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Scalene_triangle_no_sides_are_equal()
     {
         Assert.True(Triangle.IsScalene(5, 4, 6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Scalene_triangle_all_sides_are_equal()
     {
         Assert.False(Triangle.IsScalene(4, 4, 4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Scalene_triangle_two_sides_are_equal()
     {
         Assert.False(Triangle.IsScalene(4, 4, 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Scalene_triangle_may_not_violate_triangle_inequality()
     {
         Assert.False(Triangle.IsScalene(7, 3, 2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Scalene_triangle_sides_may_be_floats()
     {
         Assert.True(Triangle.IsScalene(0.5, 0.4, 0.6));

--- a/exercises/trinary/TrinaryTests.cs
+++ b/exercises/trinary/TrinaryTests.cs
@@ -8,61 +8,61 @@ public class TrinaryTest
         Assert.Equal(1, Trinary.ToDecimal("1"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trinary_2_is_decimal_2()
     {
         Assert.Equal(2, Trinary.ToDecimal("2"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trinary_10_is_decimal_3()
     {
         Assert.Equal(3, Trinary.ToDecimal("10"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trinary_11_is_decimal_4()
     {
         Assert.Equal(4, Trinary.ToDecimal("11"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trinary_100_is_decimal_9()
     {
         Assert.Equal(9, Trinary.ToDecimal("100"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trinary_112_is_decimal_14()
     {
         Assert.Equal(14, Trinary.ToDecimal("112"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trinary_222_is_decimal_26()
     {
         Assert.Equal(26, Trinary.ToDecimal("222"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Trinary_1122000120_is_decimal_32091()
     {
         Assert.Equal(32091, Trinary.ToDecimal("1122000120"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_trinary_digits_returns_0()
     {
         Assert.Equal(0, Trinary.ToDecimal("1234"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_word_as_input_returns_0()
     {
         Assert.Equal(0, Trinary.ToDecimal("carrot"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Invalid_numbers_with_letters_as_input_returns_0()
     {
         Assert.Equal(0, Trinary.ToDecimal("0a1b2c"));

--- a/exercises/twelve-days/TwelveDaysTests.cs
+++ b/exercises/twelve-days/TwelveDaysTests.cs
@@ -11,84 +11,84 @@ public class TwelveDaysTests
         Assert.Equal(expected, TwelveDays.Recite(1));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Second_day_two_turtle_doves()
     {
         var expected = "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(2));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Third_day_three_french_hens()
     {
         var expected = "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fourth_day_four_calling_birds()
     {
         var expected = "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(4));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fifth_day_five_gold_rings()
     {
         var expected = "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(5));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sixth_day_six_geese_a_laying()
     {
         var expected = "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Seventh_day_seven_swans_a_swimming()
     {
         var expected = "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(7));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Eighth_day_eight_maids_a_milking()
     {
         var expected = "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(8));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ninth_day_nine_ladies_dancing()
     {
         var expected = "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(9));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tenth_day_ten_lords_a_leaping()
     {
         var expected = "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(10));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Eleventh_day_eleven_pipers_piping()
     {
         var expected = "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(11));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Twelfth_day_twelve_drummers_drumming()
     {
         var expected = "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
         Assert.Equal(expected, TwelveDays.Recite(12));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recites_first_three_verses_of_the_song()
     {
         var expected = 
@@ -98,7 +98,7 @@ public class TwelveDaysTests
         Assert.Equal(expected, TwelveDays.Recite(1, 3));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recites_three_verses_from_the_middle_of_the_song()
     {
         var expected = 
@@ -108,7 +108,7 @@ public class TwelveDaysTests
         Assert.Equal(expected, TwelveDays.Recite(4, 6));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Recites_the_whole_song()
     {
         var expected = 

--- a/exercises/two-bucket/TwoBucketTests.cs
+++ b/exercises/two-bucket/TwoBucketTests.cs
@@ -14,7 +14,7 @@ public class TwoBucketTests
         Assert.Equal(Bucket.One, actual.GoalBucket);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Measure_using_bucket_one_of_size_3_and_bucket_two_of_size_5_start_with_bucket_two()
     {
         var sut = new TwoBucket(3, 5, Bucket.Two);
@@ -24,7 +24,7 @@ public class TwoBucketTests
         Assert.Equal(Bucket.Two, actual.GoalBucket);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Measure_using_bucket_one_of_size_7_and_bucket_two_of_size_11_start_with_bucket_one()
     {
         var sut = new TwoBucket(7, 11, Bucket.One);
@@ -34,7 +34,7 @@ public class TwoBucketTests
         Assert.Equal(Bucket.One, actual.GoalBucket);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Measure_using_bucket_one_of_size_7_and_bucket_two_of_size_11_start_with_bucket_two()
     {
         var sut = new TwoBucket(7, 11, Bucket.Two);
@@ -44,7 +44,7 @@ public class TwoBucketTests
         Assert.Equal(Bucket.Two, actual.GoalBucket);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Measure_one_step_using_bucket_one_of_size_1_and_bucket_two_of_size_3_start_with_bucket_two()
     {
         var sut = new TwoBucket(1, 3, Bucket.Two);
@@ -54,7 +54,7 @@ public class TwoBucketTests
         Assert.Equal(Bucket.Two, actual.GoalBucket);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Measure_using_bucket_one_of_size_2_and_bucket_two_of_size_3_start_with_bucket_one_and_end_with_bucket_two()
     {
         var sut = new TwoBucket(2, 3, Bucket.One);

--- a/exercises/two-fer/TwoFerTests.cs
+++ b/exercises/two-fer/TwoFerTests.cs
@@ -10,13 +10,13 @@ public class TwoFerTests
         Assert.Equal("One for you, one for me.", TwoFer.Speak());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void A_name_given()
     {
         Assert.Equal("One for Alice, one for me.", TwoFer.Speak("Alice"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Another_name_given()
     {
         Assert.Equal("One for Bob, one for me.", TwoFer.Speak("Bob"));

--- a/exercises/variable-length-quantity/VariableLengthQuantityTests.cs
+++ b/exercises/variable-length-quantity/VariableLengthQuantityTests.cs
@@ -13,7 +13,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Arbitrary_single_byte()
     {
         var integers = new[] { 0x40u };
@@ -21,7 +21,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Largest_single_byte()
     {
         var integers = new[] { 0x7Fu };
@@ -29,7 +29,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Smallest_double_byte()
     {
         var integers = new[] { 0x80u };
@@ -37,7 +37,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Arbitrary_double_byte()
     {
         var integers = new[] { 0x2000u };
@@ -45,7 +45,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Largest_double_byte()
     {
         var integers = new[] { 0x3FFFu };
@@ -53,7 +53,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Smallest_triple_byte()
     {
         var integers = new[] { 0x4000u };
@@ -61,7 +61,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Arbitrary_triple_byte()
     {
         var integers = new[] { 0x100000u };
@@ -69,7 +69,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Largest_triple_byte()
     {
         var integers = new[] { 0x1FFFFFu };
@@ -77,7 +77,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Smallest_quadruple_byte()
     {
         var integers = new[] { 0x200000u };
@@ -85,7 +85,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Arbitrary_quadruple_byte()
     {
         var integers = new[] { 0x8000000u };
@@ -93,7 +93,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Largest_quadruple_byte()
     {
         var integers = new[] { 0xFFFFFFFu };
@@ -101,7 +101,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Smallest_quintuple_byte()
     {
         var integers = new[] { 0x10000000u };
@@ -109,7 +109,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Arbitrary_quintuple_byte()
     {
         var integers = new[] { 0xFF000000u };
@@ -117,7 +117,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Maximum_32_bit_integer_input()
     {
         var integers = new[] { 0xFFFFFFFFu };
@@ -125,7 +125,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_single_byte_values()
     {
         var integers = new[] { 0x40u, 0x7Fu };
@@ -133,7 +133,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_multi_byte_values()
     {
         var integers = new[] { 0x4000u, 0x123456u };
@@ -141,7 +141,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Many_multi_byte_values()
     {
         var integers = new[] { 0x2000u, 0x123456u, 0xFFFFFFFu, 0x0u, 0x3FFFu, 0x4000u };
@@ -149,7 +149,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Encode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void One_byte()
     {
         var integers = new[] { 0x7Fu };
@@ -157,7 +157,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Decode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_bytes()
     {
         var integers = new[] { 0xC0u, 0x0u };
@@ -165,7 +165,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Decode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Three_bytes()
     {
         var integers = new[] { 0xFFu, 0xFFu, 0x7Fu };
@@ -173,7 +173,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Decode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_bytes()
     {
         var integers = new[] { 0x81u, 0x80u, 0x80u, 0x0u };
@@ -181,7 +181,7 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Decode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Maximum_32_bit_integer()
     {
         var integers = new[] { 0x8Fu, 0xFFu, 0xFFu, 0xFFu, 0x7Fu };
@@ -189,21 +189,21 @@ public class VariableLengthQuantityTests
         Assert.Equal(expected, VariableLengthQuantity.Decode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Incomplete_sequence_causes_error()
     {
         var integers = new[] { 0xFFu };
         Assert.Throws<InvalidOperationException>(() => VariableLengthQuantity.Decode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Incomplete_sequence_causes_error_even_if_value_is_zero()
     {
         var integers = new[] { 0x80u };
         Assert.Throws<InvalidOperationException>(() => VariableLengthQuantity.Decode(integers));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_values()
     {
         var integers = new[] { 0xC0u, 0x0u, 0xC8u, 0xE8u, 0x56u, 0xFFu, 0xFFu, 0xFFu, 0x7Fu, 0x0u, 0xFFu, 0x7Fu, 0x81u, 0x80u, 0x0u };

--- a/exercises/word-count/WordCountTests.cs
+++ b/exercises/word-count/WordCountTests.cs
@@ -16,7 +16,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Count_one_of_each_word()
     {
         var actual = WordCount.CountWords("one of each");
@@ -29,7 +29,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_occurrences_of_a_word()
     {
         var actual = WordCount.CountWords("one fish two fish red fish blue fish");
@@ -44,7 +44,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Handles_cramped_lists()
     {
         var actual = WordCount.CountWords("one,two,three");
@@ -57,7 +57,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Handles_expanded_lists()
     {
         var actual = WordCount.CountWords("one,\ntwo,\nthree");
@@ -70,7 +70,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ignore_punctuation()
     {
         var actual = WordCount.CountWords("car: carpet as java: javascript!!&@$%^&");
@@ -85,7 +85,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Include_numbers()
     {
         var actual = WordCount.CountWords("testing, 1, 2 testing");
@@ -98,7 +98,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Normalize_case()
     {
         var actual = WordCount.CountWords("go Go GO Stop stop");
@@ -110,7 +110,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void With_apostrophes()
     {
         var actual = WordCount.CountWords("First: don't laugh. Then: don't cry.");
@@ -125,7 +125,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void With_quotations()
     {
         var actual = WordCount.CountWords("Joe can't tell between 'large' and large.");
@@ -141,7 +141,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Substrings_from_the_beginning()
     {
         var actual = WordCount.CountWords("Joe can't tell between app, apple and a.");
@@ -159,7 +159,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_spaces_not_detected_as_a_word()
     {
         var actual = WordCount.CountWords(" multiple   whitespaces");
@@ -171,7 +171,7 @@ public class WordCountTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Alternating_word_separators_not_detected_as_a_word()
     {
         var actual = WordCount.CountWords(",\n,one,\n ,two \n 'three'");

--- a/exercises/word-search/WordSearchTests.cs
+++ b/exercises/word-search/WordSearchTests.cs
@@ -20,7 +20,7 @@ public class WordSearchTests
         Assert.Null(expected["clojure"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_one_word_written_left_to_right()
     {
         var wordsToSearchFor = new[] { "clojure" };
@@ -34,7 +34,7 @@ public class WordSearchTests
         Assert.Equal(expected["clojure"], actual["clojure"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_the_same_word_written_left_to_right_in_a_different_position()
     {
         var wordsToSearchFor = new[] { "clojure" };
@@ -48,7 +48,7 @@ public class WordSearchTests
         Assert.Equal(expected["clojure"], actual["clojure"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_a_different_left_to_right_word()
     {
         var wordsToSearchFor = new[] { "coffee" };
@@ -62,7 +62,7 @@ public class WordSearchTests
         Assert.Equal(expected["coffee"], actual["coffee"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_that_different_left_to_right_word_in_a_different_position()
     {
         var wordsToSearchFor = new[] { "coffee" };
@@ -76,7 +76,7 @@ public class WordSearchTests
         Assert.Equal(expected["coffee"], actual["coffee"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_a_left_to_right_word_in_two_line_grid()
     {
         var wordsToSearchFor = new[] { "clojure" };
@@ -92,7 +92,7 @@ public class WordSearchTests
         Assert.Equal(expected["clojure"], actual["clojure"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_a_left_to_right_word_in_three_line_grid()
     {
         var wordsToSearchFor = new[] { "clojure" };
@@ -109,7 +109,7 @@ public class WordSearchTests
         Assert.Equal(expected["clojure"], actual["clojure"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_a_left_to_right_word_in_ten_line_grid()
     {
         var wordsToSearchFor = new[] { "clojure" };
@@ -133,7 +133,7 @@ public class WordSearchTests
         Assert.Equal(expected["clojure"], actual["clojure"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_that_left_to_right_word_in_a_different_position_in_a_ten_line_grid()
     {
         var wordsToSearchFor = new[] { "clojure" };
@@ -157,7 +157,7 @@ public class WordSearchTests
         Assert.Equal(expected["clojure"], actual["clojure"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_a_different_left_to_right_word_in_a_ten_line_grid()
     {
         var wordsToSearchFor = new[] { "fortran" };
@@ -181,7 +181,7 @@ public class WordSearchTests
         Assert.Equal(expected["fortran"], actual["fortran"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_multiple_words()
     {
         var wordsToSearchFor = new[] { "fortran", "clojure" };
@@ -207,7 +207,7 @@ public class WordSearchTests
         Assert.Equal(expected["fortran"], actual["fortran"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_a_single_word_written_right_to_left()
     {
         var wordsToSearchFor = new[] { "elixir" };
@@ -221,7 +221,7 @@ public class WordSearchTests
         Assert.Equal(expected["elixir"], actual["elixir"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_multiple_words_written_in_different_horizontal_directions()
     {
         var wordsToSearchFor = new[] { "elixir", "clojure" };
@@ -247,7 +247,7 @@ public class WordSearchTests
         Assert.Equal(expected["elixir"], actual["elixir"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_words_written_top_to_bottom()
     {
         var wordsToSearchFor = new[] { "clojure", "elixir", "ecmascript" };
@@ -275,7 +275,7 @@ public class WordSearchTests
         Assert.Equal(expected["ecmascript"], actual["ecmascript"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_words_written_bottom_to_top()
     {
         var wordsToSearchFor = new[] { "clojure", "elixir", "ecmascript", "rust" };
@@ -305,7 +305,7 @@ public class WordSearchTests
         Assert.Equal(expected["rust"], actual["rust"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_words_written_top_left_to_bottom_right()
     {
         var wordsToSearchFor = new[] { "clojure", "elixir", "ecmascript", "rust", "java" };
@@ -337,7 +337,7 @@ public class WordSearchTests
         Assert.Equal(expected["java"], actual["java"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_words_written_bottom_right_to_top_left()
     {
         var wordsToSearchFor = new[] { "clojure", "elixir", "ecmascript", "rust", "java", "lua" };
@@ -371,7 +371,7 @@ public class WordSearchTests
         Assert.Equal(expected["lua"], actual["lua"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_words_written_bottom_left_to_top_right()
     {
         var wordsToSearchFor = new[] { "clojure", "elixir", "ecmascript", "rust", "java", "lua", "lisp" };
@@ -407,7 +407,7 @@ public class WordSearchTests
         Assert.Equal(expected["lisp"], actual["lisp"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_locate_words_written_top_right_to_bottom_left()
     {
         var wordsToSearchFor = new[] { "clojure", "elixir", "ecmascript", "rust", "java", "lua", "lisp", "ruby" };
@@ -445,7 +445,7 @@ public class WordSearchTests
         Assert.Equal(expected["ruby"], actual["ruby"]);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Should_fail_to_locate_a_word_that_is_not_in_the_puzzle()
     {
         var wordsToSearchFor = new[] { "clojure", "elixir", "ecmascript", "rust", "java", "lua", "lisp", "ruby", "haskell" };

--- a/exercises/wordy/WordyTests.cs
+++ b/exercises/wordy/WordyTests.cs
@@ -11,133 +11,133 @@ public class WordyTests
         Assert.Equal(5, Wordy.Answer("What is 5?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Addition()
     {
         Assert.Equal(2, Wordy.Answer("What is 1 plus 1?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void More_addition()
     {
         Assert.Equal(55, Wordy.Answer("What is 53 plus 2?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Addition_with_negative_numbers()
     {
         Assert.Equal(-11, Wordy.Answer("What is -1 plus -10?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Large_addition()
     {
         Assert.Equal(45801, Wordy.Answer("What is 123 plus 45678?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtraction()
     {
         Assert.Equal(16, Wordy.Answer("What is 4 minus -12?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiplication()
     {
         Assert.Equal(-75, Wordy.Answer("What is -3 multiplied by 25?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Division()
     {
         Assert.Equal(-11, Wordy.Answer("What is 33 divided by -3?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_additions()
     {
         Assert.Equal(3, Wordy.Answer("What is 1 plus 1 plus 1?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Addition_and_subtraction()
     {
         Assert.Equal(8, Wordy.Answer("What is 1 plus 5 minus -2?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_subtraction()
     {
         Assert.Equal(3, Wordy.Answer("What is 20 minus 4 minus 13?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Subtraction_then_addition()
     {
         Assert.Equal(14, Wordy.Answer("What is 17 minus 6 plus 3?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_multiplication()
     {
         Assert.Equal(-12, Wordy.Answer("What is 2 multiplied by -2 multiplied by 3?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Addition_and_multiplication()
     {
         Assert.Equal(-8, Wordy.Answer("What is -3 plus 7 multiplied by -2?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Multiple_division()
     {
         Assert.Equal(2, Wordy.Answer("What is -12 divided by 2 divided by -3?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Unknown_operation()
     {
         Assert.Throws<ArgumentException>(() => Wordy.Answer("What is 52 cubed?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Non_math_question()
     {
         Assert.Throws<ArgumentException>(() => Wordy.Answer("Who is the President of the United States?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reject_problem_missing_an_operand()
     {
         Assert.Throws<ArgumentException>(() => Wordy.Answer("What is 1 plus?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reject_problem_with_no_operands_or_operators()
     {
         Assert.Throws<ArgumentException>(() => Wordy.Answer("What is?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reject_two_operations_in_a_row()
     {
         Assert.Throws<ArgumentException>(() => Wordy.Answer("What is 1 plus plus 2?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reject_two_numbers_in_a_row()
     {
         Assert.Throws<ArgumentException>(() => Wordy.Answer("What is 1 plus 2 1?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reject_postfix_notation()
     {
         Assert.Throws<ArgumentException>(() => Wordy.Answer("What is 1 2 plus?"));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Reject_prefix_notation()
     {
         Assert.Throws<ArgumentException>(() => Wordy.Answer("What is plus 1 2?"));

--- a/exercises/yacht/YachtTests.cs
+++ b/exercises/yacht/YachtTests.cs
@@ -10,163 +10,163 @@ public class YachtTests
         Assert.Equal(50, YachtGame.Score(new[] { 5, 5, 5, 5, 5 }, YachtCategory.Yacht));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Not_yacht()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 1, 3, 3, 2, 5 }, YachtCategory.Yacht));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ones()
     {
         Assert.Equal(3, YachtGame.Score(new[] { 1, 1, 1, 3, 5 }, YachtCategory.Ones));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Ones_out_of_order()
     {
         Assert.Equal(3, YachtGame.Score(new[] { 3, 1, 1, 5, 1 }, YachtCategory.Ones));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_ones()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 4, 3, 6, 5, 5 }, YachtCategory.Ones));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Twos()
     {
         Assert.Equal(2, YachtGame.Score(new[] { 2, 3, 4, 5, 6 }, YachtCategory.Twos));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Fours()
     {
         Assert.Equal(8, YachtGame.Score(new[] { 1, 4, 1, 4, 1 }, YachtCategory.Fours));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Yacht_counted_as_threes()
     {
         Assert.Equal(15, YachtGame.Score(new[] { 3, 3, 3, 3, 3 }, YachtCategory.Threes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Yacht_of_3s_counted_as_fives()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 3, 3, 3, 3, 3 }, YachtCategory.Fives));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Sixes()
     {
         Assert.Equal(6, YachtGame.Score(new[] { 2, 3, 4, 5, 6 }, YachtCategory.Sixes));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_house_two_small_three_big()
     {
         Assert.Equal(16, YachtGame.Score(new[] { 2, 2, 4, 4, 4 }, YachtCategory.FullHouse));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_house_three_small_two_big()
     {
         Assert.Equal(19, YachtGame.Score(new[] { 5, 3, 3, 5, 3 }, YachtCategory.FullHouse));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Two_pair_is_not_a_full_house()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 2, 2, 4, 4, 5 }, YachtCategory.FullHouse));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_of_a_kind_is_not_a_full_house()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 1, 4, 4, 4, 4 }, YachtCategory.FullHouse));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Yacht_is_not_a_full_house()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 2, 2, 2, 2, 2 }, YachtCategory.FullHouse));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_of_a_kind()
     {
         Assert.Equal(24, YachtGame.Score(new[] { 6, 6, 4, 6, 6 }, YachtCategory.FourOfAKind));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Yacht_can_be_scored_as_four_of_a_kind()
     {
         Assert.Equal(12, YachtGame.Score(new[] { 3, 3, 3, 3, 3 }, YachtCategory.FourOfAKind));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Full_house_is_not_four_of_a_kind()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 3, 3, 3, 5, 5 }, YachtCategory.FourOfAKind));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Little_straight()
     {
         Assert.Equal(30, YachtGame.Score(new[] { 3, 5, 4, 1, 2 }, YachtCategory.LittleStraight));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Little_straight_as_big_straight()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 1, 2, 3, 4, 5 }, YachtCategory.BigStraight));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Four_in_order_but_not_a_little_straight()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 1, 1, 2, 3, 4 }, YachtCategory.LittleStraight));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_pairs_but_not_a_little_straight()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 1, 2, 3, 4, 6 }, YachtCategory.LittleStraight));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Minimum_is_1_maximum_is_5_but_not_a_little_straight()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 1, 1, 3, 4, 5 }, YachtCategory.LittleStraight));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Big_straight()
     {
         Assert.Equal(30, YachtGame.Score(new[] { 4, 6, 2, 5, 3 }, YachtCategory.BigStraight));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Big_straight_as_little_straight()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 6, 5, 4, 3, 2 }, YachtCategory.LittleStraight));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void No_pairs_but_not_a_big_straight()
     {
         Assert.Equal(0, YachtGame.Score(new[] { 6, 5, 4, 3, 1 }, YachtCategory.BigStraight));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Choice()
     {
         Assert.Equal(23, YachtGame.Score(new[] { 3, 3, 5, 6, 6 }, YachtCategory.Choice));
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Yacht_as_choice()
     {
         Assert.Equal(10, YachtGame.Score(new[] { 2, 2, 2, 2, 2 }, YachtCategory.Choice));

--- a/exercises/zebra-puzzle/ZebraPuzzleTests.cs
+++ b/exercises/zebra-puzzle/ZebraPuzzleTests.cs
@@ -10,7 +10,7 @@ public class ZebraPuzzleTests
         Assert.Equal(Nationality.Norwegian, ZebraPuzzle.DrinksWater());
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Resident_who_owns_zebra()
     {
         Assert.Equal(Nationality.Japanese, ZebraPuzzle.OwnsZebra());

--- a/exercises/zipper/ZipperTests.cs
+++ b/exercises/zipper/ZipperTests.cs
@@ -14,7 +14,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Left_right_and_value()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -24,7 +24,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Dead_end()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -33,7 +33,7 @@ public class ZipperTests
         Assert.Null(actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Tree_from_deep_focus()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -43,7 +43,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Traversing_up_from_top()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -52,7 +52,7 @@ public class ZipperTests
         Assert.Null(actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Left_right_and_up()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -62,7 +62,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_value()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -72,7 +72,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_value_after_traversing_up()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -82,7 +82,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_left_with_leaf()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -92,7 +92,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_right_with_null()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -102,7 +102,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_right_with_subtree()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -112,7 +112,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Set_value_on_deep_focus()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));
@@ -122,7 +122,7 @@ public class ZipperTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(Skip = "Remove to run test")]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Different_paths_to_same_zipper()
     {
         var tree = new BinTree(1, new BinTree(2, null, new BinTree(3, null, null)), new BinTree(4, null, null));

--- a/generators/Exercises/Generators/Clock.cs
+++ b/generators/Exercises/Generators/Clock.cs
@@ -20,7 +20,7 @@ namespace Exercism.CSharp.Exercises.Generators
 
         protected override void UpdateTestClass(TestClass testClass)
         {
-            testClass.AdditionalMethods.Add(@"[Fact(Skip = ""Remove to run test"")]
+            testClass.AdditionalMethods.Add(@"[Fact(Skip = ""Remove this Skip property to run this test"")]
 public void Clocks_are_immutable()
 {
     var sut = new Clock(0, 0);

--- a/generators/Exercises/Generators/DndCharacter.cs
+++ b/generators/Exercises/Generators/DndCharacter.cs
@@ -83,7 +83,7 @@ namespace Exercism.CSharp.Exercises.Generators
         private static void AddTestMethodForDistribution(TestClass testClass)
         {
             testClass.AdditionalMethods.Add(@"
-[Fact(Skip = ""Remove to run test"")]
+[Fact(Skip = ""Remove this Skip property to run this test"")]
 public void Random_ability_is_distributed_correctly()
 {
     var expectedDistribution = new Dictionary<int, int>

--- a/generators/Output/Rendering/Templates/_TestMethod.liquid
+++ b/generators/Output/Rendering/Templates/_TestMethod.liquid
@@ -1,4 +1,4 @@
-﻿[Fact{% if Skip %}(Skip = "Remove to run test"){% endif %}]
+﻿[Fact{% if Skip %}(Skip = "Remove this Skip property to run this test"){% endif %}]
 public void {{ Name }}()
 {
 {{ Arrange | indent }}

--- a/test.ps1
+++ b/test.ps1
@@ -52,7 +52,7 @@ function Copy-Exercises {
 function Enable-All-Tests {
     Write-Output "Enabling all tests"
     Get-ChildItem -Path $buildDir -Include "*Tests.cs" -Recurse | ForEach-Object {
-        (Get-Content $_.FullName) -replace "Skip = ""Remove to run test""", "" | Set-Content $_.FullName
+        (Get-Content $_.FullName) -replace "Skip = ""Remove this Skip property to run this test""", "" | Set-Content $_.FullName
     }
 }
 


### PR DESCRIPTION
Per https://github.com/exercism/v3/issues/1047

PR is paired with same change for v3: https://github.com/exercism/v3/pull/1082

Ran: `grep -ril "Remove to run test" . | xargs sed -i "s/Remove to run test/Remove this Skip property to run this test/"`

Any other repos with tooling for this track that may need updating?