### PR TITLE
fix: remove duplicate link in randomness concept

### DIFF
--- a/concepts/randomness/links.json
+++ b/concepts/randomness/links.json
@@ -4,10 +4,6 @@
     "description": "system-random"
   },
   {
-    "url": "https://docs.microsoft.com/en-us/dotnet/api/system.random?view=netcore-3.1",
-    "description": "system-random"
-  },
-  {
     "url": "https://docs.microsoft.com/en-us/dotnet/api/system.random?view=netcore-3.1#instantiating-the-random-number-generator",
     "description": "random-seedless"
   },


### PR DESCRIPTION
Removing duplicate link in [csharp/concepts/randomness](https://exercism.org/tracks/csharp/concepts/randomness)
Duplicate link: `https://docs.microsoft.com/en-us/dotnet/api/system.random?view=netcore-3.1`

Feel free to close this PR if this is already being tackled in https://github.com/exercism/csharp/issues/1461.