### PR TITLE
Remove duplicate date time format links

### DIFF
--- a/concepts/string-formatting/links.json
+++ b/concepts/string-formatting/links.json
@@ -76,14 +76,6 @@
     "description": "custom-numeric-format-strings"
   },
   {
-    "url": "https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings",
-    "description": "standard-date-and-time-format-strings"
-  },
-  {
-    "url": "https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings",
-    "description": "custom-date-and-time-format-strings"
-  },
-  {
     "url": "https://docs.microsoft.com/en-us/dotnet/standard/base-types/stringbuilder",
     "description": "string-builder"
   },


### PR DESCRIPTION
'standard-date-and-time-format-strings', 'custom-date-and-time-format-strings' appeared twice