### PR TITLE
Fix link contributing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism exercises in C#
 
 ## Contributing Guide
 
-Please see the [contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks)
+Please see the [contributing guide](https://exercism.org/docs/building)
 
 ### Adding a new exercise
 To add a new exercise you can run the `add-new-exercise.ps1` PowerShell script. This will create all the necessary files and tests for you. Then you just need to implement the `Example.cs` file and to check if the generated tests make sense. Parameters and examples for running the script can be found in the script file.  


### PR DESCRIPTION
Fix for issue #1594: The link in the README file pointing to the contributing guide was broken. This change replaces it with the new link on the exercism page.