### PR TITLE
🤖 Remove empty `source_url` property

### DIFF
--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -22,6 +22,5 @@
       ".meta/Example.cs"
     ]
   },
-  "source": "Inspired by an interview question at a famous company.",
-  "source_url": ""
+  "source": "Inspired by an interview question at a famous company."
 }


### PR DESCRIPTION
The track CI runs `configlet lint`, which currently exits with a
non-zero exit code if it sees an optional string key that has the value
of the empty string.

This PR therefore removes all such key/value pairs on the track -
they otherwise cause a failing CI check.


---

Tracking: https://github.com/exercism/v3-launch/issues/57
