### PR TITLE
Fix capitalization and clarity for UTF-16 example

### DIFF
--- a/concepts/chars/introduction.md
+++ b/concepts/chars/introduction.md
@@ -6,7 +6,7 @@ processed independently. Their literals have single quotes e.g. `'A'`.
 
 C# `char`s support UTF-16 Unicode encoding so in addition to the latin character set
 pretty much all the writing systems in use world can be represented,
-e.g. ancient greek `'β'`.
+e.g. the Greek letter `'β'`.
 
 There are many builtin library methods to inspect and manipulate `char`s. These
 can be found as static methods of the `System.Char` class.

--- a/exercises/concept/squeaky-clean/.docs/introduction.md
+++ b/exercises/concept/squeaky-clean/.docs/introduction.md
@@ -8,7 +8,7 @@ processed independently. Their literals have single quotes e.g. `'A'`.
 
 C# `char`s support UTF-16 Unicode encoding so in addition to the latin character set
 pretty much all the writing systems in use world can be represented,
-e.g. ancient greek `'β'`.
+e.g. the Greek letter `'β'`.
 
 There are many builtin library methods to inspect and manipulate `char`s. These
 can be found as static methods of the `System.Char` class.


### PR DESCRIPTION
I noticed that the proper name 'Ancient Greek' was not properly capitalized in the introduction to chars. I have made changes to fix this and make the example sentence more clear and readable.