### PR TITLE
hyperia-forex: Add missing test cases and fix Exemplar.cs

### DIFF
--- a/exercises/concept/hyperia-forex/.meta/Exemplar.cs
+++ b/exercises/concept/hyperia-forex/.meta/Exemplar.cs
@@ -24,7 +24,12 @@ public struct CurrencyAmount
 
     public static bool operator !=(CurrencyAmount @this, CurrencyAmount other)
     {
-        return @this != other;
+        if (@this.currency != other.currency)
+        {
+            throw new ArgumentException();
+        }
+
+        return @this.amount != other.amount;
     }
 
     public static bool operator >(CurrencyAmount @this, CurrencyAmount other)

--- a/exercises/concept/hyperia-forex/.meta/Exemplar.cs
+++ b/exercises/concept/hyperia-forex/.meta/Exemplar.cs
@@ -82,11 +82,6 @@ public struct CurrencyAmount
         return new CurrencyAmount(@this.amount / divisor, @this.currency);
     }
 
-    public static CurrencyAmount operator /(decimal divisor, CurrencyAmount @this)
-    {
-        return new CurrencyAmount(@this.amount / divisor, @this.currency);
-    }
-
     public static explicit operator double(CurrencyAmount @this)
     {
         return (double)@this.amount;

--- a/exercises/concept/hyperia-forex/.meta/config.json
+++ b/exercises/concept/hyperia-forex/.meta/config.json
@@ -1,21 +1,10 @@
 {
   "blurb": "Learn about operator overloading by introducing a new currency to a bank.",
-  "contributors": [
-    "ErikSchierboom",
-    "yzAlvin"
-  ],
-  "authors": [
-    "mikedamay"
-  ],
+  "contributors": ["ErikSchierboom", "yzAlvin", "sanderploegsma"],
+  "authors": ["mikedamay"],
   "files": {
-    "solution": [
-      "HyperiaForex.cs"
-    ],
-    "test": [
-      "HyperiaForexTests.cs"
-    ],
-    "exemplar": [
-      ".meta/Exemplar.cs"
-    ]
+    "solution": ["HyperiaForex.cs"],
+    "test": ["HyperiaForexTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/exercises/concept/hyperia-forex/HyperiaForex.csproj
+++ b/exercises/concept/hyperia-forex/HyperiaForex.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FsCheck" Version="2.16.3" />
+    <PackageReference Include="FsCheck.Xunit" Version="2.16.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/exercises/concept/hyperia-forex/HyperiaForexTests.cs
+++ b/exercises/concept/hyperia-forex/HyperiaForexTests.cs
@@ -2,7 +2,7 @@ using System;
 using Xunit;
 using Exercism.Tests;
 
-public class OperatorOverloadingTests
+public class HyperiaForexTests
 {
     [Fact]
     public void Equality_true()
@@ -17,8 +17,116 @@ public class OperatorOverloadingTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Equality_bad()
+    public void Equality_different_currencies()
     {
         Assert.Throws<ArgumentException>(() => new CurrencyAmount(55, "HD") == new CurrencyAmount(60, "USD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Inequality_true()
+    {
+        Assert.True(new CurrencyAmount(55, "HD") != new CurrencyAmount(60, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Inequality_false()
+    {
+        Assert.False(new CurrencyAmount(55, "HD") != new CurrencyAmount(55, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Inequality_different_currencies()
+    {
+        Assert.Throws<ArgumentException>(() => new CurrencyAmount(55, "HD") != new CurrencyAmount(60, "USD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void LessThan_true()
+    {
+        Assert.True(new CurrencyAmount(55, "HD") < new CurrencyAmount(60, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void LessThan_false()
+    {
+        Assert.False(new CurrencyAmount(60, "HD") < new CurrencyAmount(55, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void LessThan_different_currencies()
+    {
+        Assert.Throws<ArgumentException>(() => new CurrencyAmount(55, "HD") < new CurrencyAmount(60, "USD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void GreaterThan_true()
+    {
+        Assert.True(new CurrencyAmount(60, "HD") > new CurrencyAmount(55, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void GreaterThan_false()
+    {
+        Assert.False(new CurrencyAmount(55, "HD") > new CurrencyAmount(60, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void GreaterThan_different_currencies()
+    {
+        Assert.Throws<ArgumentException>(() => new CurrencyAmount(60, "HD") > new CurrencyAmount(55, "USD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Addition_same_currencies()
+    {
+        Assert.Equal(new CurrencyAmount(155, "HD"), new CurrencyAmount(55, "HD") + new CurrencyAmount(100, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Addition_different_currencies()
+    {
+        Assert.Throws<ArgumentException>(() => new CurrencyAmount(55, "HD") + new CurrencyAmount(55, "USD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Subtraction_same_currencies()
+    {
+        Assert.Equal(new CurrencyAmount(45, "HD"), new CurrencyAmount(100, "HD") - new CurrencyAmount(55, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Subtraction_different_currencies()
+    {
+        Assert.Throws<ArgumentException>(() => new CurrencyAmount(100, "HD") - new CurrencyAmount(55, "USD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Multiplication_left_hand_side()
+    {
+        Assert.Equal(new CurrencyAmount(20, "HD"), new CurrencyAmount(10, "HD") * 2m);
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Multiplication_right_hand_side()
+    {
+        Assert.Equal(new CurrencyAmount(20, "HD"), 2m * new CurrencyAmount(10, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Division()
+    {
+        Assert.Equal(new CurrencyAmount(5, "HD"), new CurrencyAmount(10, "HD") / 2m);
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Cast_to_double()
+    {
+        Assert.Equal(55.5d, (double)new CurrencyAmount(55.5m, "HD"));
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Cast_to_decimal()
+    {
+        Assert.Equal(55.5m, (decimal)new CurrencyAmount(55.5m, "HD"));
     }
 }

--- a/exercises/concept/hyperia-forex/HyperiaForexTests.cs
+++ b/exercises/concept/hyperia-forex/HyperiaForexTests.cs
@@ -127,6 +127,7 @@ public class HyperiaForexTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Cast_to_decimal()
     {
-        Assert.Equal(55.5m, (decimal)new CurrencyAmount(55.5m, "HD"));
+        decimal actual = new CurrencyAmount(55.5m, "HD");
+        Assert.Equal(55.5m, actual);
     }
 }

--- a/exercises/concept/hyperia-forex/HyperiaForexTests.cs
+++ b/exercises/concept/hyperia-forex/HyperiaForexTests.cs
@@ -1,133 +1,163 @@
 using System;
 using Xunit;
-using Exercism.Tests;
+using FsCheck.Xunit;
+using FsCheck;
 
 public class HyperiaForexTests
 {
-    [Fact]
-    public void Equality_true()
+    [Property]
+    public void Equality_with_same_currency(decimal value)
     {
-        Assert.True(new CurrencyAmount(55, "HD") == new CurrencyAmount(55, "HD"));
+        var amount1 = new CurrencyAmount(value, "HD");
+        var amount2 = new CurrencyAmount(value, "HD");
+
+        Assert.True(amount1 == amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Equality_false()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Equality_with_different_currency(decimal value)
     {
-        Assert.False(new CurrencyAmount(55, "HD") == new CurrencyAmount(60, "HD"));
+        var amount1 = new CurrencyAmount(value, "HD");
+        var amount2 = new CurrencyAmount(value, "USD");
+
+        Assert.Throws<ArgumentException>(() => amount1 == amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Equality_different_currencies()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public Property Inequality_with_same_currency(decimal value1, decimal value2)
     {
-        Assert.Throws<ArgumentException>(() => new CurrencyAmount(55, "HD") == new CurrencyAmount(60, "USD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "HD");
+
+        return Prop.When(value1 != value2, () => Assert.True(amount1 != amount2));
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Inequality_true()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Inequality_with_different_currency(decimal value1, decimal value2)
     {
-        Assert.True(new CurrencyAmount(55, "HD") != new CurrencyAmount(60, "HD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "USD");
+
+        Assert.Throws<ArgumentException>(() => amount1 != amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Inequality_false()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public Property LessThan_with_same_currency(decimal value1, decimal value2)
     {
-        Assert.False(new CurrencyAmount(55, "HD") != new CurrencyAmount(55, "HD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "HD");
+
+        return Prop.When(value1 < value2, () => Assert.True(amount1 < amount2));
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Inequality_different_currencies()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void LessThan_with_different_currency(decimal value1, decimal value2)
     {
-        Assert.Throws<ArgumentException>(() => new CurrencyAmount(55, "HD") != new CurrencyAmount(60, "USD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "USD");
+
+        Assert.Throws<ArgumentException>(() => amount1 < amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LessThan_true()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public Property GreaterThan_with_same_currency(decimal value1, decimal value2)
     {
-        Assert.True(new CurrencyAmount(55, "HD") < new CurrencyAmount(60, "HD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "HD");
+
+        return Prop.When(value1 > value2, () => Assert.True(amount1 > amount2));
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LessThan_false()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void GreaterThan_with_different_currency(decimal value1, decimal value2)
     {
-        Assert.False(new CurrencyAmount(60, "HD") < new CurrencyAmount(55, "HD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "USD");
+
+        Assert.Throws<ArgumentException>(() => amount1 > amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LessThan_different_currencies()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Addition_with_same_currency(decimal value1, decimal value2)
     {
-        Assert.Throws<ArgumentException>(() => new CurrencyAmount(55, "HD") < new CurrencyAmount(60, "USD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "HD");
+        var expected = new CurrencyAmount(value1 + value2, "HD");
+
+        Assert.Equal(expected, amount1 + amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GreaterThan_true()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Addition_is_commutative(decimal value1, decimal value2)
     {
-        Assert.True(new CurrencyAmount(60, "HD") > new CurrencyAmount(55, "HD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "HD");
+
+        Assert.Equal(amount1 + amount2, amount2 + amount1);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GreaterThan_false()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Addition_with_different_currency(decimal value1, decimal value2)
     {
-        Assert.False(new CurrencyAmount(55, "HD") > new CurrencyAmount(60, "HD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "USD");
+
+        Assert.Throws<ArgumentException>(() => amount1 + amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GreaterThan_different_currencies()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Subtraction_with_same_currency(decimal value1, decimal value2)
     {
-        Assert.Throws<ArgumentException>(() => new CurrencyAmount(60, "HD") > new CurrencyAmount(55, "USD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "HD");
+        var expected = new CurrencyAmount(value1 - value2, "HD");
+
+        Assert.Equal(expected, amount1 - amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Addition_same_currencies()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Subtraction_with_different_currency(decimal value1, decimal value2)
     {
-        Assert.Equal(new CurrencyAmount(155, "HD"), new CurrencyAmount(55, "HD") + new CurrencyAmount(100, "HD"));
+        var amount1 = new CurrencyAmount(value1, "HD");
+        var amount2 = new CurrencyAmount(value2, "USD");
+
+        Assert.Throws<ArgumentException>(() => amount1 - amount2);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Addition_different_currencies()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Multiplication(decimal value, decimal factor)
     {
-        Assert.Throws<ArgumentException>(() => new CurrencyAmount(55, "HD") + new CurrencyAmount(55, "USD"));
+        Assert.Equal(new CurrencyAmount(factor * value, "HD"),
+                     factor * new CurrencyAmount(value, "HD"));
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Subtraction_same_currencies()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Multiplication_is_commutative(decimal value, decimal factor)
     {
-        Assert.Equal(new CurrencyAmount(45, "HD"), new CurrencyAmount(100, "HD") - new CurrencyAmount(55, "HD"));
+        var amount = new CurrencyAmount(value, "HD");
+
+        Assert.Equal(amount * factor, factor * amount);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Subtraction_different_currencies()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public Property Division(decimal value, decimal divisor)
     {
-        Assert.Throws<ArgumentException>(() => new CurrencyAmount(100, "HD") - new CurrencyAmount(55, "USD"));
+        return Prop.When(
+            divisor != 0,
+            () => Assert.True(new CurrencyAmount(value, "HD") / divisor ==
+                              new CurrencyAmount(value / divisor, "HD")));
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Multiplication_left_hand_side()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Cast_to_double(decimal value)
     {
-        Assert.Equal(new CurrencyAmount(20, "HD"), new CurrencyAmount(10, "HD") * 2m);
+        Assert.Equal(Convert.ToDouble(value), (double)new CurrencyAmount(value, "HD"));
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Multiplication_right_hand_side()
+    [Property(Skip = "Remove this Skip property to run this test")]
+    public void Cast_to_decimal(decimal value)
     {
-        Assert.Equal(new CurrencyAmount(20, "HD"), 2m * new CurrencyAmount(10, "HD"));
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Division()
-    {
-        Assert.Equal(new CurrencyAmount(5, "HD"), new CurrencyAmount(10, "HD") / 2m);
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Cast_to_double()
-    {
-        Assert.Equal(55.5d, (double)new CurrencyAmount(55.5m, "HD"));
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Cast_to_decimal()
-    {
-        decimal actual = new CurrencyAmount(55.5m, "HD");
-        Assert.Equal(55.5m, actual);
+        decimal actual = new CurrencyAmount(value, "HD");
+        Assert.Equal(value, actual);
     }
 }


### PR DESCRIPTION
This adds test cases to cover all tasks of the exercise, instead of just the `==` operator. To get all of the tests to pass two changes were required to the exemplar implementation:

1. The `!=` operator was not correctly overridden: it actually calls itself causing a stack overflow.
2. The `/` operator was overloaded to support both `new CurrencyAmount(100, "USD") / 2m` and `2m / new CurrencyAmount(100, "USD")`. The first version is part of the specification and makes total sense. However, the second version is not mentioned in the instructions anywhere, and in my opinion also doesn't make any sense: what would this even return?

This fixes #1652.