### PR TITLE
improving test for GetEnumerable() in Simple Linked List

### DIFF
--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -64,28 +64,22 @@ public class SimpleLinkedListTests
         Assert.Equal(2, list.Next.Next.Next.Next.Value);
     }
 
-    [Theory(Skip = "Remove this Skip property to run this test")]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(10)]
-    [InlineData(100)]
-    public void Reverse(int length)
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Reverse()
     {
-        var values = Enumerable.Range(1, length).ToArray();
+        var values = Enumerable.Range(1, 5).ToArray();
         var list = new SimpleLinkedList<int>(values);
-        var reversed = list.Reverse();
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
+        var reversed = enumerable.Reverse();
         Assert.Equal(values.Reverse(), reversed);
     }
 
-    [Theory(Skip = "Remove this Skip property to run this test")]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(10)]
-    [InlineData(100)]
-    public void Roundtrip(int length)
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Roundtrip()
     {
-        var values = Enumerable.Range(1, length);
-        var listValues = new SimpleLinkedList<int>(values);
-        Assert.Equal(values, listValues);
+        var values = Enumerable.Range(1, 7);
+        var list = new SimpleLinkedList<int>(values);
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
+        Assert.Equal(values, enumerable);
     }
 }

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -41,8 +41,14 @@ public class SimpleLinkedListTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Implements_enumerable()
     {
-        var values = new SimpleLinkedList<int>(2).Add(1).Add(3);
-        Assert.Equal(new[] { 2, 1, 3 }, values);
+        var list = new SimpleLinkedList<int>(2).Add(1);
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);
+        var enumerator = enumerable.GetEnumerator();
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(2, enumerator.Current);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(1, enumerator.Current);
+        Assert.False(enumerator.MoveNext());
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -41,13 +41,15 @@ public class SimpleLinkedListTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Implements_enumerable()
     {
-        var list = new SimpleLinkedList<int>(2).Add(1);
+        var list = new SimpleLinkedList<int>(2).Add(1).Add(3);
         var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);
         var enumerator = enumerable.GetEnumerator();
         Assert.True(enumerator.MoveNext());
         Assert.Equal(2, enumerator.Current);
         Assert.True(enumerator.MoveNext());
         Assert.Equal(1, enumerator.Current);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(3, enumerator.Current);
         Assert.False(enumerator.MoveNext());
     }
 

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Collections.Generic;
 using Xunit;
 
 public class SimpleLinkedListTests

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -41,8 +41,8 @@ public class SimpleLinkedListTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Implements_enumerable()
     {
-        var values = new SimpleLinkedList<int>(2).Add(1);
-        Assert.Equal(new[] { 2, 1 }, values);
+        var values = new SimpleLinkedList<int>(2).Add(1).Add(3);
+        Assert.Equal(new[] { 2, 1, 3 }, values);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]


### PR DESCRIPTION
**Exercise:** [Simple Linked List](https://exercism.org/tracks/csharp/exercises/simple-linked-list)

**Problem:**  A number of community solutions pass the existing tests, but fail to implement `GetEnumerator()` correctly. This is because the test case is too simple to validate the implementation. 

This is an example of implementation that will pass the current test which tests only two items in the list, but will fail for any list longer than two elements.
```csharp
public SimpleLinkedList<T> Add(T value)
{
  /* this is incorrect but enough for the tests to pass */
  this.next = new SimpleLinkedList<T>(value);
  return this;
}

public IEnumerator<T> GetEnumerator() {
  var current = this;
  while(current != null) { 
    yield return (T)current.Value;
    current = current.Next;
  }
}
```

**Solution:** The proposed change improves robustness of the test suit to ensure invalid solutions are not marked as passed. 

**See:** [Forum discussion](https://forum.exercism.org/t/incorrect-solutions-passing-tests-in-c-track/4840).