### PR TITLE
Add test for task 3 of wizards and warriors exercise

### DIFF
--- a/exercises/concept/wizards-and-warriors/.docs/instructions.md
+++ b/exercises/concept/wizards-and-warriors/.docs/instructions.md
@@ -45,6 +45,8 @@ Implement the `Wizard.PrepareSpell()` method to allow a Wizard to prepare a spel
 ```csharp
 var wizard = new Wizard();
 wizard.PrepareSpell();
+Console.WriteLine(wizard.spellPrepared);
+// => true
 ```
 
 ## 4. Make Wizards vulnerable when not having prepared a spell

--- a/exercises/concept/wizards-and-warriors/.docs/instructions.md
+++ b/exercises/concept/wizards-and-warriors/.docs/instructions.md
@@ -45,8 +45,8 @@ Implement the `Wizard.PrepareSpell()` method to allow a Wizard to prepare a spel
 ```csharp
 var wizard = new Wizard();
 wizard.PrepareSpell();
-Console.WriteLine(wizard.spellPrepared);
-// => true
+wizard.Vulnerable();
+// => false
 ```
 
 ## 4. Make Wizards vulnerable when not having prepared a spell

--- a/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
+++ b/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
@@ -29,7 +29,7 @@ public class WizardsAndWarriorsTests
 
     [Fact]
     [Task(3)]
-    public void Warrior_is_not_vulnerable_after_preparing_spell()
+    public void Wizard_is_not_vulnerable_after_preparing_spell()
     {
         var wizard = new Wizard();
         wizard.PrepareSpell();

--- a/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
+++ b/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
@@ -28,6 +28,15 @@ public class WizardsAndWarriorsTests
     }
 
     [Fact]
+    [Task(3)]
+    public void Warrior_is_not_vulnerable()
+    {
+        var wizard = new Wizard();
+        wizard.PrepareSpell();
+        Assert.False(warrior.Vulnerable());
+    }
+    
+    [Fact]
     [Task(4)]
     public void Wizard_is_vulnerable()
     {

--- a/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
+++ b/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
@@ -33,7 +33,7 @@ public class WizardsAndWarriorsTests
     {
         var wizard = new Wizard();
         wizard.PrepareSpell();
-        Assert.False(warrior.Vulnerable());
+        Assert.False(wizard.Vulnerable());
     }
     
     [Fact]

--- a/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
+++ b/exercises/concept/wizards-and-warriors/WizardsAndWarriorsTests.cs
@@ -29,7 +29,7 @@ public class WizardsAndWarriorsTests
 
     [Fact]
     [Task(3)]
-    public void Warrior_is_not_vulnerable()
+    public void Warrior_is_not_vulnerable_after_preparing_spell()
     {
         var wizard = new Wizard();
         wizard.PrepareSpell();


### PR DESCRIPTION
Issue: #1953 

I added a unit test for task 3, and updated the task instructions to show the expected output.

I'm a bit out of my element here, so I will totally understand if this is partially or completely wrong/unnecessary. I just thought it was confusing that there was no test for that particular task. It still seems slightly weird though, because the following task also states that the wizard should _not_ be vulnerable after preparing a spell. Perhaps this could be made clearer somehow.

EDIT: Wait... I just realized that we cannot call `wizard.Vulnerable()` at this point because the student has not defined that method yet! How else could we test this?  `spellPrepared` is a private variable.

Moreover, once the wizard has prepared a spell, we can no longer test whether they are vulnerable by default! Perhaps we could make `spellPrepared` public?