### PR TITLE
Fix expected values for bert

### DIFF
--- a/exercises/concept/developer-privileges/DeveloperPrivilegesTests.cs
+++ b/exercises/concept/developer-privileges/DeveloperPrivilegesTests.cs
@@ -30,7 +30,7 @@ public class DeveloperPrivilegesTests
 
     [Fact]
     [Task(2)]
-    public void GetDevelopers()
+    public void GetDevelopers_Bertrand()
     {
         var authenticator = new Authenticator();
         var developers = authenticator.Developers;
@@ -38,15 +38,46 @@ public class DeveloperPrivilegesTests
         {
             developers["Bertrand"]?.Email,
             developers["Bertrand"]?.FacialFeatures.EyeColor,
-            developers["Anders"]?.FacialFeatures.PhiltrumWidth.ToString(CultureInfo.InvariantCulture),
-            developers["Anders"]?.NameAndAddress[1]
+            developers["Bertrand"]?.FacialFeatures.PhiltrumWidth.ToString(CultureInfo.InvariantCulture),
+            developers["Bertrand"]?.NameAndAddress[0],
+            developers["Bertrand"]?.NameAndAddress[1],
+            developers["Bertrand"]?.NameAndAddress[2]
         };
         string[] expected =
         {
             "bert@ex.ism",
             "blue",
             "0.8",
-            "Paris"
+            "Bertrand",
+            "Paris",
+            "France"
+        };
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    [Task(3)]
+    public void GetDevelopers_Anders()
+    {
+        var authenticator = new Authenticator();
+        var developers = authenticator.Developers;
+        string[] actual =
+        {
+            developers["Anders"]?.Email,
+            developers["Anders"]?.FacialFeatures.EyeColor,
+            developers["Anders"]?.FacialFeatures.PhiltrumWidth.ToString(CultureInfo.InvariantCulture),
+            developers["Anders"]?.NameAndAddress[0],
+            developers["Anders"]?.NameAndAddress[1],
+            developers["Anders"]?.NameAndAddress[2]
+        };
+        string[] expected =
+        {
+            "anders@ex.ism",
+            "brown",
+            "0.85",
+            "Anders",
+            "Redmond",
+            "USA"
         };
         Assert.Equal(expected, actual);
     }

--- a/exercises/concept/developer-privileges/DeveloperPrivilegesTests.cs
+++ b/exercises/concept/developer-privileges/DeveloperPrivilegesTests.cs
@@ -45,8 +45,8 @@ public class DeveloperPrivilegesTests
         {
             "bert@ex.ism",
             "blue",
-            "0.85",
-            "Redmond"
+            "0.8",
+            "Paris"
         };
         Assert.Equal(expected, actual);
     }


### PR DESCRIPTION
As per the docs for the exercise [here](https://exercism.org/tracks/csharp/exercises/developer-privileges), Bertrand's philtrum width is stated as 0.8, and Address 1 as Paris.

To conform to these constraints, I have updated the test's expected values to match the docs.