### PR TITLE
Fix missing periods in building-telemetry headers

### DIFF
--- a/exercises/concept/building-telemetry/.docs/instructions.md
+++ b/exercises/concept/building-telemetry/.docs/instructions.md
@@ -23,7 +23,7 @@ var sp2 = car.DisplaySponsor(sponsorNum: 1);
 // => "Walker Industries"
 ```
 
-## 2 Get the car's telemetry data
+## 2. Get the car's telemetry data
 
 Implement the `RemoteControlCar.GetTelemetryData()` method.
 
@@ -44,7 +44,7 @@ car.GetTelemetryData(ref serialNum, out batteryPercentage, out distanceDrivenInM
 // => false, 4L, -1, -1
 ```
 
-## 3 Add functionality so that the telemetry system can get battery usage per meter
+## 3. Add functionality so that the telemetry system can get battery usage per meter
 
 Implement the `TelemetryClient.GetBatteryUsagePerMeter()` method.
 


### PR DESCRIPTION
The second and third tasks in the building-telemetry exercise are missing periods, which means the numbers are not correctly stripped in the Exercism UI:

![image](https://user-images.githubusercontent.com/828553/193264588-4555ea69-4a44-4bf1-a9cb-080eeada1737.png)
