### PR TITLE
Remove second link 'floating-point-numeric-types'

### DIFF
--- a/concepts/overflow/links.json
+++ b/concepts/overflow/links.json
@@ -16,10 +16,6 @@
     "description": "floating-point-numeric-types"
   },
   {
-    "url": "https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types",
-    "description": "floating-point-numeric-types"
-  },
-  {
     "url": "https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger?view=netcore-3.1",
     "description": "big-integer"
   },


### PR DESCRIPTION
Also remove the duplicate 'floating-point-numeric-types' link next to it as well