### PR TITLE
Change references to using statements to refer to using directives

### DIFF
--- a/concepts/extension-methods/about.md
+++ b/concepts/extension-methods/about.md
@@ -17,9 +17,9 @@ namespace MyExtensions
 // => 2
 ```
 
-Extension methods are brought into scope at the namespace level. This means that if you are in different namespace to the one the extension method is defined in, it's namespace must be in a `using` statement first; For example, if we wanted to use the above example in our code, we would first need a `using MyExtensions` statement. If you are in the same namespace as the one the extension method is defined in, you can use the extension methods without a `using` statement.
+Extension methods are brought into scope at the namespace level. This means that if you are in different namespace to the one the extension method is defined in, it's namespace must be in a `using` directive first; For example, if we wanted to use the above example in our code, we would first need a `using MyExtensions` directive. If you are in the same namespace as the one the extension method is defined in, you can use the extension methods without a `using` directive.
 
-A well-known example of extension methods are the [LINQ][linq] standard query operators that add query functionality to the existing IEnumerable types. To bring these into scope we need a `using System.Linq;` statement.
+A well-known example of extension methods are the [LINQ][linq] standard query operators that add query functionality to the existing IEnumerable types. To bring these into scope we need a `using System.Linq;` directives.
 
 [linq]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/
 [extension-methods]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods


### PR DESCRIPTION
Fixes about.md to refer to `using directives` instead of `using statements`

https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive

improves #1659