### PR TITLE
fix: correct unit tests in hyper-optimised-telemetry exercise

### DIFF
--- a/exercises/concept/hyper-optimized-telemetry/.meta/Exemplar.cs
+++ b/exercises/concept/hyper-optimized-telemetry/.meta/Exemplar.cs
@@ -25,15 +25,9 @@ public static class TelemetryBuffer
             bytes = BitConverter.GetBytes((int)reading);
             bytes.CopyTo(allBytes, 1);
         }
-        else if (reading > Int16.MaxValue)
-        {
-            allBytes[0] = 0x2;
-            bytes = BitConverter.GetBytes((ushort)reading);
-            bytes.CopyTo(allBytes, 1);
-        }
         else if (reading >= 0)
         {
-            allBytes[0] = 0xfe;
+            allBytes[0] = 0x2;
             bytes = BitConverter.GetBytes((ushort)reading);
             bytes.CopyTo(allBytes, 1);
         }

--- a/exercises/concept/hyper-optimized-telemetry/HyperOptimizedTelemetryTests.cs
+++ b/exercises/concept/hyper-optimized-telemetry/HyperOptimizedTelemetryTests.cs
@@ -73,7 +73,7 @@ public class HyperOptimizedTelemetryTests
     public void ToBuffer_upper_short()
     {
         var bytes = TelemetryBuffer.ToBuffer(Int16.MaxValue);
-        Assert.Equal(new byte[] { 0xfe, 0xff, 0x7f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, bytes);
+        Assert.Equal(new byte[] { 0x2, 0xff, 0x7f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, bytes);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class HyperOptimizedTelemetryTests
     public void ToBuffer_Zero()
     {
         var bytes = TelemetryBuffer.ToBuffer(0);
-        Assert.Equal(new byte[] { 0xfe, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, bytes);
+        Assert.Equal(new byte[] { 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, bytes);
     }
 
     [Fact]


### PR DESCRIPTION
This PR fixes two unit tests on the hyper-optimised-telemetry exercise that wrongly assume `0` and `Int16.MaxValue` (32767) should be encoded into signed shorts, rather than unsigned shorts as specified in the exercise instructions.

![image](https://user-images.githubusercontent.com/28660369/139483729-45ab4a48-bac3-44dc-9d57-6e9f38f2eeee.png)

 Directly targets issue #1795 and #1621 (The latter having been closed, though it reports the same problem)

This PR is incompatible with PR #1756, as the author of that PR aims to change the instructions to be in line with how the unit tests have been set up, while this PR aims to do the exact inverse by changing the unit tests to match the instructions instead.

