### PR TITLE
The count should be 4 as there are already 3 values in Dictionary.

### DIFF
--- a/exercises/concept/international-calling-connoisseur/InternationalCallingConnoisseurTests.cs
+++ b/exercises/concept/international-calling-connoisseur/InternationalCallingConnoisseurTests.cs
@@ -157,11 +157,11 @@ public class DialingCodesTest
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Update_country_name_in_dictionary_for_non_existent_country_count_is_3()
+    public void Update_country_name_in_dictionary_for_non_existent_country_count_is_4()
     {
         var countryCodes = DialingCodes.UpdateDictionary(
             DialingCodes.GetExistingDictionary(), 999, "Newlands");
-        Assert.Equal(3, countryCodes.Count);
+        Assert.Equal(4, countryCodes.Count);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]


### PR DESCRIPTION
see test #2 
```cs

    [Fact]
    public void Existing_dictionary_count_is_3()
    {
        var prePopulated = DialingCodes.GetExistingDictionary();
        Assert.Equal(3, prePopulated.Count);
    }
```
and problem description
![image](https://user-images.githubusercontent.com/63421973/133938065-14c45924-2c55-4300-9426-15102be1a2d2.png)



