### PR TITLE
[docs] bump Visual Studio version number

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -16,7 +16,7 @@ If the output is a version greater than or equal to `6.0.100`, the .NET SDK has 
 
 If you want a more full-featured editing experience, you probably want to to use an IDE. These are the most popular IDE's that support building .NET projects:
 
-- [Visual Studio 2019](https://www.visualstudio.com/downloads/)
+- [Visual Studio 2022](https://www.visualstudio.com/downloads/)
 - [Visual Studio Code](https://code.visualstudio.com/download) with the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 - [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/)
 - [Project Rider](https://www.jetbrains.com/rider/download/)


### PR DESCRIPTION
Updates installation docs link from Visual Studio 2019 to 2022.