### PR TITLE
Luhn: A new test case with odd number of digits

### DIFF
--- a/exercises/practice/luhn/LuhnTests.cs
+++ b/exercises/practice/luhn/LuhnTests.cs
@@ -101,6 +101,12 @@ public class LuhnTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Valid_string_with_an_odd_number_of_digits_and_non_zero_first_digit()
+    {
+        Assert.True(Luhn.IsValid("109"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Using_ascii_value_for_non_doubled_non_digit_isnt_allowed()
     {
         Assert.False(Luhn.IsValid("055b 444 285"));


### PR DESCRIPTION
A new positive test case with odd number of digits and non-zero first digit.
I have seen a solution in Golang which passes all the tests for Luhn containing odd number of digits and never reads the first digit.
It happens because in all such cases the first digit is zero . I am sure it is also relevant for C#.