### PR TITLE
DZ use HashSet in GoCounting

### DIFF
--- a/exercises/practice/go-counting/GoCounting.cs
+++ b/exercises/practice/go-counting/GoCounting.cs
@@ -15,12 +15,12 @@ public class GoCounting
         throw new NotImplementedException("You need to implement this function.");
     }
 
-    public Tuple<Owner, IEnumerable<(int, int)>> Territory((int, int) coord)
+    public Tuple<Owner, ISet<(int, int)>> Territory((int, int) coord)
     {
         throw new NotImplementedException("You need to implement this function.");
     }
 
-    public Dictionary<Owner, IEnumerable<(int, int)>> Territories()
+    public Dictionary<Owner, ISet<(int, int)>> Territories()
     {
         throw new NotImplementedException("You need to implement this function.");
     }

--- a/exercises/practice/go-counting/GoCounting.cs
+++ b/exercises/practice/go-counting/GoCounting.cs
@@ -15,12 +15,12 @@ public class GoCounting
         throw new NotImplementedException("You need to implement this function.");
     }
 
-    public Tuple<Owner, ISet<(int, int)>> Territory((int, int) coord)
+    public Tuple<Owner, HashSet<(int, int)>> Territory((int, int) coord)
     {
         throw new NotImplementedException("You need to implement this function.");
     }
 
-    public Dictionary<Owner, ISet<(int, int)>> Territories()
+    public Dictionary<Owner, HashSet<(int, int)>> Territories()
     {
         throw new NotImplementedException("You need to implement this function.");
     }

--- a/exercises/practice/go-counting/GoCountingTests.cs
+++ b/exercises/practice/go-counting/GoCountingTests.cs
@@ -140,7 +140,6 @@ public class GoCountingTests
             [Owner.White] = new HashSet<(int, int)>(),
             [Owner.None] = new HashSet<(int, int)> { (0, 0) }
         };
-        Assert.Equal(expected.Keys.Count, actual.Keys.Count);
         Assert.Equal(expected[Owner.Black], actual[Owner.Black]);
         Assert.Equal(expected[Owner.White], actual[Owner.White]);
         Assert.Equal(expected[Owner.None], actual[Owner.None]);
@@ -160,7 +159,6 @@ public class GoCountingTests
             [Owner.White] = new HashSet<(int, int)> { (3, 0), (3, 1) },
             [Owner.None] = new HashSet<(int, int)>()
         };
-        Assert.Equal(expected.Keys.Count, actual.Keys.Count);
         Assert.Equal(expected[Owner.Black], actual[Owner.Black]);
         Assert.Equal(expected[Owner.White], actual[Owner.White]);
         Assert.Equal(expected[Owner.None], actual[Owner.None]);
@@ -178,7 +176,6 @@ public class GoCountingTests
             [Owner.White] = new HashSet<(int, int)>(),
             [Owner.None] = new HashSet<(int, int)>()
         };
-        Assert.Equal(expected.Keys.Count, actual.Keys.Count);
         Assert.Equal(expected[Owner.Black], actual[Owner.Black]);
         Assert.Equal(expected[Owner.White], actual[Owner.White]);
         Assert.Equal(expected[Owner.None], actual[Owner.None]);

--- a/exercises/practice/go-counting/GoCountingTests.cs
+++ b/exercises/practice/go-counting/GoCountingTests.cs
@@ -16,7 +16,7 @@ public class GoCountingTests
             "  W  ";
         var sut = new GoCounting(board);
         var actual = sut.Territory(coordinate);
-        var expected = (Owner.Black, new[] { (0, 0), (0, 1), (1, 0) });
+        var expected = (Owner.Black, new HashSet<(int, int)> { (0, 0), (0, 1), (1, 0) });
         Assert.Equal(expected.Item1, actual.Item1);
         Assert.Equal(expected.Item2, actual.Item2);
     }
@@ -33,7 +33,7 @@ public class GoCountingTests
             "  W  ";
         var sut = new GoCounting(board);
         var actual = sut.Territory(coordinate);
-        var expected = (Owner.White, new[] { (2, 3) });
+        var expected = (Owner.White, new HashSet<(int, int)> { (2, 3) });
         Assert.Equal(expected.Item1, actual.Item1);
         Assert.Equal(expected.Item2, actual.Item2);
     }
@@ -50,7 +50,7 @@ public class GoCountingTests
             "  W  ";
         var sut = new GoCounting(board);
         var actual = sut.Territory(coordinate);
-        var expected = (Owner.None, new[] { (0, 3), (0, 4), (1, 4) });
+        var expected = (Owner.None, new HashSet<(int, int)> { (0, 3), (0, 4), (1, 4) });
         Assert.Equal(expected.Item1, actual.Item1);
         Assert.Equal(expected.Item2, actual.Item2);
     }
@@ -67,7 +67,7 @@ public class GoCountingTests
             "  W  ";
         var sut = new GoCounting(board);
         var actual = sut.Territory(coordinate);
-        var expected = (Owner.None, Array.Empty<(int, int)>());
+        var expected = (Owner.None, new HashSet<(int, int)>());
         Assert.Equal(expected.Item1, actual.Item1);
         Assert.Equal(expected.Item2, actual.Item2);
     }
@@ -134,13 +134,13 @@ public class GoCountingTests
         var board = " ";
         var sut = new GoCounting(board);
         var actual = sut.Territories();
-        var expected = new Dictionary<Owner, (int, int)[]>
+        var expected = new Dictionary<Owner, HashSet<(int, int)>>
         {
-            [Owner.Black] = Array.Empty<(int, int)>(),
-            [Owner.White] = Array.Empty<(int, int)>(),
-            [Owner.None] = new[] { (0, 0) }
+            [Owner.Black] = new HashSet<(int, int)>(),
+            [Owner.White] = new HashSet<(int, int)>(),
+            [Owner.None] = new HashSet<(int, int)> { (0, 0) }
         };
-        Assert.Equal(expected.Keys, actual.Keys);
+        Assert.Equal(expected.Keys.Count, actual.Keys.Count);
         Assert.Equal(expected[Owner.Black], actual[Owner.Black]);
         Assert.Equal(expected[Owner.White], actual[Owner.White]);
         Assert.Equal(expected[Owner.None], actual[Owner.None]);
@@ -154,13 +154,13 @@ public class GoCountingTests
             " BW ";
         var sut = new GoCounting(board);
         var actual = sut.Territories();
-        var expected = new Dictionary<Owner, (int, int)[]>
+        var expected = new Dictionary<Owner, HashSet<(int, int)>>
         {
-            [Owner.Black] = new[] { (0, 0), (0, 1) },
-            [Owner.White] = new[] { (3, 0), (3, 1) },
-            [Owner.None] = Array.Empty<(int, int)>()
+            [Owner.Black] = new HashSet<(int, int)> { (0, 0), (0, 1) },
+            [Owner.White] = new HashSet<(int, int)> { (3, 0), (3, 1) },
+            [Owner.None] = new HashSet<(int, int)>()
         };
-        Assert.Equal(expected.Keys, actual.Keys);
+        Assert.Equal(expected.Keys.Count, actual.Keys.Count);
         Assert.Equal(expected[Owner.Black], actual[Owner.Black]);
         Assert.Equal(expected[Owner.White], actual[Owner.White]);
         Assert.Equal(expected[Owner.None], actual[Owner.None]);
@@ -172,13 +172,13 @@ public class GoCountingTests
         var board = " B ";
         var sut = new GoCounting(board);
         var actual = sut.Territories();
-        var expected = new Dictionary<Owner, (int, int)[]>
+        var expected = new Dictionary<Owner, HashSet<(int, int)>>
         {
-            [Owner.Black] = new[] { (0, 0), (2, 0) },
-            [Owner.White] = Array.Empty<(int, int)>(),
-            [Owner.None] = Array.Empty<(int, int)>()
+            [Owner.Black] = new HashSet<(int, int)> { (0, 0), (2, 0) },
+            [Owner.White] = new HashSet<(int, int)>(),
+            [Owner.None] = new HashSet<(int, int)>()
         };
-        Assert.Equal(expected.Keys, actual.Keys);
+        Assert.Equal(expected.Keys.Count, actual.Keys.Count);
         Assert.Equal(expected[Owner.Black], actual[Owner.Black]);
         Assert.Equal(expected[Owner.White], actual[Owner.White]);
         Assert.Equal(expected[Owner.None], actual[Owner.None]);

--- a/generators/Exercises/Generators/GoCounting.cs
+++ b/generators/Exercises/Generators/GoCounting.cs
@@ -72,7 +72,6 @@ namespace Exercism.CSharp.Exercises.Generators
         private string RenderTerritoriesAssert()
         {
             var territoriesAssert = new StringBuilder();
-            territoriesAssert.AppendLine(Render.AssertEqual("expected.Keys.Count", "actual.Keys.Count"));
             territoriesAssert.AppendLine(Render.AssertEqual("expected[Owner.Black]", "actual[Owner.Black]"));
             territoriesAssert.AppendLine(Render.AssertEqual("expected[Owner.White]", "actual[Owner.White]"));
             territoriesAssert.AppendLine(Render.AssertEqual("expected[Owner.None]", "actual[Owner.None]"));

--- a/generators/Exercises/Generators/GoCounting.cs
+++ b/generators/Exercises/Generators/GoCounting.cs
@@ -49,7 +49,7 @@ namespace Exercism.CSharp.Exercises.Generators
         {
             var expected = new[]
             {
-                "new Dictionary<Owner, (int, int)[]>",
+                "new Dictionary<Owner, HashSet<(int, int)>>",
                 "{",
                 $"    [Owner.Black] = {RenderTerritory(testMethod.Expected!["territoryBlack"])},",
                 $"    [Owner.White] = {RenderTerritory(testMethod.Expected!["territoryWhite"])},",
@@ -72,7 +72,7 @@ namespace Exercism.CSharp.Exercises.Generators
         private string RenderTerritoriesAssert()
         {
             var territoriesAssert = new StringBuilder();
-            territoriesAssert.AppendLine(Render.AssertEqual("expected.Keys", "actual.Keys"));
+            territoriesAssert.AppendLine(Render.AssertEqual("expected.Keys.Count", "actual.Keys.Count"));
             territoriesAssert.AppendLine(Render.AssertEqual("expected[Owner.Black]", "actual[Owner.Black]"));
             territoriesAssert.AppendLine(Render.AssertEqual("expected[Owner.White]", "actual[Owner.White]"));
             territoriesAssert.AppendLine(Render.AssertEqual("expected[Owner.None]", "actual[Owner.None]"));
@@ -82,7 +82,7 @@ namespace Exercism.CSharp.Exercises.Generators
         private UnescapedValue RenderOwner(dynamic owner) => Render.Enum("Owner", owner);
 
         private string RenderTerritory(dynamic territory)
-            => Render.Object(((JArray)territory).Select(coordinate => (coordinate[0]!.ToObject<int>(), coordinate[1]!.ToObject<int>())).ToArray());
+            => Render.Object(((JArray)territory).Select(coordinate => (coordinate[0]!.ToObject<int>(), coordinate[1]!.ToObject<int>())).ToHashSet());
 
         protected override void UpdateNamespaces(ISet<string> namespaces) => namespaces.Add(typeof(Dictionary<int, int>).Namespace!);
     }

--- a/generators/Output/Rendering/Render.cs
+++ b/generators/Output/Rendering/Render.cs
@@ -30,6 +30,9 @@ namespace Exercism.CSharp.Output.Rendering
                     if (IsList(val))
                         return List((dynamic)val);
 
+                    if (IsHashSet(val))
+                        return HashSet((dynamic)val);
+
                     if (IsArray(val))
                         return Array((dynamic)val);
 
@@ -67,6 +70,9 @@ namespace Exercism.CSharp.Output.Rendering
 
         private static bool IsArray(object obj)
             => obj.GetType().IsArray;
+
+        private static bool IsHashSet(object obj)
+            => obj.GetType().IsGenericType && obj.GetType().GetGenericTypeDefinition() == typeof(HashSet<>);
 
         private static bool IsDictionary(object obj)
             => obj.GetType().IsGenericType && obj.GetType().GetGenericTypeDefinition() == typeof(Dictionary<,>);

--- a/generators/Output/Rendering/RenderHashSet.cs
+++ b/generators/Output/Rendering/RenderHashSet.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Exercism.CSharp.Helpers;
+
+namespace Exercism.CSharp.Output.Rendering
+{
+    internal partial class Render
+    {
+        public string HashSet<T>(HashSet<T> elements) =>
+            elements.Any()
+                ? $"new HashSet<{typeof(T).ToFriendlyName()}>{CollectionInitializer(elements)}"
+                : $"new HashSet<{typeof(T).ToFriendlyName()}>()";
+    }
+}


### PR DESCRIPTION
Currently the tests are very brittle assuming elements are added to the lists in a particular order.
Using `HashSet` instead of `IEnumerable` and `Array` makes the tests more robust.