### PR TITLE
Change the return type for TestTrack.Race() to void

### DIFF
--- a/exercises/concept/remote-control-competition/.meta/Exemplar.cs
+++ b/exercises/concept/remote-control-competition/.meta/Exemplar.cs
@@ -37,10 +37,9 @@ public class ExperimentalRemoteControlCar : IRemoteControlCar
 
 public static class TestTrack
 {
-    public static decimal Race(IRemoteControlCar car)
+    public static void Race(IRemoteControlCar car)
     {
         car.Drive();
-        return car.DistanceTravelled;
     }
 
     public static List<ProductionRemoteControlCar> GetRankedCars(ProductionRemoteControlCar prc1,

--- a/exercises/concept/remote-control-competition/RemoteControlCompetition.cs
+++ b/exercises/concept/remote-control-competition/RemoteControlCompetition.cs
@@ -29,7 +29,7 @@ public class ExperimentalRemoteControlCar
 
 public static class TestTrack
 {
-    public static int Race(IRemoteControlCar car)
+    public static void Race(IRemoteControlCar car)
     {
         throw new NotImplementedException($"Please implement the (static) TestTrack.Race() method");
     }


### PR DESCRIPTION
The instructions are not clear on what value should be returned. Most users are returning `DistanceTravelled`. However, the unit tests do not check the return value.

I suggest changing the return type to void.