### PR TITLE
modify expected exception in case of divide by zero attempt

### DIFF
--- a/exercises/practice/forth/.meta/Example.cs
+++ b/exercises/practice/forth/.meta/Example.cs
@@ -159,7 +159,7 @@ public class Division : BinaryOperation
     public override List<int> operation(int x, int y)
     {
         if (y == 0)
-            throw new InvalidOperationException();
+            throw new DivideByZeroException();
 
         return new List<int> { x / y };
     }

--- a/exercises/practice/forth/ForthTests.cs
+++ b/exercises/practice/forth/ForthTests.cs
@@ -78,7 +78,7 @@ public class ForthTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Division_errors_if_dividing_by_zero()
     {
-        Assert.Throws<InvalidOperationException>(() => Forth.Evaluate(new[] { "4 0 /" }));
+        Assert.Throws<DivideByZeroException>(() => Forth.Evaluate(new[] { "4 0 /" }));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]

--- a/generators/Exercises/Generators/Forth.cs
+++ b/generators/Exercises/Generators/Forth.cs
@@ -11,7 +11,7 @@ namespace Exercism.CSharp.Exercises.Generators
 
             if (testMethod.ExpectedIsError)
             {
-                testMethod.ExceptionThrown = typeof(InvalidOperationException);
+                testMethod.ExceptionThrown = testMethod.Expected!["error"] == "divide by zero" ? typeof(DivideByZeroException) : typeof(InvalidOperationException);
             }
             else
             {


### PR DESCRIPTION
The test case that tried to divide by zero and expected a `InvalidOperationException` should now expect a `DivideByZeroException`.