### PR TITLE
Update: minor fix of instructions.append.md

### DIFF
--- a/exercises/practice/difference-of-squares/.docs/instructions.append.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.append.md
@@ -1,5 +1,4 @@
 # Hints
 
 This exercise requires you to process a collection of data. You can simplify your code by using LINQ (Language Integrated Query).
-For more information, see [this page]
-(https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq).
+For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq).


### PR DESCRIPTION
Markdown syntax is seen to users: there's need to remove space between `[this page]` and the following link.