### PR TITLE
Add tests for warrior damage

### DIFF
--- a/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
+++ b/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
@@ -65,4 +65,23 @@ public class RolePlayingGameTests
 
         Assert.Equal(3, wizard.DamagePoints(otherWizard));
     }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Attack_points_for_warrior_with_vulnerable_target()
+    {
+        var warrior = new Warrior();
+        var wizard = new Wizard();
+
+        Assert.Equal(10, warrior.DamagePoints(wizard));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Attack_points_for_warrior_with_non_vulnerable_target()
+    {
+        var warrior = new Warrior();
+        var wizard = new Wizard();
+        wizard.PrepareSpell();
+
+        Assert.Equal(6, warrior.DamagePoints(wizard));
+    }
 }


### PR DESCRIPTION
New tests have been added to test the warrior's damage, according to the specs for the exercise.

This was previously reported as issue [#1593](https://github.com/exercism/csharp/issues/1593)