### PR TITLE
Removed unused property on the Manager class

### DIFF
--- a/exercises/concept/football-match-reports/.meta/Exemplar.cs
+++ b/exercises/concept/football-match-reports/.meta/Exemplar.cs
@@ -76,12 +76,10 @@ public static class PlayAnalyzer
 public class Manager
 {
     public string Name { get; }
-    public string Activity { get; }
 
-    public Manager(string name, string activity)
+    public Manager(string name)
     {
         this.Name = name;
-        this.Activity = activity;
     }
 }
 

--- a/exercises/concept/football-match-reports/FootballMatchReports.cs
+++ b/exercises/concept/football-match-reports/FootballMatchReports.cs
@@ -17,12 +17,10 @@ public static class PlayAnalyzer
 public class Manager
 {
     public string Name { get; }
-    public string Activity { get; }
 
-    public Manager(string name, string activity)
+    public Manager(string name)
     {
         this.Name = name;
-        this.Activity = activity;
     }
 }
 

--- a/exercises/concept/football-match-reports/FootballMatchReportsTests.cs
+++ b/exercises/concept/football-match-reports/FootballMatchReportsTests.cs
@@ -61,14 +61,14 @@ public class TuplesTest
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void AnalyzeOffField_anonymous_manager()
     {
-        Assert.Equal("the manager", PlayAnalyzer.AnalyzeOffField(new Manager(string.Empty, string.Empty)));
+        Assert.Equal("the manager", PlayAnalyzer.AnalyzeOffField(new Manager(string.Empty)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void AnalyzeOffField_named_manager()
     {
         Assert.Equal("José Mário dos Santos Mourinho Félix",
-            PlayAnalyzer.AnalyzeOffField(new Manager("José Mário dos Santos Mourinho Félix", string.Empty)));
+            PlayAnalyzer.AnalyzeOffField(new Manager("José Mário dos Santos Mourinho Félix")));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]


### PR DESCRIPTION
The Activity property on the Manager class is never used in the tests. Also, the instructions don't make mention of it as one of the tasks that needs to be implemented. I suggest removing the property to add clarity to the Manager class and associated tests.