### PR TITLE
Updated HyperiaForex.cs to remove build errors when starting development

### DIFF
--- a/exercises/concept/hyperia-forex/HyperiaForex.cs
+++ b/exercises/concept/hyperia-forex/HyperiaForex.cs
@@ -1,3 +1,5 @@
+using System;
+
 public struct CurrencyAmount
 {
     private decimal amount;
@@ -11,9 +13,64 @@ public struct CurrencyAmount
 
     // TODO: implement equality operators
 
+    public static bool operator ==(CurrencyAmount @this, CurrencyAmount other)
+    {
+        throw new NotImplementedException("Please implement the == operator.");
+    }
+
+    public static bool operator !=(CurrencyAmount @this, CurrencyAmount other)
+    {
+        throw new NotImplementedException("Please implement the != operator.");
+    }
+
     // TODO: implement comparison operators
+
+    public static bool operator >(CurrencyAmount @this, CurrencyAmount other)
+    {
+        throw new NotImplementedException("Please implement the > operator.");
+    }
+
+    public static bool operator <(CurrencyAmount @this, CurrencyAmount other)
+    {
+        throw new NotImplementedException("Please implement the <!=> operator.");
+    }
 
     // TODO: implement arithmetic operators
 
+    public static CurrencyAmount operator +(CurrencyAmount @this, CurrencyAmount other)
+    {
+        throw new NotImplementedException("Please implement the + operator.");
+    }
+
+    public static CurrencyAmount operator -(CurrencyAmount @this, CurrencyAmount other)
+    {
+        throw new NotImplementedException("Please implement the - operator.");
+    }
+
+    public static CurrencyAmount operator *(CurrencyAmount @this, decimal multiplier)
+    {
+        throw new NotImplementedException("Please implement the * operator.");
+    }
+
+    public static CurrencyAmount operator *(decimal multiplier, CurrencyAmount @this)
+    {
+        throw new NotImplementedException("Please implement the * operator.");
+    }
+
+    public static CurrencyAmount operator /(CurrencyAmount @this, decimal divisor)
+    {
+        throw new NotImplementedException("Please implement the / operator.");
+    }
+
     // TODO: implement type conversion operators
+
+    public static explicit operator double(CurrencyAmount @this)
+    {
+        throw new NotImplementedException("Please implement the cast to double operator.");
+    }
+
+    public static implicit operator decimal(CurrencyAmount @this)
+    {
+        throw new NotImplementedException("Please implement the cast to decimal operator.");
+    }
 }


### PR DESCRIPTION
With the new unit tests, the project won't build because of missing methods/operators in HyperiaForex.cs. I suggest adding a stub for each operator used in the tests.