### PR TITLE
Improve LogAnalysis tests

### DIFF
--- a/exercises/concept/log-analysis/LogAnalysisTests.cs
+++ b/exercises/concept/log-analysis/LogAnalysisTests.cs
@@ -23,6 +23,12 @@ public class LogAnalysisTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
+    public void SubstringBetweenLongerDelimiters()
+    {
+        Assert.Equal("SOMETHING", "FIND >>> SOMETHING <===< HERE".SubstringBetween(">>> ", " <===<"));
+    }
+    
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Message()
     {
         var log = "[WARNING]: Library is deprecated.";


### PR DESCRIPTION
I noticed that a lot of the community solutions to the SubstringBetween were simply accidentally correct, doing

    s.Substring(s.IndexOf(first) + first.Length, s.IndexOf(last) - last.Length);

i.e. thinking that the length of the last delimiter is relevant, which looks symmetrical to the handling of the first Substring parameter, and just happens to be correct on the provided string.