### PR TITLE
series: approaches: make config consistent with directory name

### DIFF
--- a/exercises/practice/series/.approaches/config.json
+++ b/exercises/practice/series/.approaches/config.json
@@ -5,8 +5,8 @@
   "approaches": [
     {
       "uuid": "037f3e0c-1c23-49f2-b1a5-6c0b0631a66e",
-      "slug": "sequence",
-      "title": "Sequence",
+      "slug": "for-loop",
+      "title": "For loop",
       "blurb": "Use a for-loop to iterate over the slices.",
       "authors": ["erikschierboom"]
     },

--- a/exercises/practice/series/.approaches/config.json
+++ b/exercises/practice/series/.approaches/config.json
@@ -7,7 +7,7 @@
       "uuid": "037f3e0c-1c23-49f2-b1a5-6c0b0631a66e",
       "slug": "for-loop",
       "title": "For loop",
-      "blurb": "Use a for-loop to iterate over the slices.",
+      "blurb": "Use a for loop to iterate over the slices.",
       "authors": ["erikschierboom"]
     },
     {


### PR DESCRIPTION
@ErikSchierboom do we prefer this, or to change the directory name to `sequence`?

---

Commit 270504d51f27 added approaches for the series exercise, but there was [no subdirectory](https://github.com/exercism/csharp/tree/ed2fa5440df4bbe5b4dcb1d044e7a850772d4a64/exercises/practice/series/.approaches) corresponding to the `slug` value of `sequence`.

In this situation, it is likely that an upcoming version of configlet will produce an error like:

```console
$ configlet lint
[...]
A 'slug' value is 'sequence', but there is no sibling directory with that name:
./exercises/practice/series/.approaches/config.json
```