### PR TITLE
Fix links in hints.md

### DIFF
--- a/exercises/concept/log-analysis/.docs/hints.md
+++ b/exercises/concept/log-analysis/.docs/hints.md
@@ -7,11 +7,11 @@
 
 ## 1. Implement the extension method SubstringAfter
 
-- Different options to search for text in a string are explored in [this tutorial][tutorial-docs.microsoft.com-search-text-in-string].
+- Different options to search for text in a string are explored in [this tutorial][tutorial-csharp.net-strings].
 
 ## 2. Implement the extension method SubstringBetween
 
-- Different options to search for text in a string are explored in [this tutorial][tutorial-docs.microsoft.com-search-text-in-string].
+- Different options to search for text in a string are explored in [this tutorial][tutorial-csharp.net-strings].
 
 ## 3. Parse message in a log
 

--- a/exercises/concept/log-analysis/.docs/instructions.md
+++ b/exercises/concept/log-analysis/.docs/instructions.md
@@ -25,7 +25,7 @@ log.SubstringAfter(": "); // => returns "File Deleted."
 
 ## 2. Allow retrieving the string in between two substrings
 
-On further inspection, you see that the log level is always located between square brackets (`[` and `]`). As you're also anticipating having to extract the log level sometime in the near future, you decide to create a another helper method to help you with that.
+On further inspection, you see that the log level is always located between square brackets (`[` and `]`). As you're also anticipating having to extract the log level sometime in the near future, you decide to create another helper method to help you with that.
 
 Implement the (_static_) `LogAnalysis.SubstringBetween()` extension method that takes in two string delimiters, and returns the substring that lies between the two delimiters.
 


### PR DESCRIPTION
A couple of links to the strings tutorial were not being rendered as links because the names were different.