### PR TITLE
`need-for-speed`: Update method name `CanFinishTrack` to `TryFinishTrack`

### DIFF
--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -69,7 +69,7 @@ car.DistanceDriven();
 ```
 ## 6. Check if a remote control car can finish a race
 
-To finish a race track, a car has to be able to drive the track's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.CarCanFinish()` method that takes a `RemoteControlCar` instance as its parameter and returns `true` if the car can finish the race track; otherwise, return `false`:
+To finish a race track, a car has to be able to drive the track's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.TryFinishTrack()` method that takes a `RemoteControlCar` instance as its parameter and returns `true` if the car can finish the race track; otherwise, return `false`:
 
 ```csharp
 int speed = 5;
@@ -79,6 +79,6 @@ var car = new RemoteControlCar(speed, batteryDrain);
 int distance = 100;
 var raceTrack = new RaceTrack(distance);
 
-raceTrack.CarCanFinish(car);
+raceTrack.TryFinishTrack(car);
 // => true
 ```

--- a/exercises/concept/need-for-speed/.meta/Exemplar.cs
+++ b/exercises/concept/need-for-speed/.meta/Exemplar.cs
@@ -45,7 +45,7 @@ class RaceTrack
         this.distance = distance;
     }
 
-    public bool CarCanFinish(RemoteControlCar car)
+    public bool TryFinishTrack(RemoteControlCar car)
     {
         while (!car.BatteryDrained())
         {

--- a/exercises/concept/need-for-speed/NeedForSpeed.cs
+++ b/exercises/concept/need-for-speed/NeedForSpeed.cs
@@ -29,8 +29,8 @@ class RaceTrack
 {
     // TODO: define the constructor for the 'RaceTrack' class
 
-    public bool CarCanFinish(RemoteControlCar car)
+    public bool TryFinishTrack(RemoteControlCar car)
     {
-        throw new NotImplementedException("Please implement the RaceTrack.CarCanFinish() method");
+        throw new NotImplementedException("Please implement the RaceTrack.TryFinishTrack() method");
     }
 }

--- a/exercises/concept/need-for-speed/NeedForSpeedTests.cs
+++ b/exercises/concept/need-for-speed/NeedForSpeedTests.cs
@@ -170,7 +170,7 @@ public class NeedForSpeedTests
         int distance = 100;
         var race = new RaceTrack(distance);
 
-        Assert.True(race.CarCanFinish(car));
+        Assert.True(race.TryFinishTrack(car));
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class NeedForSpeedTests
         int distance = 20;
         var race = new RaceTrack(distance);
 
-        Assert.True(race.CarCanFinish(car));
+        Assert.True(race.TryFinishTrack(car));
     }
 
     [Fact]
@@ -198,7 +198,7 @@ public class NeedForSpeedTests
         int distance = 16;
         var race = new RaceTrack(distance);
 
-        Assert.False(race.CarCanFinish(car));
+        Assert.False(race.TryFinishTrack(car));
     }
 
     [Fact]
@@ -212,6 +212,6 @@ public class NeedForSpeedTests
         int distance = 678;
         var race = new RaceTrack(distance);
 
-        Assert.False(race.CarCanFinish(car));
+        Assert.False(race.TryFinishTrack(car));
     }
 }


### PR DESCRIPTION
This name change clarifies that the method is supposed to try and drive the car around the track to see if it can finish the track before it runs out of battery as opposed to exposing the state of the car and directly calculating the remaining distance that that car can travel

@ErikSchierboom, this differs slightly from your suggestion of `TryToFinishTrack`

Co-authored-by: Erik Schierboom <erik_schierboom@hotmail.com>
