### PR TITLE
Changes on Pythagorean Triplets tests and exercise description

### DIFF
--- a/exercises/practice/pythagorean-triplet/.docs/instructions.md
+++ b/exercises/practice/pythagorean-triplet/.docs/instructions.md
@@ -1,24 +1,18 @@
 # Instructions
 
-A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
+A Pythagorean triplet is a set of three natural numbers, a < b < c, for
 which,
 
 ```text
 a² + b² = c²
 ```
 
-and such that,
-
-```text
-a < b < c
-```
-
 For example,
 
-```text
+```text 
 3² + 4² = 9 + 16 = 25 = 5².
 ```
 
-Given an input integer N, find all Pythagorean triplets for which `a + b + c = N`.
+Given an input integer N, find the set of Pythagorean triplets that satisfies `a + b + c = N`.
 
-For example, with N = 1000, there is exactly one Pythagorean triplet for which `a + b + c = 1000`: `{200, 375, 425}`.
+For instance, with N = 1000, there is exactly one Pythagorean triplet for which `a + b + c = 1000`: `{a = 200, b = 375, c = 425}`.

--- a/exercises/practice/pythagorean-triplet/PythagoreanTripletTests.cs
+++ b/exercises/practice/pythagorean-triplet/PythagoreanTripletTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Xunit;
 
 public class PythagoreanTripletTests
@@ -9,7 +10,7 @@ public class PythagoreanTripletTests
         Assert.Equal(new[]
         {
             (3, 4, 5)
-        }, PythagoreanTriplet.TripletsWithSum(12));
+        }, PythagoreanTriplet.TripletsWithSum(12).OrderBy(t => t.a));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -18,7 +19,7 @@ public class PythagoreanTripletTests
         Assert.Equal(new[]
         {
             (27, 36, 45)
-        }, PythagoreanTriplet.TripletsWithSum(108));
+        }, PythagoreanTriplet.TripletsWithSum(108).OrderBy(t => t.a));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -27,7 +28,7 @@ public class PythagoreanTripletTests
         Assert.Equal(new[]
         {
             (200, 375, 425)
-        }, PythagoreanTriplet.TripletsWithSum(1000));
+        }, PythagoreanTriplet.TripletsWithSum(1000).OrderBy(t => t.a));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -43,7 +44,7 @@ public class PythagoreanTripletTests
         {
             (9, 40, 41),
             (15, 36, 39)
-        }, PythagoreanTriplet.TripletsWithSum(90));
+        }, PythagoreanTriplet.TripletsWithSum(90).OrderBy(t => t.a));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -59,7 +60,7 @@ public class PythagoreanTripletTests
             (168, 315, 357),
             (210, 280, 350),
             (240, 252, 348)
-        }, PythagoreanTriplet.TripletsWithSum(840));
+        }, PythagoreanTriplet.TripletsWithSum(840).OrderBy(t => t.a));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
@@ -72,6 +73,6 @@ public class PythagoreanTripletTests
             (5000, 12000, 13000),
             (6000, 11250, 12750),
             (7500, 10000, 12500)
-        }, PythagoreanTriplet.TripletsWithSum(30000));
+        }, PythagoreanTriplet.TripletsWithSum(30000).OrderBy(t => t.a));
     }
 }


### PR DESCRIPTION
I've recently done this exercise, I did this after completing the one it is based, on Project Euler.
I found it a bit confusing that I must return with the Pythagorean triplets in ascending order by a, therefore I changed the tests to allow the users to send their answers in any order.
Also, I think Project Euler has a shorter and a little clearer (at least to me) explanation of what the triplets are.