### PR TITLE
Change exception type for weighing machine example

### DIFF
--- a/exercises/concept/weighing-machine/.docs/instructions.md
+++ b/exercises/concept/weighing-machine/.docs/instructions.md
@@ -48,7 +48,7 @@ Add validation to the `WeighingMachine.InputWeight` property to throw an `Argume
 
 ```csharp
 var wm = new WeighingMachine();
-wm.InputWeight = -10m; // Throws an ArgumentException
+wm.InputWeight = -10m; // Throws an ArgumentOutOfRangeException
 ```
 
 ## 3. Allow the US weight to be retrieved

--- a/exercises/concept/weighing-machine/.meta/Exemplar.cs
+++ b/exercises/concept/weighing-machine/.meta/Exemplar.cs
@@ -24,7 +24,7 @@ class WeighingMachine
         {
             if (value < 0)
             {
-                throw new ArgumentException("weight cannot be negative");
+                throw new ArgumentOutOfRangeException("weight cannot be negative");
             }
 
             inputWeight = value;

--- a/exercises/concept/weighing-machine/WeighingMachineTests.cs
+++ b/exercises/concept/weighing-machine/WeighingMachineTests.cs
@@ -16,7 +16,7 @@ public class WeighingMachineTests
     public void Negative_weight_is_invalid()
     {
         var wm = new WeighingMachine();
-        Assert.Throws<ArgumentException>(() => wm.InputWeight = -10);
+        Assert.Throws<ArgumentOutOfRangeException>(() => wm.InputWeight = -10);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]


### PR DESCRIPTION
Fixes #1609
Replace the exception checked in the tests and the exception stated in the code example in the instruction to be an `ArgumentOutOfRangeException`