### PR TITLE
doc(need-for-speed): fix naming missmatch in instructions for task 6

### DIFF
--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -69,7 +69,7 @@ car.DistanceDriven();
 ```
 ## 6. Check if a remote control car can finish a race
 
-To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `Race.CarCanFinish()` method that takes a `RemoteControlCar` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
+To finish a race track, a car has to be able to drive the track's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.CarCanFinish()` method that takes a `RemoteControlCar` instance as its parameter and returns `true` if the car can finish the race track; otherwise, return `false`:
 
 ```csharp
 int speed = 5;
@@ -77,8 +77,8 @@ int batteryDrain = 2;
 var car = new RemoteControlCar(speed, batteryDrain);
 
 int distance = 100;
-var race = new Race(distance);
+var raceTrack = new RaceTrack(distance);
 
-race.CarCanFinish(car);
+raceTrack.CarCanFinish(car);
 // => true
 ```


### PR DESCRIPTION
Correct the name for the class `RaceTrack` in the instructions for task 6
to match the instructions of task 2, unit tests and  and the `Exemplar.cs`.