### PR TITLE
markdown format of IEquatable docs URL

### DIFF
--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,4 +1,4 @@
 # Hints
 
 This exercise requires you to implement a type-specific method for determining equality of instances.
-For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1
+For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1)


### PR DESCRIPTION
There was lack of closing parenthesis so it was not displayed correctly.