### PR TITLE
Update hints.md

### DIFF
--- a/exercises/practice/rational-numbers/hints.md
+++ b/exercises/practice/rational-numbers/hints.md
@@ -1,5 +1,4 @@
 # Hints		
 This exercise requires you to write an extension method. For more information, see [this page](https://msdn.microsoft.com/en-us//library/bb383977.aspx).
 
-This exercise also requires you to write operator overloading methods for +, -, * and / operators. For more information, see [this page](https://msdn.microsoft.com/en-us/library/5tk49fh2.aspx).
-
+This exercise also requires you to write operator overloading methods for +, -, * and / operators. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/operator-overloading).


### PR DESCRIPTION
Changed link to point correctly to C# Operator overload reference page instead of c++ Operator overload reference page.