### PR TITLE
Solved issue #2065 (exercise weighing-machine)

### DIFF
--- a/exercises/concept/weighing-machine/WeighingMachineTests.cs
+++ b/exercises/concept/weighing-machine/WeighingMachineTests.cs
@@ -13,6 +13,14 @@ public class WeighingMachineTests
     }
 
     [Fact]
+    [Task(1)]
+    public void Get_Precision_1()
+    {
+        var wm = new WeighingMachine(precision: 1);
+        Assert.Equal(1, wm.Precision);
+    }
+
+    [Fact]
     [Task(2)]
     public void Set_weight_and_get_weight()
     {
@@ -37,6 +45,16 @@ public class WeighingMachineTests
         wm.Weight = 100.770;
         wm.TareAdjustment = 10;
         Assert.Equal("90.770 kg", wm.DisplayWeight);
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Apply_tare_adjustment_and_get_display_weight_with_precision_1()
+    {
+        var wm = new WeighingMachine(precision: 1);
+        wm.Weight = 100.770;
+        wm.TareAdjustment = 10;
+        Assert.Equal("90.8 kg", wm.DisplayWeight);
     }
 
     [Fact]

--- a/exercises/concept/weighing-machine/WeighingMachineTests.cs
+++ b/exercises/concept/weighing-machine/WeighingMachineTests.cs
@@ -2,6 +2,7 @@ using System;
 using Xunit;
 using Exercism.Tests;
 
+[UseCulture]
 public class WeighingMachineTests
 {
     [Fact]


### PR DESCRIPTION
I added two tests to test for a different precision and added a `[UseCulture]` attribute, so the tests run with InvariantCulture.
This is my first pull request, so please tell me if something is wrong.