### PR TITLE
Added a hint to remove static members

### DIFF
--- a/exercises/concept/faceid-2/.docs/hints.md
+++ b/exercises/concept/faceid-2/.docs/hints.md
@@ -27,6 +27,10 @@ Consider the [`HashSet<T>.Contains()`][hash-set-contains] method.
 
 This [documentation][reference-equality] addresses the issue of comparing instances as opposed to values.
 
+## 6. Potential workaround for failing tests
+
+If you encounter issues with the [test runner][exercism-test-runner] failing, try using instance members rather than `static` members in the `Authenticator` class.
+
 [equality]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/equality-comparisons
 [hash-set]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1?view=netcore-3.1
 [hash-code]: https://docs.microsoft.com/en-us/dotnet/api/system.hashcode?view=netcore-3.1
@@ -34,3 +38,4 @@ This [documentation][reference-equality] addresses the issue of comparing instan
 [reference-equality]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/equality-comparisons#reference-equality
 [value-equality]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type
 [hash-set-contains]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.contains?view=netcore-3.1
+[exercism-test-runner]: https://exercism.org/docs/building/tooling/test-runners

--- a/exercises/concept/faceid-2/.docs/hints.md
+++ b/exercises/concept/faceid-2/.docs/hints.md
@@ -21,7 +21,7 @@ The most performant, and "natural", way to handle a collection of unique values 
 
 ## 4. Prevent invalid identities being authenticated
 
-Consider the [`HashSet<T>.Contains()`][hash-set-contains] method. If you encounter issues with the [test runner][exercism-test-runner] failing, try using instance members rather than `static` members in the `Authenticator` class.
+Consider the [`HashSet<T>.Contains()`][hash-set-contains] method. If you encounter issues with the tests passing locally but failing on the website, try using instance members rather than `static` members in the `Authenticator` class.
 
 ## 5. Add diagnostics to detect multiple attempts to authenticate
 

--- a/exercises/concept/faceid-2/.docs/hints.md
+++ b/exercises/concept/faceid-2/.docs/hints.md
@@ -17,7 +17,7 @@ This is simply a case of applying the lessons learnt in task 1 in a trivially re
 
 ## 3. Register new identities
 
-The most performant, and "natural", way to handle a collection of unique values is by using a [hash set][hash-set]. If you encounter issues with the [test runner][exercism-test-runner] failing, try using instance members rather than `static` members in the `Authenticator` class.
+The most performant, and "natural", way to handle a collection of unique values is by using a [hash set][hash-set]. If you encounter issues with the tests passing locally but failing on the website, try using instance members rather than `static` members in the `Authenticator` class.
 
 ## 4. Prevent invalid identities being authenticated
 

--- a/exercises/concept/faceid-2/.docs/hints.md
+++ b/exercises/concept/faceid-2/.docs/hints.md
@@ -17,19 +17,15 @@ This is simply a case of applying the lessons learnt in task 1 in a trivially re
 
 ## 3. Register new identities
 
-The most performant, and "natural", way to handle a collection of unique values is by using a [hash set][hash-set].
+The most performant, and "natural", way to handle a collection of unique values is by using a [hash set][hash-set]. If you encounter issues with the [test runner][exercism-test-runner] failing, try using instance members rather than `static` members in the `Authenticator` class.
 
 ## 4. Prevent invalid identities being authenticated
 
-Consider the [`HashSet<T>.Contains()`][hash-set-contains] method.
+Consider the [`HashSet<T>.Contains()`][hash-set-contains] method. If you encounter issues with the [test runner][exercism-test-runner] failing, try using instance members rather than `static` members in the `Authenticator` class.
 
 ## 5. Add diagnostics to detect multiple attempts to authenticate
 
 This [documentation][reference-equality] addresses the issue of comparing instances as opposed to values.
-
-## 6. Potential workaround for failing tests
-
-If you encounter issues with the [test runner][exercism-test-runner] failing, try using instance members rather than `static` members in the `Authenticator` class.
 
 [equality]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/equality-comparisons
 [hash-set]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1?view=netcore-3.1


### PR DESCRIPTION
Static members can cause the test runner to fail. I added a hint about removing them if tests are failing.

Closes https://github.com/exercism/csharp/issues/1630