### PR TITLE
Changed expected values according to decription.

### DIFF
--- a/exercises/concept/hyper-optimized-telemetry/HyperOptimizedTelemetryTests.cs
+++ b/exercises/concept/hyper-optimized-telemetry/HyperOptimizedTelemetryTests.cs
@@ -64,14 +64,14 @@ public class TelemetryBufferTests
     public void ToBuffer_upper_short()
     {
         var bytes = TelemetryBuffer.ToBuffer(Int16.MaxValue);
-        Assert.Equal(new byte[] { 0xfe, 0xff, 0x7f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, bytes);
+        Assert.Equal(new byte[] { 0x2, 0xff, 0x7f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, bytes);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void ToBuffer_Zero()
     {
         var bytes = TelemetryBuffer.ToBuffer(0);
-        Assert.Equal(new byte[] { 0xfe, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, bytes);
+        Assert.Equal(new byte[] { 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, bytes);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]


### PR DESCRIPTION
According to the table in Problem statement the values should be positive as the numbers fall into the range of ushort Type.
Table in description:
![image](https://user-images.githubusercontent.com/63421973/133880694-c15f6229-3956-442c-97d0-9f0553b9e13b.png)
Values in test case:
![image](https://user-images.githubusercontent.com/63421973/133880737-7f9d3758-4fdb-4b77-a12e-fb5a9ca0e7eb.png)
As the values fall into the ushort Type range the prefix should indicate a positive value as seen below
![image](https://user-images.githubusercontent.com/63421973/133880813-c0ba119c-3f5b-4c28-be51-462a0d6a6ed8.png)

Solves #1621 
