### PR TITLE
Simple list with LIFO behaviour

### DIFF
--- a/exercises/practice/simple-linked-list/.meta/Example.cs
+++ b/exercises/practice/simple-linked-list/.meta/Example.cs
@@ -1,63 +1,49 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 public class SimpleLinkedList<T> : IEnumerable<T>
 {
-    public SimpleLinkedList(T value) :
-        this(new[] { value })
-    {
+    private class Node { 
+        public T Value { get; set; }
+        public Node Next { get; set; }
     }
+    
+    private Node head;
 
-    public SimpleLinkedList(IEnumerable<T> values)
+    public SimpleLinkedList() { }
+
+    public SimpleLinkedList(params T[] values)
     {
-        var array = values.ToArray();
-
-        if (array.Length == 0)
-        {
-            throw new ArgumentException("Cannot create tree from empty list");
-        }
-
-        Value = array[0];
-        Next = null;
-
-        foreach (var value in array.Skip(1))
-        {
+        foreach(var value in values) { 
             Add(value);
         }
     }
 
-    public T Value { get; }
-
-    public SimpleLinkedList<T> Next { get; private set; }
-
-    public SimpleLinkedList<T> Add(T value)
+    public void Add(T value)
     {
-        var last = this;
+        var node = new Node { Value = value, Next = this.head };
+        this.head = node;
+    }
 
-        while (last.Next != null)
-        {
-            last = last.Next;
+    public T Remove()
+    {
+        if (this.head == null) { 
+            throw new InvalidOperationException("List is empty!");
         }
-
-        last.Next = new SimpleLinkedList<T>(value);
-
-        return this;
+        var value = head.Value;
+        head = head.Next;
+        return value;
     }
 
     public IEnumerator<T> GetEnumerator()
     {
-        yield return Value;
-
-        foreach (var next in Next?.AsEnumerable() ?? Enumerable.Empty<T>())
-        {
-            yield return next;
+        var current = this.head;
+        while(current != null) { 
+            yield return current.Value;
+            current = current.Next;
         }
     }
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.cs
@@ -1,48 +1,65 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
+using Xunit;
+using System.Collections.Generic;
 
-public class SimpleLinkedList<T> : IEnumerable<T>
+public class SimpleLinkedListTests
 {
-    public SimpleLinkedList(T value)
+    [Fact]
+    public void Single_item_list_value()
     {
-        throw new NotImplementedException("You need to implement this function.");
+        var list = new SimpleLinkedList<int>(1);
+        Assert.Equal(1, list.Remove());
     }
 
-    public SimpleLinkedList(IEnumerable<T> values)
+    [Fact]
+    public void Two_item_list_first_value()
     {
-        throw new NotImplementedException("You need to implement this function.");
+        var list = new SimpleLinkedList<int>(1, 2);
+        Assert.Equal(2, list.Remove());
     }
 
-    public T Value 
-    { 
-        get
-        {
-            throw new NotImplementedException("You need to implement this function.");
-        } 
-    }
-
-    public SimpleLinkedList<T> Next
-    { 
-        get
-        {
-            throw new NotImplementedException("You need to implement this function.");
-        } 
-    }
-
-    public SimpleLinkedList<T> Add(T value)
+    [Fact]
+    public void Two_item_list_second_value()
     {
-        throw new NotImplementedException("You need to implement this function.");
+        var list = new SimpleLinkedList<int>(1, 2);
+        list.Remove();
+        Assert.Equal(1, list.Remove());
     }
 
-    public IEnumerator<T> GetEnumerator()
+    [Fact]
+    public void Multivalue_initialisation()
     {
-        throw new NotImplementedException("You need to implement this function.");
+        var values = new SimpleLinkedList<int>(2, 1, 3);
+        Assert.Equal(new[] { 3, 1, 2 }, values);
     }
 
-    IEnumerator IEnumerable.GetEnumerator()
+    [Fact]
+    public void From_enumerable()
     {
-        throw new NotImplementedException("You need to implement this function.");
+        var list = new SimpleLinkedList<int>(new[] { 11, 7, 5, 3, 2 });
+        Assert.Equal(2, list.Remove());
+        Assert.Equal(3, list.Remove());
+        Assert.Equal(5, list.Remove());
+        Assert.Equal(7, list.Remove());
+        Assert.Equal(11, list.Remove());
+    }
+
+    [Fact]
+    public void Reverse_enumerable()
+    {
+        var values = Enumerable.Range(1, 5).ToArray();
+        var list = new SimpleLinkedList<int>(values);
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
+        var reversed = enumerable.Reverse();
+        Assert.Equal(values, reversed);
+    }
+
+    [Fact]
+    public void Roundtrip()
+    {
+        var values = Enumerable.Range(1, 7);
+        var list = new SimpleLinkedList<int>(values.ToArray());
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
+        Assert.Equal(values.Reverse(), enumerable);
     }
 }

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -64,28 +64,22 @@ public class SimpleLinkedListTests
         Assert.Equal(2, list.Next.Next.Next.Next.Value);
     }
 
-    [Theory(Skip = "Remove this Skip property to run this test")]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(10)]
-    [InlineData(100)]
-    public void Reverse(int length)
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Reverse()
     {
-        var values = Enumerable.Range(1, length).ToArray();
+        var values = Enumerable.Range(1, 5).ToArray();
         var list = new SimpleLinkedList<int>(values);
-        var reversed = list.Reverse();
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
+        var reversed = enumerable.Reverse();
         Assert.Equal(values.Reverse(), reversed);
     }
 
-    [Theory(Skip = "Remove this Skip property to run this test")]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(10)]
-    [InlineData(100)]
-    public void Roundtrip(int length)
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Roundtrip()
     {
-        var values = Enumerable.Range(1, length);
-        var listValues = new SimpleLinkedList<int>(values);
-        Assert.Equal(values, listValues);
+        var values = Enumerable.Range(1, 7);
+        var list = new SimpleLinkedList<int>(values);
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
+        Assert.Equal(values, enumerable);
     }
 }

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -41,8 +41,14 @@ public class SimpleLinkedListTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Implements_enumerable()
     {
-        var values = new SimpleLinkedList<int>(2).Add(1).Add(3);
-        Assert.Equal(new[] { 2, 1, 3 }, values);
+        var list = new SimpleLinkedList<int>(2).Add(1);
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);
+        var enumerator = enumerable.GetEnumerator();
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(2, enumerator.Current);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(1, enumerator.Current);
+        Assert.False(enumerator.MoveNext());
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -41,13 +41,15 @@ public class SimpleLinkedListTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Implements_enumerable()
     {
-        var list = new SimpleLinkedList<int>(2).Add(1);
+        var list = new SimpleLinkedList<int>(2).Add(1).Add(3);
         var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);
         var enumerator = enumerable.GetEnumerator();
         Assert.True(enumerator.MoveNext());
         Assert.Equal(2, enumerator.Current);
         Assert.True(enumerator.MoveNext());
         Assert.Equal(1, enumerator.Current);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(3, enumerator.Current);
         Assert.False(enumerator.MoveNext());
     }
 

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Collections.Generic;
 using Xunit;
 
 public class SimpleLinkedListTests

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -41,8 +41,8 @@ public class SimpleLinkedListTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Implements_enumerable()
     {
-        var values = new SimpleLinkedList<int>(2).Add(1);
-        Assert.Equal(new[] { 2, 1 }, values);
+        var values = new SimpleLinkedList<int>(2).Add(1).Add(3);
+        Assert.Equal(new[] { 2, 1, 3 }, values);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]


### PR DESCRIPTION
**Discussion on the forum:** [(link)](http://forum.exercism.org/t/incorrect-solutions-passing-tests-in-c-track/4840/14).
**The problem:** The exercise [Simple Linked List (specification)](https://github.com/exercism/problem-specifications/blob/main/exercises/simple-linked-list/description.md) explains simple linked list as something with Last In First Out (LIFO) behaviour. It is at odds with what is currently [the reference implementation](https://github.com/exercism/csharp/blob/main/exercises/practice/simple-linked-list/.meta/Example.cs) in C# track, and what is required to pass [the tests](https://github.com/exercism/csharp/blob/main/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs). 

The track's expected behaviour is First In First Out (FIFO). At the same time, the implementation, while technically correct, it is less classic, especially in the context of object oriented language like C#. There is no encapsulation of the list internals which can lead to problems with references should LIFO behaviour be implemented. Imagine the below situation:

```csharp
var a = new SimpleLinkedList<int>(1,2,3);
var b = a;
/* at this stage both a and b point to node with value 3 */
a.Remove();  /* LIFO pop operation */
/* now a points to 2 but b still points to 3 */
```

That is why the common implementation (examples from other tracks: [go](https://github.com/exercism/go/blob/main/exercises/practice/simple-linked-list/.meta/example.go), [c++](https://github.com/exercism/cpp/blob/main/exercises/practice/simple-linked-list/.meta/example.h), [java](https://github.com/exercism/java/blob/main/exercises/practice/simple-linked-list/.meta/src/reference/java/SimpleLinkedList.java), ) uses a container external object encapsulating the linked list logic. As you can see in the provided ode the implementation is actually simpler than doing it without encapsulation.

**The solution:** What I'm proposing means big changes, but it bring the c# track in line with tracks from languages with similar philosophies while at the same time maintaining the .net / C# feel by maintaining `IEnumerable`, using `Add(T value)` and `Remove()` rather than `Push()` or `Pop()`. It introduces or exercises the concept without forcing solutions that have significant problems (hanging references). 

This is not finished product. I have done minimal work on the tests, only enough to make them work with the new structure again. If this is the direction we want to go in, I will work on more comprehensive test suite. 

**Open questions:**
* Is this a step we can take considering all the existing solutions would be invalidated (but future user will have better learning experience)
* Should we introduce `Count()` function in line with the problem spec?
* Is Remove the right method name? In C# typically it is used to remove a specific element from a collection. Perhaps RemoveFirst() would be an option, or perhaps building on top of `IEnumerable` we could use Next()?