### PR TITLE
SgfParsing: fix test assertions

### DIFF
--- a/exercises/practice/sgf-parsing/SgfParsingTests.cs
+++ b/exercises/practice/sgf-parsing/SgfParsingTests.cs
@@ -30,7 +30,7 @@ public class SgfParsingTests
     {
         var encoded = "(;)";
         var expected = new SgfTree(new Dictionary<string, string[]>());
-        Assert.Equal(expected, SgfParser.ParseTree(encoded));
+        AssertEqual(expected, SgfParser.ParseTree(encoded));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -38,7 +38,7 @@ public class SgfParsingTests
     {
         var encoded = "(;A[B])";
         var expected = new SgfTree(new Dictionary<string, string[]> { ["A"] = new[] { "B" } });
-        Assert.Equal(expected, SgfParser.ParseTree(encoded));
+        AssertEqual(expected, SgfParser.ParseTree(encoded));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -46,7 +46,7 @@ public class SgfParsingTests
     {
         var encoded = "(;A[b]C[d])";
         var expected = new SgfTree(new Dictionary<string, string[]> { ["A"] = new[] { "b" }, ["C"] = new[] { "d" } });
-        Assert.Equal(expected, SgfParser.ParseTree(encoded));
+        AssertEqual(expected, SgfParser.ParseTree(encoded));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -75,7 +75,7 @@ public class SgfParsingTests
     {
         var encoded = "(;A[B];B[C])";
         var expected = new SgfTree(new Dictionary<string, string[]> { ["A"] = new[] { "B" } }, new SgfTree(new Dictionary<string, string[]> { ["B"] = new[] { "C" } }));
-        Assert.Equal(expected, SgfParser.ParseTree(encoded));
+        AssertEqual(expected, SgfParser.ParseTree(encoded));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -83,7 +83,7 @@ public class SgfParsingTests
     {
         var encoded = "(;A[B](;B[C])(;C[D]))";
         var expected = new SgfTree(new Dictionary<string, string[]> { ["A"] = new[] { "B" } }, new SgfTree(new Dictionary<string, string[]> { ["B"] = new[] { "C" } }), new SgfTree(new Dictionary<string, string[]> { ["C"] = new[] { "D" } }));
-        Assert.Equal(expected, SgfParser.ParseTree(encoded));
+        AssertEqual(expected, SgfParser.ParseTree(encoded));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -91,7 +91,7 @@ public class SgfParsingTests
     {
         var encoded = "(;A[b][c][d])";
         var expected = new SgfTree(new Dictionary<string, string[]> { ["A"] = new[] { "b", "c", "d" } });
-        Assert.Equal(expected, SgfParser.ParseTree(encoded));
+        AssertEqual(expected, SgfParser.ParseTree(encoded));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -99,6 +99,16 @@ public class SgfParsingTests
     {
         var encoded = "(;A[\\]b\\nc\\nd\\t\\te \\n\\]])";
         var expected = new SgfTree(new Dictionary<string, string[]> { ["A"] = new[] { "]b\nc\nd  e \n]" } });
-        Assert.Equal(expected, SgfParser.ParseTree(encoded));
+        AssertEqual(expected, SgfParser.ParseTree(encoded));
     }
+
+        private void AssertEqual(SgfTree expected, SgfTree actual)
+        {
+            Assert.Equal(expected.Data, actual.Data);
+            Assert.Equal(expected.Children.Length, actual.Children.Length);
+            for (var i = 0; i < expected.Children.Length; i++)
+            {
+                AssertEqual(expected.Children[i], actual.Children[i]);
+            }
+        }
 }

--- a/generators/Exercises/Generators/SgfParsing.cs
+++ b/generators/Exercises/Generators/SgfParsing.cs
@@ -14,7 +14,10 @@ namespace Exercism.CSharp.Exercises.Generators
             if (testMethod.ExpectedIsError)
                 testMethod.ExceptionThrown = typeof(ArgumentException);
             else
+            {
                 testMethod.Expected = RenderTree(testMethod.Expected);
+                testMethod.Assert = "AssertEqual(expected, SgfParser.ParseTree(encoded));";
+            }
 
             testMethod.TestedClass = "SgfParser";
             testMethod.TestedMethod = "ParseTree";
@@ -28,6 +31,20 @@ namespace Exercism.CSharp.Exercises.Generators
             namespaces.Add(typeof(ArgumentException).Namespace!);
             namespaces.Add(typeof(Dictionary<string, string[]>).Namespace!);
         }
+
+        protected override void UpdateTestClass(TestClass testClass) => AddAssertEqualMethod(testClass);
+
+        private void AddAssertEqualMethod(TestClass testClass) =>
+            testClass.AdditionalMethods.Add(@"
+    private void AssertEqual(SgfTree expected, SgfTree actual)
+    {
+        Assert.Equal(expected.Data, actual.Data);
+        Assert.Equal(expected.Children.Length, actual.Children.Length);
+        for (var i = 0; i < expected.Children.Length; i++)
+        {
+            AssertEqual(expected.Children[i], actual.Children[i]);
+        }
+    }");
 
         private UnescapedValue? RenderTree(dynamic tree)
         {


### PR DESCRIPTION
Issue
==
https://github.com/exercism/csharp/issues/1842

Summary
==
Currently test won't pass with default equality unless students implement equality on `SgfTree` to do a deep comparison, which is a bit out of scope of the exercise and not indicated in the exercise anywhere.

This change implements an assertion check that will do the deep comparison necessary.
