### PR TITLE
The '??=' operator for assigning default values.

### DIFF
--- a/exercises/concept/tim-from-marketing/.docs/introduction.md
+++ b/exercises/concept/tim-from-marketing/.docs/introduction.md
@@ -65,6 +65,18 @@ string? name2 = null;
 name2 ?? "George"; // => "George"
 ```
 
+The `??=` operator allows one to assign a default value when the values is 'null':
+
+```csharp
+string? name1 = "Peter";
+name1 ??= "Alexander";
+name1 // => "Peter"
+
+string? name2 = null;
+name2 ??= "George";
+name2 // => "George" 
+```
+
 The `?.` operator allows one to call members safely on a possibly `null` value:
 
 ```csharp


### PR DESCRIPTION
There is no '??=' operator which is used to assign a default value to a variable when its actual value is 'null'. It may not be that important, but I think it wouldn't hurt to make it clear.