### PR TITLE
Add BeginTransaction method to Database in Orm In One Go

### DIFF
--- a/exercises/concept/orm-in-one-go/.docs/instructions.md
+++ b/exercises/concept/orm-in-one-go/.docs/instructions.md
@@ -8,7 +8,7 @@ The database has the following instance methods:
 
 - `Database.BeginTransaction()` starts a transaction on the database.
 - `Database.Write(string data)` writes data to the database within the transaction. If it receives bad data an exception will be thrown. An attempt to call this method without `BeginTransction()` having been called will cause an exception to be thrown. If successful the internal state of the database will change to `DataWritten`.
-- `Database.Commit()` commits the transaction to the database. It may throw an exception if it can't close the transaction or if `Database.BeginTransaction()` had not been called.
+- `Database.EndTransaction()` commits the transaction to the database. It may throw an exception if it can't close the transaction or if `Database.BeginTransaction()` had not been called.
 - A call to`Databse.Dispose()` will clean up the database if an exception is thrown during a transaction. This will change the state of the database to `Closed`.
 
 ## 1. Write to the database

--- a/exercises/concept/orm-in-one-go/.meta/Exemplar.cs
+++ b/exercises/concept/orm-in-one-go/.meta/Exemplar.cs
@@ -13,6 +13,7 @@ public class Orm
     {
         using (database)
         {
+            database.BeginTransaction();
             database.Write(data);
             database.EndTransaction();
         }
@@ -23,6 +24,7 @@ public class Orm
         using var db = database;
         try
         {
+            db.BeginTransaction();
             db.Write(data);
             db.EndTransaction();
 

--- a/exercises/concept/orm-in-one-go/OrmInOneGoTests.cs
+++ b/exercises/concept/orm-in-one-go/OrmInOneGoTests.cs
@@ -88,8 +88,12 @@ public class Database : IDisposable
     public static State DbState { get; private set; } = State.Closed;
     public static string lastData = string.Empty;
 
-    public Database()
+    public void BeginTransaction()
     {
+        if (DbState != State.Closed)
+        {
+            throw new InvalidOperationException();
+        }
         DbState = State.TransactionStarted;
     }
 


### PR DESCRIPTION
Update Database class in OrmInOneGoTests.cs to add backBeginTransaction()
Update instructions.md to refer to database.EndTransaction() instead of database.Commit()
Update Exemplar.cs to call BeginTransaction() in both Write() and  WriteSafely() methods

fixes #1677 