### PR TITLE
🤖 Add file patterns to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,6 +14,20 @@
     "indent_style": "space",
     "indent_size": 4
   },
+  "files": {
+    "solution": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "test": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "example": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "exemplar": [
+      "path/to/%{kebab_slug}.ext"
+    ]
+  },
   "exercises": {
     "concept": [
       {
@@ -641,8 +655,14 @@
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "57f02d0e-7b75-473b-892d-26a7d980c4ce",
-        "practices": ["optional-parameters", "string-interpolation"],
-        "prerequisites": ["optional-parameters", "string-interpolation"],
+        "practices": [
+          "optional-parameters",
+          "string-interpolation"
+        ],
+        "prerequisites": [
+          "optional-parameters",
+          "string-interpolation"
+        ],
         "difficulty": 1,
         "topics": [
           "optional_values",
@@ -653,8 +673,15 @@
         "slug": "leap",
         "name": "Leap",
         "uuid": "8ba15933-29a2-49b1-a9ce-70474bad3007",
-        "practices": ["math-operators", "if-statements"],
-        "prerequisites": ["math-operators", "if-statements", "numbers"],
+        "practices": [
+          "math-operators",
+          "if-statements"
+        ],
+        "prerequisites": [
+          "math-operators",
+          "if-statements",
+          "numbers"
+        ],
         "difficulty": 1,
         "topics": [
           "conditionals",
@@ -1059,8 +1086,18 @@
         "slug": "accumulate",
         "name": "Accumulate",
         "uuid": "3c0563dc-665a-45b4-9b29-f133e235efd0",
-        "practices": ["lambdas", "foreach", "yield"],
-        "prerequisites": ["lambdas", "generic-types", "foreach", "enumerables", "extension-methods"],
+        "practices": [
+          "lambdas",
+          "foreach",
+          "yield"
+        ],
+        "prerequisites": [
+          "lambdas",
+          "generic-types",
+          "foreach",
+          "enumerables",
+          "extension-methods"
+        ],
         "difficulty": 2,
         "topics": [
           "extension_methods",

--- a/config.json
+++ b/config.json
@@ -15,18 +15,10 @@
     "indent_size": 4
   },
   "files": {
-    "solution": [
-      "path/to/%{kebab_slug}.ext"
-    ],
-    "test": [
-      "path/to/%{kebab_slug}.ext"
-    ],
-    "example": [
-      "path/to/%{kebab_slug}.ext"
-    ],
-    "exemplar": [
-      "path/to/%{kebab_slug}.ext"
-    ]
+    "solution": ["%{pascal_slug}.cs"],
+    "test": ["%{pascal_slug}Tests.cs"],
+    "example": [".meta/Example.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   },
   "exercises": {
     "concept": [
@@ -655,14 +647,8 @@
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "57f02d0e-7b75-473b-892d-26a7d980c4ce",
-        "practices": [
-          "optional-parameters",
-          "string-interpolation"
-        ],
-        "prerequisites": [
-          "optional-parameters",
-          "string-interpolation"
-        ],
+        "practices": ["optional-parameters", "string-interpolation"],
+        "prerequisites": ["optional-parameters", "string-interpolation"],
         "difficulty": 1,
         "topics": [
           "optional_values",
@@ -673,15 +659,8 @@
         "slug": "leap",
         "name": "Leap",
         "uuid": "8ba15933-29a2-49b1-a9ce-70474bad3007",
-        "practices": [
-          "math-operators",
-          "if-statements"
-        ],
-        "prerequisites": [
-          "math-operators",
-          "if-statements",
-          "numbers"
-        ],
+        "practices": ["math-operators", "if-statements"],
+        "prerequisites": ["math-operators", "if-statements", "numbers"],
         "difficulty": 1,
         "topics": [
           "conditionals",
@@ -1086,18 +1065,8 @@
         "slug": "accumulate",
         "name": "Accumulate",
         "uuid": "3c0563dc-665a-45b4-9b29-f133e235efd0",
-        "practices": [
-          "lambdas",
-          "foreach",
-          "yield"
-        ],
-        "prerequisites": [
-          "lambdas",
-          "generic-types",
-          "foreach",
-          "enumerables",
-          "extension-methods"
-        ],
+        "practices": ["lambdas", "foreach", "yield"],
+        "prerequisites": ["lambdas", "generic-types", "foreach", "enumerables", "extension-methods"],
         "difficulty": 2,
         "topics": [
           "extension_methods",


### PR DESCRIPTION
**⚠ This PR requires you to make a simple change before merging. ⚠**

---

To save maintainers from having to manually specify the `files` key in their exercises' `.meta/config.json` files, we are providing support for track-level patterns. See [this PR](https://github.com/exercism/docs/pull/58) for details.

This PR adds (**purposefully wrong**) file patterns to the `config.json` file. It is up to you, the track maintainers, to change these patterns to their correct value.

You can use the following placeholders:
- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)

We will soon update `configlet` to enable it to automatically populate the `.meta/config.json` file's `files` property, at which point we will then batch-PR updates to all tracks that have merged this PR.

## Tracking
https://github.com/exercism/v3-launch/issues/19
