### PR TITLE
Remove Tasks heading from instructions.md

### DIFF
--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -17,8 +17,6 @@ Having found the kidnappers, Annalyn considers which of the following actions sh
 
 You have four tasks: to implement the logic for determining if the above actions are available based on the state of the three characters found in the forest and whether Annalyn's pet dog is present or not.
 
-## Tasks
-
 ## 1. Check if a fast attack can be made
 
 Implement the (_static_) `QuestLogic.CanFastAttack()` method that takes a boolean value that indicates if the knight is awake. This method returns `true` if a fast attack can be made based on the state of the knight. Otherwise, returns `false`:


### PR DESCRIPTION
The `## Tasks` heading should not be in `instructions.md` files.
