### PR TITLE
Adds section on splitting strings

### DIFF
--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -17,10 +17,7 @@ escaped == verbatim;
 // => true
 ```
 
-At some point you might need to separate a string into multiple parts. This might be because you want to concatenate different parts from multiple strings or you 
-need to analyse a specific part more closely but don't need the rest. That happens mostly with application logs.
-
-The easiest way to do this is with the [Substring method][substring] 
+If you only need a part of a string, you can use the [`Substring()` method][substring] to extract just that part:
 
 ```csharp
 string sentence = "Frank chases the bus.";

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -17,6 +17,19 @@ escaped == verbatim;
 // => true
 ```
 
+At some point you might need to separate a string into multiple parts. This might be because you want to concatenate different parts from multiple strings or you 
+need to analyse a specific part more closely but don't need the rest. That happens mostly with application logs.
+
+The easiest way to do this is with the [Substring method][substring] 
+
+```csharp
+string sentence = "Frank chases the bus.";
+string name = sentence.Substring(0,5)
+// => "Frank"
+```
+
+If you need to split the string at a certain character you can use [Substring][substring] in combination with [IndexOf][indexof]. In recent C# versions also the [Split method] has become very powerful. Check this out as well. 
+
 Finally, there are [many ways to concatenate a string][concatenation]. The simplest one is by using the [`+` operator][plus-operator].
 
 ```csharp
@@ -40,3 +53,6 @@ $"Hello {name}!";
 [escaping]: https://devblogs.microsoft.com/csharpfaq/what-character-escape-sequences-are-available/
 [methods]: https://docs.microsoft.com/en-us/dotnet/api/system.string?view=netcore-3.1#methods
 [properties]: https://docs.microsoft.com/en-us/dotnet/api/system.string?view=netcore-3.1#properties
+[substring]: https://docs.microsoft.com/en-us/dotnet/api/system.string.substring?view=netcore-3.1
+[indexof]: https://docs.microsoft.com/en-us/dotnet/api/system.string.indexof?view=netcore-3.1
+[splitting]: https://docs.microsoft.com/en-us/dotnet/api/system.string.split?view=netcore-3.1

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -25,7 +25,15 @@ string name = sentence.Substring(0, 5);
 // => "Frank"
 ```
 
-If you need to split the string at a certain character you can use [Substring][substring] in combination with [IndexOf][indexof]. In recent C# versions also the [Split method][splitting] has become very powerful. Check this out as well. 
+The [`IndexOf`() method][indexof] can be used to find the index of the first occurence of a `string` within a `string`, returning `-1` if the specified value could not be found:
+
+```csharp
+"continuous-integration".IndexOf("integration")
+// => 11
+
+"continuous-integration".IndexOf("deployment")
+// => -1
+```
 
 Finally, there are [many ways to concatenate a string][concatenation]. The simplest one is by using the [`+` operator][plus-operator].
 

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -21,7 +21,7 @@ If you only need a part of a string, you can use the [`Substring()` method][subs
 
 ```csharp
 string sentence = "Frank chases the bus.";
-string name = sentence.Substring(0,5)
+string name = sentence.Substring(0, 5);
 // => "Frank"
 ```
 

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -28,7 +28,7 @@ string name = sentence.Substring(0,5)
 // => "Frank"
 ```
 
-If you need to split the string at a certain character you can use [Substring][substring] in combination with [IndexOf][indexof]. In recent C# versions also the [Split method] has become very powerful. Check this out as well. 
+If you need to split the string at a certain character you can use [Substring][substring] in combination with [IndexOf][indexof]. In recent C# versions also the [Split method][splitting] has become very powerful. Check this out as well. 
 
 Finally, there are [many ways to concatenate a string][concatenation]. The simplest one is by using the [`+` operator][plus-operator].
 


### PR DESCRIPTION
In a recent mentoring discussion on the _Log Levels_ exercise the mentee complained that the splitting topic as a whole was missing on the concepts page.

It is kind of present with the link to the String methods, but also burried in there if you don't know what you're looking for.

The new part adds the classic  `Substring` and `IndexOf` way of doing the splitting, but withholding the possibility of a simple `string.Split` felt wrong for
me, since it makes things a lot easier from my point of view.