### PR TITLE
Wizards-and-warriors: Fix typo in instructions.md

### DIFF
--- a/exercises/concept/wizards-and-warriors/.docs/instructions.md
+++ b/exercises/concept/wizards-and-warriors/.docs/instructions.md
@@ -11,7 +11,7 @@ For a Warrior, these are the rules:
 
 For a Wizard, these are the rules:
 
-- Deal 12 points of damage if the Wizard prepared a spell in advanced
+- Deal 12 points of damage if the Wizard prepared a spell in advance
 - Deal 3 points of damage if the Wizard did not prepare a spell in advance
 
 In general, characters are never vulnerable. However, Wizards _are_ vulnerable if they haven't prepared a spell.


### PR DESCRIPTION
Minor typo