### PR TITLE
Fix Tim from Marketing instructions to reflect the correct task output

### DIFF
--- a/exercises/concept/tim-from-marketing/.docs/instructions.md
+++ b/exercises/concept/tim-from-marketing/.docs/instructions.md
@@ -4,7 +4,7 @@ In this exercise you'll be writing code to print name badges for factory employe
 
 ## 1. Print a badge for an employee
 
-Employees have an ID, name and department name. Employee badge labels are formatted as follows: `"[id] - [name] - [DEPARTMENT]"`. Implement the (_static_) `Badge.Print()` method to return an employee's badge label:
+Employees have an ID, name and department name. Employee badge labels are formatted as follows: `"[id] - name - DEPARTMENT"`. Implement the (_static_) `Badge.Print()` method to return an employee's badge label:
 
 ```csharp
 Badge.Print(734, "Ernest Johnny Payne", "Strategic Communication");


### PR DESCRIPTION
In Tim from Marketing, this model pattern is given:

> "[id] - [name] - [DEPARTMENT]"

with this result:

```csharp
// => "[734] - Ernest Johnny Payne - STRATEGIC COMMUNICATION"
```

I suggest that the model pattern is changed to:

> "[id] - name - DEPARTMENT"

to reflect the absence of square brackets around the latter two terms.

Closes https://github.com/exercism/csharp/issues/1592