### PR TITLE
Update instructions.md

### DIFF
--- a/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
+++ b/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
@@ -45,4 +45,4 @@ TelemetryBuffer.FromBuffer(new byte[] {0xfc, 0xff, 0xff, 0xff, 0x7f, 0x0, 0x0, 0
 // => 2147483647
 ```
 
-If the prefix byte is not one of `-8`, `-4`, `-2`, `2` or `4` then `0` should be returned.
+If the prefix byte is not one of `-8`, `-4`, `-2`, `2`, `4` or `8` then `0` should be returned.


### PR DESCRIPTION
The list of valid prefix bytes in the last sentence of the instructions should include `8`.