### PR TITLE
Updated description of greater than or equal to

### DIFF
--- a/exercises/concept/interest-is-interesting/.docs/instructions.md
+++ b/exercises/concept/interest-is-interesting/.docs/instructions.md
@@ -4,8 +4,8 @@ In this exercise you'll be working with savings accounts. Each year, the balance
 
 - 3.213% for a negative balance (balance gets more negative).
 - 0.5% for a positive balance less than `1000` dollars.
-- 1.621% for a positive balance greater or equal than `1000` dollars and less than `5000` dollars.
-- 2.475% for a positive balance greater or equal than `5000` dollars.
+- 1.621% for a positive balance greater than or equal to `1000` dollars and less than `5000` dollars.
+- 2.475% for a positive balance greater than or equal to `5000` dollars.
 
 You have four tasks, each of which will deal your balance and its interest rate.
 


### PR DESCRIPTION
Updated the description of bullet points 3 & 4 to phrase greater than or equal to instead of greater or equal than.
The current phrasing doesn't make sense. 