### PR TITLE
Fix typo in exercise reference

### DIFF
--- a/reference/exercise-concepts/bowling.md
+++ b/reference/exercise-concepts/bowling.md
@@ -5,7 +5,7 @@
 ## General
 
 - functions: used as the main entry point for the exercise
-- function arguments: input strand is passed as an arguments
+- function arguments: input strand is passed as an argument
 - return values: returning a value from a method
 - conditionals using if: conditionally execute logic using an `if` statement
 - exceptions: throw an exception in the event of invalid input

--- a/reference/exercise-concepts/gigasecond.md
+++ b/reference/exercise-concepts/gigasecond.md
@@ -6,7 +6,7 @@
 
 - functions: used as the main entry point for the exercise
 - static function: the static keyword is the modifier that makes the method static, and enables it to be called without instantiation. The static method can access the variables passed in as arguments, global, and only other static members of the class.
-- function arguments: input 'moment' is passed as an arguments
+- function arguments: input 'moment' is passed as an argument
 - return values: returning a value from a method
 - scoping: use `{` and `}` to denote scoping
 - type inference: using `var` to define the seconds

--- a/reference/exercise-concepts/protein-translation.md
+++ b/reference/exercise-concepts/protein-translation.md
@@ -9,7 +9,7 @@
 - static keyword: in order to class/methods accessible without having to instantiate the class
 - arrays: for the return value from the main function
 - functions: used as the main entry point for the exercise
-- function arguments: input strand is passed as an arguments
+- function arguments: input strand is passed as an argument
 - var keyword: in order to prevent verbose declarations `List<string> results = new List<string>()`
 - assignment: setting a variable to a specific value
 - new keyword: used to instantiate a class

--- a/reference/exercise-concepts/resistor-color.md
+++ b/reference/exercise-concepts/resistor-color.md
@@ -6,7 +6,7 @@
 
 - functions: used as the main entry point for the exercise
 - static function: the static keyword is the modifier that makes the method static, and enables it to be called without instantiation. The static method can access the variables passed in as arguments, global, and only other static members of the class.
-- function arguments: input color is passed as an arguments
+- function arguments: input color is passed as an argument
 - return values: returning a value from a method
 - exceptions: throw an exception in the event of invalid/null input
 - scoping: use `{` and `}` to denote scoping


### PR DESCRIPTION
Here we talk about passing an argument, but argument was plural.