### PR TITLE
Remove redundant concurrent_dictionary link

### DIFF
--- a/concepts/dictionaries/links.json
+++ b/concepts/dictionaries/links.json
@@ -4,10 +4,6 @@
     "description": "gethashcode"
   },
   {
-    "url": "https://docs.microsoft.com/en-gb/dotnet/api/system.collections.concurrent.concurrentdictionary-2?view=netcore-3.1",
-    "description": "concurrent-dictionary"
-  },
-  {
     "url": "https://docs.microsoft.com/en-gb/dotnet/api/system.collections.generic.hashset-1?view=netcore-3.1",
     "description": "hashset"
   },


### PR DESCRIPTION
Those two links are exactly same, and I choose remove the first one as the second one group together with the rest of the links slightly better.