### PR TITLE
Fixed bugs preventing script to scaffold new exercise from running and added readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Exercism exercises in C#
 Please see the [contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks)
 
 ### Adding a new exercise
-To add a new exercise you can run the add-new-exercise.ps1 powershell script. This will create all the necessary files and tests for you. Then you just need to implement the Example.cs file.  Parameters and examples for running the script can be found in the script file.  
+To add a new exercise you can run the `add-new-exercise.ps1` PowerShell script. This will create all the necessary files and tests for you. Then you just need to implement the `Example.cs` file and to check if the generated tests make sense. Parameters and examples for running the script can be found in the script file.  
 
 ## Support
 Need assistance? Check out our Gitter Channel at https://gitter.im/exercism/xcsharp where you can get support and ask questions related to the C# track.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Exercism exercises in C#
 
 Please see the [contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks)
 
-##### Adding a new exercise
+### Adding a new exercise
 To add a new exercise you can run the add-new-exercise.ps1 powershell script. This will create all the necessary files and tests for you. Then you just need to implement the Example.cs file.  Parameters and examples for running the script can be found in the script file.  
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -8,5 +8,8 @@ Exercism exercises in C#
 
 Please see the [contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks)
 
+##### Adding a new exercise
+To add a new exercise you can run the add-new-exercise.ps1 powershell script. This will create all the necessary files and tests for you. Then you just need to implement the Example.cs file.  Parameters and examples for running the script can be found in the script file.  
+
 ## Support
 Need assistance? Check out our Gitter Channel at https://gitter.im/exercism/xcsharp where you can get support and ask questions related to the C# track.

--- a/add-new-exercise.ps1
+++ b/add-new-exercise.ps1
@@ -54,14 +54,14 @@ function Add-Project {
     New-Item -ItemType File -Path "$exerciseDir/Example.cs"
     
     [xml]$proj = Get-Content $csProj
-    $compilePropertyGroup = $proj.CreateElement("PropertyGroup");
+    $compileItemGroup = $proj.CreateElement("ItemGroup");
     $compileElement = $proj.CreateElement("Compile");
     $removeAttribute = $proj.CreateAttribute("Remove");
     $removeAttribute.Value = "Example.cs";
     $compileElement.Attributes.Append($removeAttribute);
-    $compilePropertyGroup.AppendChild($compileElement);
+    $compileItemGroup.AppendChild($compileElement);
     $propertyGroup = $proj.Project.PropertyGroup
-    $propertyGroup.ParentNode.InsertAfter($compilePropertyGroup, $propertyGroup)
+    $propertyGroup.ParentNode.InsertAfter($compileItemGroup, $propertyGroup)
     $proj.Save($csProj)
 }
 

--- a/copy-track-files.ps1
+++ b/copy-track-files.ps1
@@ -35,7 +35,7 @@ function Copy-Track-Files {
     Write-Output "Copying track files"
 
     $filter = if ($Exercise) { $($Exercise) } else { @() }
-    Get-Childitem –Path "exercises" -Filter $filter -Directory | ForEach-Object {
+    Get-Childitem -Path "exercises" -Filter $filter -Directory | ForEach-Object {
         Copy-Track-Files-For-Exercise -ExerciseDirectory $_
     }
 }


### PR DESCRIPTION
3 things added in this PR:

1) A character in copy-track-files.ps1 was incorrect and caused the add-new-exercise.ps1 to error out.  The dash (-) was replaced to resolve the issue.
2) The add-new-exercise.ps1 was adding the following property group to the .csproj of new exercise
```
<PropertyGroup>
    <Compile Remove="Example.cs" />
</PropertyGroup>
```
This prevent Visual Studio 2019 from loading the .csproj.  Other exercises seem to use `ItemGroup` instead, so I changed the script to use `ItemGroup` to fix the error.
3) Added a new section to the README explaining how to add a new exercise using the scaffolding script.


Resolves #1416