### PR TITLE
Modify Longest_country_name test to prevent test passing by alphabetical sort

### DIFF
--- a/exercises/concept/international-calling-connoisseur/InternationalCallingConnoisseurTests.cs
+++ b/exercises/concept/international-calling-connoisseur/InternationalCallingConnoisseurTests.cs
@@ -279,8 +279,9 @@ public class InternationalCallingConnoisseurTests
     [Task(9)]
     public void Longest_country_name()
     {
-        var longestCountryName = DialingCodes.FindLongestCountryName(
-            DialingCodes.GetExistingDictionary());
+        var countryCodes = DialingCodes.AddCountryToExistingDictionary(
+            DialingCodes.GetExistingDictionary(), 263, "Zimbabwe");
+        var longestCountryName = DialingCodes.FindLongestCountryName(countryCodes);
         Assert.Equal("United States of America", longestCountryName);
     }
 


### PR DESCRIPTION
Relates to https://github.com/exercism/csharp/issues/1961
Updates Longest_country_name test to add Zimbabwe to the list of countries in the dictionary to prevent algorithms that are finding the alphabetically last country instead of the longest name from passing.