### PR TITLE
football-match-reports: revise exercise tasks

### DIFF
--- a/config.json
+++ b/config.json
@@ -373,7 +373,7 @@
         "name": "Football Match Reports",
         "uuid": "eb9faaec-9754-4df1-8eb1-09ca0ad94665",
         "concepts": ["switch-statements"],
-        "prerequisites": ["classes", "inheritance"]
+        "prerequisites": ["classes", "inheritance", "nullability"]
       },
       {
         "slug": "beauty-salon-goes-global",
@@ -413,9 +413,7 @@
         "name": "Log Analysis",
         "uuid": "4a940e54-eda8-4500-bcb2-25d83af01fb1",
         "concepts": ["extension-methods"],
-        "prerequisites": [
-          "strings"
-        ]
+        "prerequisites": ["strings"]
       }
     ],
     "practice": [

--- a/exercises/concept/football-match-reports/.docs/hints.md
+++ b/exercises/concept/football-match-reports/.docs/hints.md
@@ -13,7 +13,7 @@
 ## 3. Extend the coverage to include off field activity
 
 - [Pattern matching on types][switch-pattern-matching] is the key to this task.
-- Use the [`default`][default] statement to match any other type
+- Use the [`default`][default] statement to match any other type.
 
 ## 5. Report on club managers
 

--- a/exercises/concept/football-match-reports/.docs/hints.md
+++ b/exercises/concept/football-match-reports/.docs/hints.md
@@ -6,15 +6,16 @@
 
 - The [`break`][break] statement is useful.
 
-## 2. Raise an alert if an unknown shirt number is encountered.
+## 2. Raise an alert if an unknown shirt number is encountered
 
 - The [`default`][default] statement is useful.
 
 ## 3. Extend the coverage to include off field activity
 
 - [Pattern matching on types][switch-pattern-matching] is the key to this task.
+- Use the [`default`][default] statement to match any other type
 
-## 4. Where the manager has a name available we want that output instead of "the manager"
+## 5. Report on club managers
 
 - See this [documentation][switch-when] for the `when` keyword.
 

--- a/exercises/concept/football-match-reports/.docs/instructions.md
+++ b/exercises/concept/football-match-reports/.docs/instructions.md
@@ -1,6 +1,7 @@
 # Instructions
 
-You are developing a system to help the staff of a football/soccer club's web site report on matches. Data is received from a variety of sources and piped into a single stream after being cleaned up.
+You are developing a system to help the staff of a football/soccer club's web site report on matches. 
+This system is capable of analyzing different aspects in the match, both on and off the field, and converts them into a stream of events.
 
 ## 1. Output descriptions of the players based on their shirt number
 
@@ -26,35 +27,60 @@ PlayAnalyzer.AnalyzeOnField(10);
 // => "striker"
 ```
 
-## 2. Raise an alert if an unknown shirt number is encountered.
+## 2. Raise an alert if an unknown shirt number is encountered
 
 Modify the `PlayAnalyzer.AnalyzeOnField()` method to throw an `ArgumentOutOfRangeException` when a shirt number outside the range 1-11 is processed.
 
 ## 3. Extend the coverage to include off field activity
 
-Implement the `PlayAnalyzer.AnalyzeOffField()` method to output description of activities and characters around the field of play.
+Implement the `PlayAnalyzer.AnalyzeOffField()` method to output descriptions of activities and characters around the field of play.
+This method receives different types of data that should be analyzed and converted to appropriate text to help the journalists.
 
-You receive a stream of data that has been cleaned. Your task is to analyse it and output appropriate text to help the journalists.
+To start off, we will cover data about the stadium:
 
-The data comprises:
+- The current number of supporters in the stadium (any `int`)
+- Announcements made over the stadium's PA system (any `string`)
 
-- shirt numbers (any `int`) -> text as per on field analysis
-- free form text (any `string`) -> the text unchanged
-- incidents in play (any subclass of the type `Incident`) -> "Injury", "Foul" etc.
-- opposing managers (objects of type `Manager`) -> "the manager"
+Unknown types of data should not be processed, so if the method receives data of a different type an `ArgumentException` should be thrown.
 
 ```csharp
-PlayAnalyzer.AnalyzeOffField(new Injury());
-// => "A player is injured. Medics are on the field."
-PlayAnalyzer.AnalyzeOffField(new Manager());
-// => "the manager"
+PlayAnalyzer.AnalyzeOffField(5000);
+// => "There are 5000 supporters at the match."
+
+PlayAnalyzer.AnalyzeOffField("5 minutes to go!");
+// => "5 minutes to go!"
+
+PlayAnalyzer.AnalyzeOffField(0.5);
+// => throws ArgumentException
 ```
 
-## 4. Where the manager has a name available we want that output instead of "the manager"
+## 4. Report on incidents during the match
 
-Modify the `PlayAnalyzer.AnalyzeOffField()` method to output any name such as "Jürgen Klopp" if there is one. If there is no name then the `Manager.Name` property is guaranteed to be an empty string rather than null.
+Modify the `PlayAnalyzer.AnalyzeOffField()` method to output descriptions of incidents that happen during the match. 
+
+Incidents can be any subclass of the `Incident` type, and will contain a description of the incident. 
+Injuries are a special kind of incident because they cause the match to be put on hold, so they should be treated differently. 
 
 ```csharp
-PlayAnalyzer.AnalyzeOffField(new Manager("José Mário dos Santos Mourinho Félix", string.Empty))
+PlayAnalyzer.AnalyzeOffField(new Foul());
+// => "The referee deemed a foul."
+
+PlayAnalyzer.AnalyzeOffField(new Injury(8));
+// => "Oh no! Player 8 is injured. Medics are on the field.
+```
+
+## 5. Report on club managers
+
+Modify the `PlayAnalyzer.AnalyzeOffField()` method to mention the club managers present during the match.
+
+Managers are instances of the `Manager` type and have a name and the name of the club they manage. 
+The manager's club may be unknown, in which case it will be set to `null`. 
+If a manager's club is not known, it should not be part of the description.
+
+```csharp
+PlayAnalyzer.AnalyzeOffField(new Manager("José Mário dos Santos Mourinho Félix", null));
 // => "José Mário dos Santos Mourinho Félix"
+
+PlayAnalyzer.AnalyzeOffField(new Manager("Jürgen Klopp", "Liverpool"));
+// => "Jürgen Klopp (Liverpool)"
 ```

--- a/exercises/concept/football-match-reports/.meta/Exemplar.cs
+++ b/exercises/concept/football-match-reports/.meta/Exemplar.cs
@@ -4,70 +4,50 @@ public static class PlayAnalyzer
 {
     public static string AnalyzeOnField(int shirtNum)
     {
-        string playerDescription;
         switch (shirtNum)
         {
             case 1:
-                playerDescription = "goalie";
-                break;
+                return "goalie";
             case 2:
-                playerDescription = "left back";
-                break;
+                return "left back";
             case 5:
-                playerDescription = "right back";
-                break;
+                return "right back";
             case 3:
             case 4:
-                playerDescription = "center back";
-                break;
+                return "center back";
             case 6:
             case 7:
             case 8:
-                playerDescription = "midfielder";
-                break;
+                return "midfielder";
             case 9:
-                playerDescription = "left wing";
-                break;
+                return "left wing";
             case 11:
-                playerDescription = "right wing";
-                break;
+                return "right wing";
             case 10:
-                playerDescription = "striker";
-                break;
+                return "striker";
             default:
                 throw new ArgumentOutOfRangeException();
         }
-
-        return playerDescription;
     }
 
     public static string AnalyzeOffField(object report)
     {
-        string description;
         switch (report)
         {
-            case int shirtNum:
-                description = AnalyzeOnField(shirtNum);
-                break;
-            case string freeFormText:
-                description = freeFormText;
-                break;
+            case int supporters:
+                return $"There are {supporters} supporters at the match."
+            case string announcement:
+                return announcement;
             case Injury injury:
-                description = $"{injury.GetDescription()} Medics are on the field.";
-                break;
+                return $"Oh no! {injury.GetDescription()} Medics are on the field.";
             case Incident incident:
-                description = incident.GetDescription();
-                break;
-            case Manager manager when !string.IsNullOrWhiteSpace(manager.Name):
-                description = manager.Name;
-                break;
+                return incident.GetDescription();
+            case Manager manager when manager.Club != null:
+                return $"{manager.Name} ({manager.Club})";
             case Manager manager:
-                description = "the manager";
-                break;
+                return manager.Name;
             default:
                 throw new ArgumentException();
         }
-
-        return description;
     }
 }

--- a/exercises/concept/football-match-reports/.meta/Exemplar.cs
+++ b/exercises/concept/football-match-reports/.meta/Exemplar.cs
@@ -35,7 +35,7 @@ public static class PlayAnalyzer
         switch (report)
         {
             case int supporters:
-                return $"There are {supporters} supporters at the match."
+                return $"There are {supporters} supporters at the match.";
             case string announcement:
                 return announcement;
             case Injury injury:

--- a/exercises/concept/football-match-reports/.meta/design.md
+++ b/exercises/concept/football-match-reports/.meta/design.md
@@ -19,4 +19,5 @@
 ## Prerequisites
 
 - `classes`
+- `nullability`
 - `inheritance`: with type pattern matching the student needs to be aware of the need for a common base type including `Object`.

--- a/exercises/concept/football-match-reports/FootballMatchReports.csproj
+++ b/exercises/concept/football-match-reports/FootballMatchReports.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/exercises/concept/football-match-reports/FootballMatchReportsTests.cs
+++ b/exercises/concept/football-match-reports/FootballMatchReportsTests.cs
@@ -1,8 +1,7 @@
 using System;
 using Xunit;
-using Exercism.Tests;
 
-public class TuplesTest
+public class FootballMatchReportsTests
 {
     [Fact]
     public void AnalyzeOnField_1()
@@ -33,6 +32,12 @@ public class TuplesTest
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => PlayAnalyzer.AnalyzeOnField(1729));
     }
+    
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void AnalyzeOffField_number()
+    {
+        Assert.Equal("There are 4200 supporters at the match.", PlayAnalyzer.AnalyzeOffField(4200));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void AnalyzeOffField_text()
@@ -55,24 +60,23 @@ public class TuplesTest
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void AnalyzeOffField_injury()
     {
-        Assert.Equal("A player is injured. Medics are on the field.", PlayAnalyzer.AnalyzeOffField(new Injury()));
+        Assert.Equal("Oh no! Player 3 is injured. Medics are on the field.", PlayAnalyzer.AnalyzeOffField(new Injury(3)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnalyzeOffField_anonymous_manager()
+    public void AnalyzeOffField_manager_no_club()
     {
-        Assert.Equal("the manager", PlayAnalyzer.AnalyzeOffField(new Manager(string.Empty)));
+        Assert.Equal("David Moyes", PlayAnalyzer.AnalyzeOffField(new Manager("David Moyes", null)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnalyzeOffField_named_manager()
+    public void AnalyzeOffField_manager_with_club()
     {
-        Assert.Equal("José Mário dos Santos Mourinho Félix",
-            PlayAnalyzer.AnalyzeOffField(new Manager("José Mário dos Santos Mourinho Félix")));
+        Assert.Equal("Thomas Tuchel (Chelsea)", PlayAnalyzer.AnalyzeOffField(new Manager("Thomas Tuchel", "Chelsea")));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnalyzeOffField_throws_type_single()
+    public void AnalyzeOffField_throws_unknown_type()
     {
         Assert.Throws<ArgumentException>(() => PlayAnalyzer.AnalyzeOffField(90.0f));
     }

--- a/exercises/concept/football-match-reports/OffFieldActivitiesAndCharacters.cs
+++ b/exercises/concept/football-match-reports/OffFieldActivitiesAndCharacters.cs
@@ -2,9 +2,12 @@
 {
     public string Name { get; }
 
-    public Manager(string name)
+    public string? Club { get; }
+
+    public Manager(string name, string? club)
     {
         this.Name = name;
+        this.Club = club;
     }
 }
 
@@ -20,5 +23,12 @@ public class Foul : Incident
 
 public class Injury : Incident
 {
-    public override string GetDescription() => "A player is injured.";
+    private readonly int player;
+
+    public Injury(int player)
+    {
+        this.player = player;
+    }
+
+    public override string GetDescription() => $"Player {player} is injured.";
 }


### PR DESCRIPTION
This revises the tasks of the exercise so that each requirement of the `PlayAnalyzer.AnalyzeOffField()` method is introduced in a separate task.

### Task 3: type guard on built-in types

This task requires the student to switch on the built-in types `int` and `string`, and provide a default case to match on any other type. I deliberately did not split up these two types into their own tasks to avoid people going in the wrong direction using something like this:

``` csharp
if (report is int count)
{
    return $"There are {count} supporters at the match.";
}
```

To make the instructions a little bit less confusing I changed the meaning of `int` to be the number of supporters at the match instead of the shirt number (since shirt numbers are not "off the field"). Also, a `string` now represents an announcement through the stadium's PA system instead of "free form text", which speaks a little bit more to the imagination.

Throwing the `ArgumentException` in the default case was not mentioned anywhere in the instructions so I added it here. This should not be a problem since the same pattern is also used in Task 2. Doing so here also gives the added bonus that the tests can be run before finishing the exercise because the implementation code otherwise probably doesn't compile.

### Task 4: type guard on inherited classes

This task requires the student to switch on the `Incident` type and subclasses thereof. The instructions did not explicitly mention that injuries should be treated differently from other incidents, so I tried to make this more explicit.

### Task 5: type guard with `when` keyword

This final task requires the student to switch on the `Manager` type with two cases: one where the manager's club is known and one where it isn't. Because the `Manager.Club` property is a `string?` I added the `nullability` concept as a prerequisite.

## Linked issues

Fixes #1636.  
Fixes #1637.  
Fixes #1638.  
Fixes #1639.