### PR TITLE
perfect-numbers: fix duplicate uuid in approaches

### DIFF
--- a/exercises/practice/perfect-numbers/.approaches/config.json
+++ b/exercises/practice/perfect-numbers/.approaches/config.json
@@ -4,7 +4,7 @@
   },
   "approaches": [
     {
-      "uuid": "877dbf59-c01e-47c9-84ef-f54b48f78733",
+      "uuid": "525e1716-b7bf-49f3-8f76-3c8041176032",
       "slug": "if-statements",
       "title": "Use if statements",
       "blurb": "Use if statements to check for a perfect number.",


### PR DESCRIPTION
@ErikSchierboom Does this PR do what we want?

---

Commit 5c45f13c5624 added a UUID that already existed in:

https://github.com/exercism/csharp/blob/5c45f13c5624eba4e4f3a7f0a48dfae58db818a8/exercises/practice/parallel-letter-frequency/.approaches/config.json#L7

An upcoming version of `configlet` produced:

```console
$ configlet lint
[...]
A `approaches.uuid` value is `877dbf59-c01e-47c9-84ef-f54b48f78733`, which is not unique on the track:
./exercises/practice/perfect-numbers/.approaches/config.json
```

Change that UUID to a new one.