### PR TITLE
parsing-log-files: clarify instructions

### DIFF
--- a/exercises/concept/parsing-log-files/.docs/instructions.md
+++ b/exercises/concept/parsing-log-files/.docs/instructions.md
@@ -54,10 +54,10 @@ Lines passed to the routine may or may not be valid as defined in task 1. We pro
 
 ```csharp
 string lines =
-    "[INF] passWord " + Environment.NewLine +
-    "\"passWord\"" + Environment.NewLine +
-    "[INF] User saw error message \"Unexpected Error\" on page load." + Environment.NewLine +
-    "[INF] \"The secret password was added by the user\"";
+    "[INF] passWord " + Environment.NewLine + // contains 'password' but not surrounded by quotation marks
+    "\"passWord\"" + Environment.NewLine + // count this one
+    "[INF] User saw error message \"Unexpected Error\" on page load." + Environment.NewLine + //does not contain 'password'
+    "[INF] \"The secret password was added by the user\""; // count this one
 
 var lp = new LogParser();
 lp.CountQuotedPasswords(lines);

--- a/exercises/concept/parsing-log-files/.docs/instructions.md
+++ b/exercises/concept/parsing-log-files/.docs/instructions.md
@@ -43,7 +43,7 @@ lp.SplitLogLine("Section 1<===>Section 2<^-^>Section 3");
 
 ## 3. Count the number of lines containing a quoted password
 
-The team needs to know how about passwords occurring in quoted text so that they can be examined manually.
+The team needs to know about passwords occurring in quoted text so that they can be examined manually.
 
 Implement the `LogParser.CountQuotedPasswords()` method to provide an indication of the likely scale of the manual exercise.
 

--- a/exercises/concept/parsing-log-files/.docs/instructions.md
+++ b/exercises/concept/parsing-log-files/.docs/instructions.md
@@ -41,15 +41,14 @@ lp.SplitLogLine("Section 1<===>Section 2<^-^>Section 3");
 // => {"Section 1", "Section 2", "Section 3"}
 ```
 
-## 3. Count the number of lines containing a password
+## 3. Count the number of lines containing a quoted password
 
-A log line is considered to contain a password if it contains the literal string "password" followed by a space and then a word (the actual password).
+The team needs to know how about passwords occurring in quoted text so that they can be examined manually.
 
-It is important to find any passwords included in a file. These will be dealt with automatically, but the team needs to know how about passwords occurred in quoted text so that they can be examined manually.
+Implement the `LogParser.CountQuotedPasswords()` method to provide an indication of the likely scale of the manual exercise.
 
-Implement the `LogParser.CountQuotedPasswords()`method to provide an indication of the likely scale of the manual exercise.
-
-The literal string "password" may be in upper or lower case or any combination.
+Identify log lines where the literal string "password", which may be in any combination of upper or lower case, is surrounded by quotation marks.
+You should account for the possibility of additional content between the quotatoin marks before and after "password".
 
 Lines passed to the routine may or may not be valid as defined in task 1. We process them in the same way, whether or not they are valid.
 
@@ -57,6 +56,7 @@ Lines passed to the routine may or may not be valid as defined in task 1. We pro
 string lines =
     "[INF] passWord " + Environment.NewLine +
     "\"passWord\"" + Environment.NewLine +
+    "[INF] User saw error message \"Unexpected Error\" on page load." + Environment.NewLine +
     "[INF] \"The secret password was added by the user\"";
 
 var lp = new LogParser();

--- a/exercises/concept/parsing-log-files/.docs/instructions.md
+++ b/exercises/concept/parsing-log-files/.docs/instructions.md
@@ -48,7 +48,7 @@ The team needs to know about passwords occurring in quoted text so that they can
 Implement the `LogParser.CountQuotedPasswords()` method to provide an indication of the likely scale of the manual exercise.
 
 Identify log lines where the literal string "password", which may be in any combination of upper or lower case, is surrounded by quotation marks.
-You should account for the possibility of additional content between the quotatoin marks before and after "password".
+You should account for the possibility of additional content between the quotation marks before and after "password".
 
 Lines passed to the routine may or may not be valid as defined in task 1. We process them in the same way, whether or not they are valid.
 

--- a/exercises/concept/parsing-log-files/.meta/Exemplar.cs
+++ b/exercises/concept/parsing-log-files/.meta/Exemplar.cs
@@ -16,7 +16,7 @@ public class LogParser
     public int CountQuotedPasswords(string lines)
     {
         bool[] results = new bool[lines.Length];
-        var regex = new Regex(@"^.*""[^\\""]*password[^\\""]*"".*$",
+        var regex = new Regex(@""".*password.*""",
             RegexOptions.IgnoreCase | RegexOptions.Multiline);
         var matches = regex.Matches(lines);
         return matches.Count;

--- a/exercises/concept/parsing-log-files/ParsingLogFilesTests.cs
+++ b/exercises/concept/parsing-log-files/ParsingLogFilesTests.cs
@@ -47,6 +47,7 @@ public class ParsingLogFilesTests
             string.Empty,
             "[INF] passWord",
             "\"passWord\"",
+            "[INF] User saw error message \"Unexpected Error\" on page load.",
             "[INF] The message \"Please reset your password\" was ignored by the user"
         };
         Assert.Equal(2, lp.CountQuotedPasswords(string.Join(Environment.NewLine, lines)));


### PR DESCRIPTION
Closes https://github.com/exercism/csharp/issues/1809

1. Update instructions:
   - removing the explanation about passwords followed by another word
   - explain that the goal is to identify lines with the word `password` (case-insensitive) found between quotation marks, possibly with any other content around `password`.
   - add an example log line that does not contain the word `password` in it
2. Simplify the regex in the exemplar implementation.
3. Add a log line to the `AreQuotedPasswords` test that does not contain the word `password` in it.