### PR TITLE
Updating calculation to avoid confusion

### DIFF
--- a/exercises/concept/hyperinflation-hits-hyperia/.docs/instructions.md
+++ b/exercises/concept/hyperinflation-hits-hyperia/.docs/instructions.md
@@ -40,7 +40,7 @@ If the GDP cannot be calculated then `"*** Too Big ***"` is returned.
 
 ```csharp
 CentralBank.DisplayGDP(555f, 10000f);
-// => "555000000"
+// => "5550000"
 CentralBank.DisplayGDP(float.MaxValue / 2, 10000f);
 // => "*** Too Big ***"
 ```


### PR DESCRIPTION
`CentralBank.DisplayGDP(555f, 10000f)` should be **5550000**, not **5550000_00_** (2 extra zeros in readme). This can cause confusions to someone getting their head around type overflow on why those 2 extra zeros are there 😊