### PR TITLE
🤖 Add labels append file

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,0 +1,72 @@
+- name: "bug"
+  description: ""
+  color: "fc2929"
+
+- name: "dependencies"
+  description: "Pull requests that update a dependency file"
+  color: "0025ff"
+
+- name: "discussion"
+  description: ""
+  color: "cc317c"
+
+- name: "documentation"
+  description: ""
+  color: "cc317c"
+
+- name: "duplicate"
+  description: ""
+  color: "cccccc"
+
+- name: "enhancement"
+  description: ""
+  color: "84b6eb"
+
+- name: "feature"
+  description: ""
+  color: "0e8a16"
+
+- name: "good first issue"
+  description: ""
+  color: "fcd8c4"
+
+- name: "hacktoberfest"
+  description: ""
+  color: "FF4500"
+
+- name: "help wanted"
+  description: ""
+  color: "0e8a16"
+
+- name: "in-progress"
+  description: ""
+  color: "fbca04"
+
+- name: "invalid"
+  description: ""
+  color: "cccccc"
+
+- name: "on-hold"
+  description: ""
+  color: "cccccc"
+
+- name: "optimization"
+  description: ""
+  color: "84b6eb"
+
+- name: "question"
+  description: ""
+  color: "cc317c"
+
+- name: "v3-migration 🤖"
+  description: "Preparing for Exercism v3"
+  color: "E99695"
+
+- name: "waiting-on-external"
+  description: ""
+  color: "2020a3"
+
+- name: "wontfix"
+  description: ""
+  color: "cccccc"
+


### PR DESCRIPTION
This PR adds a `.appends/.github/labels.yml` file, which contains all the labels that are currently used in this repo. The `.github/labels.yml` file will contain the full list of labels that this repo can use, which will be a combination of the `.appends/.github/labels.yml` file and a centrally-managed `labels.yml` file.

We'll automatically sync any changes, which allows us to guarantee that all the track repositories will have a pre-determined set of labels, augmented with any custom labels defined in the `.appends/.github/labels.yml` file. This syncing will be done by another (automatically-synced) workflow, which we will add in a later PR.

## Tracking

https://github.com/exercism/v3-launch/issues/41