### PR TITLE
Example response in task 2 is incorrect

### DIFF
--- a/exercises/concept/developer-privileges/.docs/instructions.md
+++ b/exercises/concept/developer-privileges/.docs/instructions.md
@@ -34,7 +34,7 @@ Implement the `Authenticator.Developers()` method to return the developers' iden
 ```csharp
 var authenticator = new Authenticator();
 authenticator.Developers;
-// => {"bert" = {"bert@ex.ism", {"blue", 0.8m}, ["Bertrand", "Paris", "France"]},
-// ["anders" = {"bert@ex.ism", {"brown", 0.85m}, ["Anders", "Redmond", "USA"]},
+// => {"Bertrand" = {"bert@ex.ism", {"blue", 0.8m}, ["Bertrand", "Paris", "France"]},
+// ["Anders" = {"anders@ex.ism", {"brown", 0.85m}, ["Anders", "Redmond", "USA"]},
 
 ```


### PR DESCRIPTION
Per the doc (and the tests) the Dictionary keys need to be the developers' name, not the first part of their email address. Also, Anders' email address was incorrect in the example response.