### PR TITLE
Allow rest-api to work with System.Text.Json

### DIFF
--- a/exercises/practice/rest-api/.meta/Example.cs
+++ b/exercises/practice/rest-api/.meta/Example.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 public class User
 {
     public string name { get; }
-    public IDictionary<string, double> owes { get; private set; }
-    public IDictionary<string, double> owed_by { get; private set; }
+    public IDictionary<string, double> owes { get;  set; }
+    public IDictionary<string, double> owed_by { get;  set; }
     public double balance => owed_by.Sum(x => x.Value) - owes.Sum(x => x.Value);
 
     public User(string name)
@@ -84,40 +84,40 @@ public class RestApi
 
     public RestApi(string database)
     {
-        users = JsonConvert.DeserializeObject<List<User>>(database);
+        users = JsonSerializer.Deserialize<List<User>>(database);
     }
 
     public string Get(string url, string payload = null)
     {
         if (payload != null)
         {
-            var values = JsonConvert.DeserializeObject<Dictionary<string, IEnumerable<string>>>(payload);
+            var values = JsonSerializer.Deserialize<Dictionary<string, IEnumerable<string>>>(payload);
             var requestedUsers = values["users"];
-            return JsonConvert.SerializeObject(users.Where(x => requestedUsers.Contains(x.name)));
+            return JsonSerializer.Serialize(users.Where(x => requestedUsers.Contains(x.name)));
         }
 
-        return JsonConvert.SerializeObject(users);
+        return JsonSerializer.Serialize(users);
     }
 
     public string Post(string url, string payload)
     {
         if (url == "/add")
         {
-            var values = JsonConvert.DeserializeObject<Dictionary<string, string>>(payload);
+            var values = JsonSerializer.Deserialize<Dictionary<string, string>>(payload);
             var newUser = new User(values["user"]);
             users.Add(newUser);
-            return JsonConvert.SerializeObject(newUser);
+            return JsonSerializer.Serialize(newUser);
         }
         else if (url == "/iou")
         {
-            var values = JsonConvert.DeserializeObject<Dictionary<string, object>>(payload);
-            var lender = users.First(x => x.name.Equals(values["lender"]));
-            var borrower = users.First(x => x.name.Equals(values["borrower"]));
-            var amount = (double)values["amount"];
+            var values = JsonSerializer.Deserialize<Dictionary<string, object>>(payload);
+            var lender = users.First(x => x.name.Equals(values["lender"].ToString()));
+            var borrower = users.First(x => x.name.Equals(values["borrower"].ToString()));
+            var amount = double.Parse(values["amount"].ToString());
             lender.Lend(borrower, amount);
             borrower.Borrow(lender, amount);
 
-            return JsonConvert.SerializeObject(new[] { lender, borrower }.OrderBy(x => x.name));
+            return JsonSerializer.Serialize(new[] { lender, borrower }.OrderBy(x => x.name));
         }
 
         return String.Empty;

--- a/exercises/practice/rest-api/RestApiTests.cs
+++ b/exercises/practice/rest-api/RestApiTests.cs
@@ -21,7 +21,7 @@ public class RestApiTests
         var database = "[]";
         var sut = new RestApi(database);
         var actual = sut.Post(url, payload);
-        var expected = "{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0.0}";
+        var expected = "{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0}";
         Assert.Equal(expected, actual);
     }
 
@@ -30,10 +30,10 @@ public class RestApiTests
     {
         var url = "/users";
         var payload = "{\"users\":[\"Bob\"]}";
-        var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0.0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0.0}]";
+        var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]";
         var sut = new RestApi(database);
         var actual = sut.Get(url, payload);
-        var expected = "[{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0.0}]";
+        var expected = "[{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]";
         Assert.Equal(expected, actual);
     }
 
@@ -41,11 +41,11 @@ public class RestApiTests
     public void Both_users_have_0_balance()
     {
         var url = "/iou";
-        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3.0}";
-        var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0.0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0.0}]";
+        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3}";
+        var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]";
         var sut = new RestApi(database);
         var actual = sut.Post(url, payload);
-        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":3.0},\"balance\":3.0},{\"name\":\"Bob\",\"owes\":{\"Adam\":3.0},\"owed_by\":{},\"balance\":-3.0}]";
+        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3},{\"name\":\"Bob\",\"owes\":{\"Adam\":3},\"owed_by\":{},\"balance\":-3}]";
         Assert.Equal(expected, actual);
     }
 
@@ -53,11 +53,11 @@ public class RestApiTests
     public void Borrower_has_negative_balance()
     {
         var url = "/iou";
-        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3.0}";
-        var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0.0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3.0},\"owed_by\":{},\"balance\":-3.0},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3.0},\"balance\":3.0}]";
+        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3}";
+        var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3}]";
         var sut = new RestApi(database);
         var actual = sut.Post(url, payload);
-        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":3.0},\"balance\":3.0},{\"name\":\"Bob\",\"owes\":{\"Adam\":3.0,\"Chuck\":3.0},\"owed_by\":{},\"balance\":-6.0}]";
+        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3},{\"name\":\"Bob\",\"owes\":{\"Adam\":3,\"Chuck\":3},\"owed_by\":{},\"balance\":-6}]";
         Assert.Equal(expected, actual);
     }
 
@@ -65,11 +65,11 @@ public class RestApiTests
     public void Lender_has_negative_balance()
     {
         var url = "/iou";
-        var payload = "{\"lender\":\"Bob\",\"borrower\":\"Adam\",\"amount\":3.0}";
-        var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0.0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3.0},\"owed_by\":{},\"balance\":-3.0},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3.0},\"balance\":3.0}]";
+        var payload = "{\"lender\":\"Bob\",\"borrower\":\"Adam\",\"amount\":3}";
+        var database = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3}]";
         var sut = new RestApi(database);
         var actual = sut.Post(url, payload);
-        var expected = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":3.0},\"owed_by\":{},\"balance\":-3.0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3.0},\"owed_by\":{\"Adam\":3.0},\"balance\":0.0}]";
+        var expected = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{\"Adam\":3},\"balance\":0}]";
         Assert.Equal(expected, actual);
     }
 
@@ -77,11 +77,11 @@ public class RestApiTests
     public void Lender_owes_borrower()
     {
         var url = "/iou";
-        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":2.0}";
-        var database = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":3.0},\"owed_by\":{},\"balance\":-3.0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3.0},\"balance\":3.0}]";
+        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":2}";
+        var database = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]";
         var sut = new RestApi(database);
         var actual = sut.Post(url, payload);
-        var expected = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":1.0},\"owed_by\":{},\"balance\":-1.0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":1.0},\"balance\":1.0}]";
+        var expected = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":1},\"owed_by\":{},\"balance\":-1},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":1},\"balance\":1}]";
         Assert.Equal(expected, actual);
     }
 
@@ -89,11 +89,11 @@ public class RestApiTests
     public void Lender_owes_borrower_less_than_new_loan()
     {
         var url = "/iou";
-        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":4.0}";
-        var database = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":3.0},\"owed_by\":{},\"balance\":-3.0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3.0},\"balance\":3.0}]";
+        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":4}";
+        var database = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]";
         var sut = new RestApi(database);
         var actual = sut.Post(url, payload);
-        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":1.0},\"balance\":1.0},{\"name\":\"Bob\",\"owes\":{\"Adam\":1.0},\"owed_by\":{},\"balance\":-1.0}]";
+        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":1},\"balance\":1},{\"name\":\"Bob\",\"owes\":{\"Adam\":1},\"owed_by\":{},\"balance\":-1}]";
         Assert.Equal(expected, actual);
     }
 
@@ -101,11 +101,11 @@ public class RestApiTests
     public void Lender_owes_borrower_same_as_new_loan()
     {
         var url = "/iou";
-        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3.0}";
-        var database = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":3.0},\"owed_by\":{},\"balance\":-3.0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3.0},\"balance\":3.0}]";
+        var payload = "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3}";
+        var database = "[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]";
         var sut = new RestApi(database);
         var actual = sut.Post(url, payload);
-        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0.0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0.0}]";
+        var expected = "[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]";
         Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
This relates to #1805 

@ErikSchierboom mentioned that it would be good if the `rest-api` exercise was modified to work with `System.Text.Json` rather than `Newtonsoft.Json`.

This PR migrates the tests and the `Example.cs` to use `System.Text.Json` instead.

Its worth noting that the main differences are how the two serializers will serialize a double/float value.  `System.Text.Json` will strip off the decimal places if they are 0 (e.g. 1.0 becomes 1) whereas `Newtonsoft.Json` will always include it.  As it happens all tests use double values that are actually integers.  It might be worth considering changing at least one of these tests to use a non integer double value.