### PR TITLE
Fix incorrect code sample in instructions

### DIFF
--- a/exercises/concept/instruments-of-texas/.docs/instructions.md
+++ b/exercises/concept/instruments-of-texas/.docs/instructions.md
@@ -29,7 +29,7 @@ Implement the `CalculatorTestHarness.TestMultiplication()` method which takes tw
 
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());
-cth.Multiply(6, 7);
+cth.TestMultiplication(6, 7);
 // => "Multiply succeeded"
 ```
 


### PR DESCRIPTION
The text references `TestMultiplication` whereas the code that follows was showing the use of `Multiply` (even though the shown expected result is the one that would be provided by `TestMultiplication`