### PR TITLE
Add more asserts for BuildingTelemetry tests

### DIFF
--- a/exercises/concept/building-telemetry/BuildingTelemetryTests.cs
+++ b/exercises/concept/building-telemetry/BuildingTelemetryTests.cs
@@ -21,7 +21,8 @@ public class ParametersTests
         car.Drive();
         car.Drive();
         int serialNum = 1;
-        car.GetTelemetryData(ref serialNum, out int batteryPercentage, out int distanceDrivenInMeters);
+        var result = car.GetTelemetryData(ref serialNum, out int batteryPercentage, out int distanceDrivenInMeters);
+        Assert.True(result);
         Assert.Equal((1, 80, 4), (serialNum, batteryPercentage, distanceDrivenInMeters));
     }
 
@@ -35,7 +36,8 @@ public class ParametersTests
         int serialNum = 4;
         car.GetTelemetryData(ref serialNum, out batteryPercentage, out distanceDrivenInMeters);
         serialNum = 1;
-        car.GetTelemetryData(ref serialNum, out batteryPercentage, out distanceDrivenInMeters);
+        bool result = car.GetTelemetryData(ref serialNum, out batteryPercentage, out distanceDrivenInMeters);
+        Assert.False(result);
         Assert.Equal((4, -1, -1), (serialNum, batteryPercentage, distanceDrivenInMeters));
     }
 


### PR DESCRIPTION
Add asserts to test the value returned by `GetTelemetryData` in the `GetTelmetryData_good` and `GetTelmetryData_bad` tests of the BuildingTelemetry exercise. The values tested are the ones mentioned in the README for the exercise.