### PR TITLE
Typo in Revoke method call

### DIFF
--- a/exercises/concept/attack-of-the-trolls/.docs/instructions.md
+++ b/exercises/concept/attack-of-the-trolls/.docs/instructions.md
@@ -41,7 +41,7 @@ Permissions.Grant(current: Permission.None, grant: Permission.Read)
 Implement the (_static_) `Permissions.Revoke()` method that revokes (removes) a permission:
 
 ```csharp
-Permissions.Revoke(current: Permission.Read, grant: Permission.Read)
+Permissions.Revoke(current: Permission.Read, revoke: Permission.Read)
 // => Permission.None
 ```
 


### PR DESCRIPTION
Should be `revoke`, not `grant`