### PR TITLE
hyper-optimized-telemetry: improve instructions

### DIFF
--- a/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
+++ b/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
@@ -6,7 +6,7 @@ Data is transmitted in a buffer (byte array). When integers are sent, the size o
 
 Each value should be represented in the smallest possible integral type (types of `byte` and `sbyte` are not included as the saving would be trivial):
 
-| Min Value                  | Max Value                 | Type     |
+| From                       | To                        | Type     |
 | -------------------------- | ------------------------- | -------- |
 | 4,294,967,296              | 9,223,372,036,854,775,807 | `long`   |
 | 2,147,483,648              | 4,294,967,295             | `uint`   |

--- a/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
+++ b/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
@@ -9,12 +9,12 @@ Each value should be represented in the smallest possible integral type (types o
 | Min Value                  | Max Value                 | Type     |
 | -------------------------- | ------------------------- | -------- |
 | 4,294,967,296              | 9,223,372,036,854,775,807 | `long`   |
-| -9,223,372,036,854,775,808 | -2,147,483,649            | `long`   |
 | 2,147,483,648              | 4,294,967,295             | `uint`   |
 | 65,536                     | 2,147,483,647             | `int`    |
-| -2,147,483,648             | -32,769                   | `int`    |
 | 0                          | 65,535                    | `ushort` |
 | -32,768                    | -1                        | `short`  |
+| -2,147,483,648             | -32,769                   | `int`    |
+| -9,223,372,036,854,775,808 | -2,147,483,649            | `long`   |
 
 The value should be converted to the appropriate number of bytes for its assigned type. The complete buffer comprises a byte indicating the number of additional bytes in the buffer (_prefix byte_) followed by the bytes holding the integer (_payload bytes_).
 

--- a/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
+++ b/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
@@ -8,13 +8,13 @@ Each value should be represented in the smallest possible integral type (types o
 
 | From                       | To                        | Type     |
 | -------------------------- | ------------------------- | -------- |
-| 4,294,967,296              | 9,223,372,036,854,775,807 | `long`   |
-| 2,147,483,648              | 4,294,967,295             | `uint`   |
-| 65,536                     | 2,147,483,647             | `int`    |
-| 0                          | 65,535                    | `ushort` |
-| -32,768                    | -1                        | `short`  |
-| -2,147,483,648             | -32,769                   | `int`    |
-| -9,223,372,036,854,775,808 | -2,147,483,649            | `long`   |
+| 4_294_967_296              | 9_223_372_036_854_775_807 | `long`   |
+| 2_147_483_648              | 4_294_967_295             | `uint`   |
+| 65_536                     | 2_147_483_647             | `int`    |
+| 0                          | 65_535                    | `ushort` |
+| -32_768                    | -1                        | `short`  |
+| -2_147_483_648             | -32_769                   | `int`    |
+| -9_223_372_036_854_775_808 | -2_147_483_649            | `long`   |
 
 The value should be converted to the appropriate number of bytes for its assigned type. The complete buffer comprises a byte indicating the number of additional bytes in the buffer (_prefix byte_) followed by the bytes holding the integer (_payload bytes_).
 

--- a/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
+++ b/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
@@ -18,7 +18,7 @@ Each value should be represented in the smallest possible integral type (types o
 
 The value should be converted to the appropriate number of bytes for its assigned type. The complete buffer comprises a byte indicating the number of additional bytes in the buffer (_prefix byte_) followed by the bytes holding the integer (_payload bytes_).
 
-If the payload bytes represent a signed type (`short`, `int` or `long`) then the prefix byte should contain the length as a negative number.
+Some of the types use an identical number of bytes (e.g. the `uint` and `int` types). Normally, they would have the same _prefix byte_, but that would make decoding problematic. To counter this, the protocol introduces a little trick: for signed types, their _prefix byte_ value is `256` minus the number of additional bytes in the buffer.
 
 Only the prefix byte and the number of following bytes indicated by the prefix will be sent in the communication. Internally a 9 byte buffer is used (with trailing zeroes, as necessary) both by sending and receiving routines.
 
@@ -27,12 +27,13 @@ Only the prefix byte and the number of following bytes indicated by the prefix w
 Please implement the static method `TelemetryBuffer.ToBuffer()` to encode a buffer taking the parameter passed to the method.
 
 ```csharp
+// Type: ushort, bytes: 2, signed: no, prefix byte: 2
 TelemetryBuffer.ToBuffer(5)
 // => {0x2, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+
+// Type: int, bytes: 4, signed: yes, prefix byte: 256 - 4
 TelemetryBuffer.ToBuffer(Int32.MaxValue)
 // => {0xfc, 0xff, 0xff, 0xff, 0x7f, 0x0, 0x0, 0x0, 0x0 };
-TelemetryBuffer.ToBuffer(-1)
-// => {0xfe, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
 ```
 
 ## 2. Decode a received buffer
@@ -44,4 +45,4 @@ TelemetryBuffer.FromBuffer(new byte[] {0xfc, 0xff, 0xff, 0xff, 0x7f, 0x0, 0x0, 0
 // => 2147483647
 ```
 
-If the prefix byte is not one of -8, -4, -2, 2, 4 then 0 should be returned.
+If the prefix byte is not one of `-8`, `-4`, `-2`, `2` or `4` then `0` should be returned.


### PR DESCRIPTION
This PR aims to make the instructions of the `hyper-optimized-telemetry` exercise a bit more clear.

- re-order ranges
- change heading
- don't use locale-specific thousands separator

@18-F-cali This does not fix #1621, but it should at least help clarify things a bit more I feel. What do you think?