### PR TITLE
Fixed minor doc issue at concepts/optional-parameters

### DIFF
--- a/concepts/optional-parameters/about.md
+++ b/concepts/optional-parameters/about.md
@@ -11,9 +11,9 @@ class Card
     }
 }
 
-Card.NewYear();  // => "Happy 2020 from me!"
-Card.Card(1999); // => "Happy 1999 from me!"
-Card.Card(sender: "mom"); // => "Happy 2020 from mom!"
+Card.NewYear();     // => "Happy 2020 from me!"
+Card.NewYear(1999); // => "Happy 1999 from me!"
+Card.NewYear(sender: "mom"); // => "Happy 2020 from mom!"
 ```
 
 An optional parameter's value must be either:

--- a/concepts/optional-parameters/introduction.md
+++ b/concepts/optional-parameters/introduction.md
@@ -13,6 +13,6 @@ class Card
     }
 }
 
-Card.NewYear();  // => "Happy 2020!"
-Card.Card(1999); // => "Happy 1999!"
+Card.NewYear();     // => "Happy 2020!"
+Card.NewYear(1999); // => "Happy 1999!"
 ```


### PR DESCRIPTION
I believe there were minor typos when calling method at the documentation for concepts/optional-parameters