### PR TITLE
Change Database.Commit() to Database.EndTransaction()

### DIFF
--- a/exercises/concept/object-relational-mapping/.docs/instructions.md
+++ b/exercises/concept/object-relational-mapping/.docs/instructions.md
@@ -12,7 +12,7 @@ The database has the following instance methods:
 
 - `Database.BeginTransaction()` starts a transaction on the database. If this is called when the database is not in a `Closed` state then an exception is thrown. If successful the internal state of the database will change to `TransactionStarted`.
 - `Database.Write(string data)` writes data to the database within the transaction. If it receives bad data an exception will be thrown. An attempt to call this method without `BeginTransaction()` having been called will cause an exception to be thrown. If successful the internal state of the database will change to `DataWritten`.
-- `Database.Commit()` commits the transaction to the database. It may throw an exception if it can't close the transaction of if `Database.BeginTransaction()` had not been called.
+- `Database.EndTransaction()` commits the transaction to the database. It may throw an exception if it can't close the transaction or if `Database.BeginTransaction()` had not been called.
 - A call to`Database.Dispose()` will clean up the database if an exception is thrown during a transaction. This will change the state of the database to `Closed`.
 
 ## 1. Begin a transaction


### PR DESCRIPTION
Update instructions.md to refer to Database.EndTransaction() instead of Database.Commit() as the latter method does not exist.

resolves #1675 