### PR TITLE
Fixed typos in Weighing Machine

### DIFF
--- a/exercises/concept/weighing-machine/.docs/instructions.md
+++ b/exercises/concept/weighing-machine/.docs/instructions.md
@@ -7,7 +7,7 @@ You have 6 tasks each of which requires you to implement one or more properties:
 ## 1. Allow the weighing machine to have a precision
 
 To cater to different demands, we allow each weighing machine to be customized with a precision (the number of digits after the decimal separator).
-Implement the `WeigingMachine` class to have a get-only `Precision` property set to the constructor's `precision` argument:
+Implement the `WeighingMachine` class to have a get-only `Precision` property set to the constructor's `precision` argument:
 
 ```csharp
 var wm = new WeighingMachine(precision: 3);
@@ -17,7 +17,7 @@ var wm = new WeighingMachine(precision: 3);
 
 ## 2. Allow the weight to be set on the weighing machine
 
-Implement the `WeigingMachine.Weight` property to allow the weight to be get _and_ set:
+Implement the `WeighingMachine.Weight` property to allow the weight to be get _and_ set:
 
 ```csharp
 var wm = new WeighingMachine(precision: 3);

--- a/exercises/concept/weighing-machine/.docs/introduction.md
+++ b/exercises/concept/weighing-machine/.docs/introduction.md
@@ -3,8 +3,8 @@
 A property in C# is a member of a class that provides access to data within that class.
 Callers can set or retrieve (get) the data. Properties can be either auto-implemented or
 have a backing field. They comprise a set accessor and/or a get accessor.
-In some other languages a "mutator" is roughly equivalent to a
-a set accessor and an "accessor" is roughly equivalent to a set accessor although
+In some other languages a "mutator" is roughly equivalent to 
+a set accessor and an "accessor" is roughly equivalent to a get accessor although
 the composition of the syntax is completely different.
 
 When setting a property the input value can be validated, formatted
@@ -26,7 +26,7 @@ The basic syntax to express properties can take two forms:
 private int myField;
 public int MyProperty
 {
-    get { return myfField; }
+    get { return myField; }
     set { myField = value; }
 }
 ```


### PR DESCRIPTION
Fixed a typo in the name WeighingMachine. It was WeigingMachine and is fixed to be WeighingMachine.