### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "c4c4c0aa-673d-431c-ad61-f902275a70f4",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing C# locally",
+      "blurb": "Learn how to install C# locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "ae6b8e1c-538e-4431-89e9-c02640e4c3c5",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn C#",
+      "blurb": "An overview of how to get started from scratch with C#"
+    },
+    {
+      "uuid": "fa718304-b7c2-4114-a288-0b4b91414771",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the C# track",
+      "blurb": "Learn how to test your C# exercises on Exercism"
+    },
+    {
+      "uuid": "6e10c3d3-f463-4606-92fe-b3152d51de58",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful C# resources",
+      "blurb": "A collection of useful resources to help you master C#"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
