### PR TITLE
Update HyperOptimizedTelemetryTests.cs

### DIFF
--- a/exercises/concept/hyper-optimized-telemetry/HyperOptimizedTelemetryTests.cs
+++ b/exercises/concept/hyper-optimized-telemetry/HyperOptimizedTelemetryTests.cs
@@ -210,7 +210,7 @@ public class HyperOptimizedTelemetryTests
     public void FromBuffer_upper_short()
     {
         Assert.Equal(Int16.MaxValue,
-            TelemetryBuffer.FromBuffer(new byte[] { 0xfe, 0xff, 0x7f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }));
+            TelemetryBuffer.FromBuffer(new byte[] { 0x2, 0xff, 0x7f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }));
     }
 
     [Fact]
@@ -218,7 +218,7 @@ public class HyperOptimizedTelemetryTests
     public void FromBuffer_Zero()
     {
         Assert.Equal(0,
-            TelemetryBuffer.FromBuffer(new byte[] { 0xfe, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }));
+            TelemetryBuffer.FromBuffer(new byte[] { 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }));
     }
 
     [Fact]


### PR DESCRIPTION
In theToBuffer_Zero test, the prefix byte is 0x2, which seems to be correct according to the table in the description. But for some reason, the prefix byte in FromBuffer_Zero is 0xfe. Similarly in ToBuffer_upper_short and FromBuffer_upper_short tests. I assume this is a bug and suggest a fix.