### PR TITLE
make argument names consistent format in Dictionaries exercise

### DIFF
--- a/exercises/concept/international-calling-connoisseur/InternationalCallingConnoisseur.cs
+++ b/exercises/concept/international-calling-connoisseur/InternationalCallingConnoisseur.cs
@@ -19,7 +19,7 @@ public static class DialingCodes
     }
 
     public static Dictionary<int, string> AddCountryToExistingDictionary(
-        Dictionary<int, string> existingDictionary, int countryCode, string CountryName)
+        Dictionary<int, string> existingDictionary, int countryCode, string countryName)
     {
         throw new NotImplementedException($"Please implement the (static) AddCountryToExistingDictionary() method");
     }


### PR DESCRIPTION
In the International Calling Connoisseur C# exercise, an argument on one of the methods didn't follow the same naming convention.

Updated so that camel case naming is consistent throughout file.