### PR TITLE
fixing link in hints section of instructions

### DIFF
--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,4 +1,4 @@
 # Hints
 
 This exercise requires you to create a linked list data structure which can be iterated. This requires you to implement the IEnumerable\<T> interface.
-For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1
+For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1).


### PR DESCRIPTION
The `instructions.append.md` had a malformed link showing url and partial markdown syntax rather than a properly formatted, clickable link.

See: [forum discussion](https://forum.exercism.org/t/incorrect-solutions-passing-tests-in-c-track/4840)