### PR TITLE
refactor: change parameter casing in exercise to be in line with C# coding conventions

### DIFF
--- a/exercises/concept/international-calling-connoisseur/.meta/Exemplar.cs
+++ b/exercises/concept/international-calling-connoisseur/.meta/Exemplar.cs
@@ -18,9 +18,9 @@ public static class DialingCodes
         };
     }
 
-    public static Dictionary<int, string> AddCountryToEmptyDictionary(int CountryCode, string CountryName)
+    public static Dictionary<int, string> AddCountryToEmptyDictionary(int countryCode, string countryName)
     {
-        return new Dictionary<int, string>() { { CountryCode, CountryName } };
+        return new Dictionary<int, string>() { { countryCode, countryName } };
     }
 
     public static Dictionary<int, string> AddCountryToExistingDictionary(

--- a/exercises/concept/international-calling-connoisseur/InternationalCallingConnoisseur.cs
+++ b/exercises/concept/international-calling-connoisseur/InternationalCallingConnoisseur.cs
@@ -13,7 +13,7 @@ public static class DialingCodes
         throw new NotImplementedException($"Please implement the (static) GetExistingDictionary() method");
     }
 
-    public static Dictionary<int, string> AddCountryToEmptyDictionary(int CountryCode, string CountryName)
+    public static Dictionary<int, string> AddCountryToEmptyDictionary(int countryCode, string countryName)
     {
         throw new NotImplementedException($"Please implement the (static) AddCountryToEmptyDictionary() method");
     }


### PR DESCRIPTION
This PR changes the casing of the parameters `CountryCode` and `CountryName` to `countryCode` and `countryName` respectively, to bring them in line with the generally accepted Microsoft C# Coding Conventions. 