### PR TITLE
Normalize practice exercise names

### DIFF
--- a/config.json
+++ b/config.json
@@ -719,7 +719,7 @@
       },
       {
         "slug": "difference-of-squares",
-        "name": "Difference Of Squares",
+        "name": "Difference of Squares",
         "uuid": "5554c048-0de3-4a85-b043-7577f429cba4",
         "practices": ["linq", "math-operators", "numbers"],
         "prerequisites": ["numbers", "math-operators"],
@@ -757,7 +757,7 @@
       },
       {
         "slug": "sum-of-multiples",
-        "name": "Sum Of Multiples",
+        "name": "Sum of Multiples",
         "uuid": "d985d4a9-1a2b-4bb1-ad08-961b8d36ee2e",
         "practices": ["enumerables", "foreach-loops", "numbers"],
         "prerequisites": [
@@ -821,7 +821,7 @@
       },
       {
         "slug": "pascals-triangle",
-        "name": "Pascals Triangle",
+        "name": "Pascal's Triangle",
         "uuid": "d5d48857-5325-45d2-9969-95a0d7bba370",
         "practices": ["yield", "enumerables"],
         "prerequisites": ["for-loops", "enumerables", "numbers"],
@@ -1003,7 +1003,7 @@
       },
       {
         "slug": "etl",
-        "name": "Etl",
+        "name": "ETL",
         "uuid": "36b7602c-44e2-4589-a97d-127a0277b2a2",
         "practices": ["linq", "dictionaries"],
         "prerequisites": ["strings", "numbers", "dictionaries"],
@@ -1185,7 +1185,7 @@
       },
       {
         "slug": "sgf-parsing",
-        "name": "Sgf Parsing",
+        "name": "SGF Parsing",
         "uuid": "da255a02-8007-41e4-8a9e-7e2cfbe81be5",
         "practices": ["dictionaries", "constructors", "properties"],
         "prerequisites": [
@@ -1278,7 +1278,7 @@
       },
       {
         "slug": "ocr-numbers",
-        "name": "Ocr Numbers",
+        "name": "OCR Numbers",
         "uuid": "2a5ddf5e-e677-4eef-b759-087d71e15986",
         "practices": ["arrays", "for-loops", "chars"],
         "prerequisites": [
@@ -1471,7 +1471,7 @@
       },
       {
         "slug": "isbn-verifier",
-        "name": "Isbn Verifier",
+        "name": "ISBN Verifier",
         "uuid": "d714b1e6-48b5-44d6-9661-d0acd3dd657b",
         "practices": ["chars", "regular-expressions"],
         "prerequisites": ["strings", "chars", "booleans"],
@@ -1508,7 +1508,7 @@
       },
       {
         "slug": "dot-dsl",
-        "name": "Dot Dsl",
+        "name": "DOT DSL",
         "uuid": "d128ec4b-190f-4726-b3e7-870be09531aa",
         "practices": ["classes", "equality"],
         "prerequisites": ["classes", "equality", "exceptions"],
@@ -1589,7 +1589,7 @@
       },
       {
         "slug": "rest-api",
-        "name": "Rest Api",
+        "name": "REST API",
         "uuid": "adaf12f9-2dea-4835-908b-dcb2a5ad92a7",
         "practices": ["optional-parameters"],
         "prerequisites": ["strings", "optional-parameters", "constructors"],
@@ -1611,7 +1611,7 @@
       },
       {
         "slug": "run-length-encoding",
-        "name": "Run Length Encoding",
+        "name": "Run-Length Encoding",
         "uuid": "4ad0d49a-e10b-4f8b-b454-623b9396d559",
         "practices": ["strings"],
         "prerequisites": [
@@ -1703,7 +1703,7 @@
       },
       {
         "slug": "diffie-hellman",
-        "name": "Diffie Hellman",
+        "name": "Diffie-Hellman",
         "uuid": "3bea029d-ccc2-48be-90f3-84bf2d5b825b",
         "practices": ["randomness", "big-integers", "math-operators"],
         "prerequisites": ["randomness", "big-integers", "math-operators"],
@@ -1734,7 +1734,7 @@
       },
       {
         "slug": "pov",
-        "name": "Pov",
+        "name": "POV",
         "uuid": "a5794706-58d2-48f7-8aab-78639d7bce77",
         "practices": ["equality", "recursion"],
         "prerequisites": ["strings", "arrays", "equality", "exceptions"],
@@ -1794,7 +1794,7 @@
       },
       {
         "slug": "rna-transcription",
-        "name": "Rna Transcription",
+        "name": "RNA Transcription",
         "uuid": "440b0b23-220d-4706-98f0-9a89fce85acb",
         "practices": ["chars", "linq", "exceptions"],
         "prerequisites": ["chars", "strings", "exceptions"],


### PR DESCRIPTION
We have added explicit exercise titles to the metadata.toml
files in problem-specifications.

This updates the exercise names to match the values
in this field.


Ref: https://github.com/exercism/exercism/issues/6579