### PR TITLE
Football-Match-Reports: Changed ArgumentException to ArgumentOutOfRangeException

### DIFF
--- a/exercises/concept/football-match-reports/.docs/instructions.md
+++ b/exercises/concept/football-match-reports/.docs/instructions.md
@@ -28,7 +28,7 @@ PlayAnalyzer.AnalyzeOnField(10);
 
 ## 2. Raise an alert if an unknown shirt number is encountered.
 
-Modify the `PlayAnalyzer.AnalyzeOnField()` method to throw an `ArgumentException` when a shirt number outside the range 1-11 is processed.
+Modify the `PlayAnalyzer.AnalyzeOnField()` method to throw an `ArgumentOutOfRangeException` when a shirt number outside the range 1-11 is processed.
 
 ## 3. Extend the coverage to include off field activity
 

--- a/exercises/concept/football-match-reports/.meta/Exemplar.cs
+++ b/exercises/concept/football-match-reports/.meta/Exemplar.cs
@@ -35,7 +35,7 @@ public static class PlayAnalyzer
                 playerDescription = "striker";
                 break;
             default:
-                throw new ArgumentException();
+                throw new ArgumentOutOfRangeException();
         }
 
         return playerDescription;

--- a/exercises/concept/football-match-reports/FootballMatchReportsTests.cs
+++ b/exercises/concept/football-match-reports/FootballMatchReportsTests.cs
@@ -31,7 +31,7 @@ public class TuplesTest
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void AnalyzeOnField_throws_unknown_shirt_number()
     {
-        Assert.Throws<ArgumentException>(() => PlayAnalyzer.AnalyzeOnField(1729));
+        Assert.Throws<ArgumentOutOfRangeException>(() => PlayAnalyzer.AnalyzeOnField(1729));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]


### PR DESCRIPTION
- Closes #1635
- Replaced `ArgumentException` with `ArgumentOutOfRangeException` for `AnalyzeOnField()` method in Instructions, Exemplar, and Test case