### PR TITLE
Remove nbsp from HelloWorld.cs

### DIFF
--- a/exercises/practice/hello-world/HelloWorld.cs
+++ b/exercises/practice/hello-world/HelloWorld.cs
@@ -1,4 +1,4 @@
-﻿public static class HelloWorld
+public static class HelloWorld
 {
     public static string Hello() => "Goodbye, Mars!";
 }


### PR DESCRIPTION
I took a peak at HelloWorld to help debug an unrelated problem, and I noticed a red dot in the editor. Upon inspection it turns out to be a non-breaking space. I assume it's not needed?
<img width="633" alt="Screenshot 2022-02-05 at 18 02 59" src="https://user-images.githubusercontent.com/7852553/152651223-248d087d-7dd9-41a3-94c7-efa9f463210f.png">

