### PR TITLE
Simple list with LIFO behaviour

### DIFF
--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -4,7 +4,7 @@ This exercise requires you to create a linked list data structure which can be i
 
 1. Implement the `Count` property - it should not be possible to change its value from the outside
 2. Implement the `Push(T value)` method that adds a value to the list at its head. 
-3. Implement `Pop()` method which removes and returns a value from the head. 
+3. Implement the `Pop()` method which removes and returns a value from the head. 
 4. Add a constructor to allow initialisation with a single value, or with an interable
 5. Implement the `IEnumerable<T>` interface. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1).
 6. Ensure `Reverse()` method is available. 

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,4 +1,10 @@
 # Hints
 
-This exercise requires you to create a linked list data structure which can be iterated. This requires you to implement the IEnumerable\<T> interface.
-For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1).
+This exercise requires you to create a linked list data structure which can be iterated. 
+
+1. Implement `Count` property - it should not be possible to change its value from the outside
+2. Implement `Push(T value)` method that adds a value to the list at its head. 
+3. Implement `Pop()` method which removes and returns a value from the head. 
+4. Add a constructor to allow initialisation with a single value, or with an interable
+5. Implement the `IEnumerable<T>` interface. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1).
+6. Ensure `Reverse()` method is available. 

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -3,7 +3,7 @@
 This exercise requires you to create a linked list data structure which can be iterated. 
 
 1. Implement the `Count` property - it should not be possible to change its value from the outside
-2. Implement `Push(T value)` method that adds a value to the list at its head. 
+2. Implement the `Push(T value)` method that adds a value to the list at its head. 
 3. Implement `Pop()` method which removes and returns a value from the head. 
 4. Add a constructor to allow initialisation with a single value, or with an interable
 5. Implement the `IEnumerable<T>` interface. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1).

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-# Hints
+# Instruction append
 
 This exercise requires you to create a linked list data structure which can be iterated. 
 

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -2,7 +2,7 @@
 
 This exercise requires you to create a linked list data structure which can be iterated. 
 
-1. Implement `Count` property - it should not be possible to change its value from the outside
+1. Implement the `Count` property - it should not be possible to change its value from the outside
 2. Implement `Push(T value)` method that adds a value to the list at its head. 
 3. Implement `Pop()` method which removes and returns a value from the head. 
 4. Add a constructor to allow initialisation with a single value, or with an interable

--- a/exercises/practice/simple-linked-list/.meta/Example.cs
+++ b/exercises/practice/simple-linked-list/.meta/Example.cs
@@ -1,63 +1,49 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 public class SimpleLinkedList<T> : IEnumerable<T>
 {
-    public SimpleLinkedList(T value) :
-        this(new[] { value })
-    {
+    private class Node { 
+        public T Value { get; set; }
+        public Node Next { get; set; }
     }
+    
+    private Node head;
 
-    public SimpleLinkedList(IEnumerable<T> values)
+    public SimpleLinkedList() { }
+
+    public SimpleLinkedList(params T[] values)
     {
-        var array = values.ToArray();
-
-        if (array.Length == 0)
-        {
-            throw new ArgumentException("Cannot create tree from empty list");
-        }
-
-        Value = array[0];
-        Next = null;
-
-        foreach (var value in array.Skip(1))
-        {
+        foreach(var value in values) { 
             Add(value);
         }
     }
 
-    public T Value { get; }
-
-    public SimpleLinkedList<T> Next { get; private set; }
-
-    public SimpleLinkedList<T> Add(T value)
+    public void Add(T value)
     {
-        var last = this;
+        var node = new Node { Value = value, Next = this.head };
+        this.head = node;
+    }
 
-        while (last.Next != null)
-        {
-            last = last.Next;
+    public T Remove()
+    {
+        if (this.head == null) { 
+            throw new InvalidOperationException("List is empty!");
         }
-
-        last.Next = new SimpleLinkedList<T>(value);
-
-        return this;
+        var value = head.Value;
+        head = head.Next;
+        return value;
     }
 
     public IEnumerator<T> GetEnumerator()
     {
-        yield return Value;
-
-        foreach (var next in Next?.AsEnumerable() ?? Enumerable.Empty<T>())
-        {
-            yield return next;
+        var current = this.head;
+        while(current != null) { 
+            yield return current.Value;
+            current = current.Next;
         }
     }
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/exercises/practice/simple-linked-list/.meta/Example.cs
+++ b/exercises/practice/simple-linked-list/.meta/Example.cs
@@ -21,7 +21,7 @@ public class SimpleLinkedList<T> : IEnumerable<T>
     }
 
     public int Count { get; private set; } = 0;
-
+    
     public void Push(T value)
     {
         var node = new Node { Value = value, Next = this.head };

--- a/exercises/practice/simple-linked-list/.meta/Example.cs
+++ b/exercises/practice/simple-linked-list/.meta/Example.cs
@@ -20,10 +20,13 @@ public class SimpleLinkedList<T> : IEnumerable<T>
         }
     }
 
+    public int Count { get; private set; } = 0;
+
     public void Push(T value)
     {
         var node = new Node { Value = value, Next = this.head };
         this.head = node;
+        this.Count++;
     }
 
     public T Pop()
@@ -33,6 +36,7 @@ public class SimpleLinkedList<T> : IEnumerable<T>
         }
         var value = head.Value;
         head = head.Next;
+        this.Count--;
         return value;
     }
 

--- a/exercises/practice/simple-linked-list/.meta/Example.cs
+++ b/exercises/practice/simple-linked-list/.meta/Example.cs
@@ -16,17 +16,17 @@ public class SimpleLinkedList<T> : IEnumerable<T>
     public SimpleLinkedList(params T[] values)
     {
         foreach(var value in values) { 
-            Add(value);
+            Push(value);
         }
     }
 
-    public void Add(T value)
+    public void Push(T value)
     {
         var node = new Node { Value = value, Next = this.head };
         this.head = node;
     }
 
-    public T Remove()
+    public T Pop()
     {
         if (this.head == null) { 
             throw new InvalidOperationException("List is empty!");

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -6,7 +6,8 @@
     "bressain",
     "j2jensen",
     "robkeim",
-    "wolf99"
+    "wolf99",
+    "michalporeba"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.cs
@@ -2,52 +2,15 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-public class SimpleLinkedList<T> : IEnumerable<T>
+public class SimpleLinkedList<T>
 {
-    private class Node { 
-        public T Value { get; set; }
-        public Node Next { get; set; }
-    }
-    
-    private Node head;
-
-    public SimpleLinkedList() { }
-
-    public SimpleLinkedList(params T[] values)
-    {
-        foreach(var value in values) { 
-            Push(value);
-        }
-    }
-
-    public int Count { get; private set; } = 0;
-    
     public void Push(T value)
     {
-        var node = new Node { Value = value, Next = this.head };
-        this.head = node;
-        this.Count++;
+        throw new NotImplementedException();
     }
 
     public T Pop()
     {
-        if (this.head == null) { 
-            throw new InvalidOperationException("List is empty!");
-        }
-        var value = head.Value;
-        head = head.Next;
-        this.Count--;
-        return value;
+        throw new NotImplementedException();
     }
-
-    public IEnumerator<T> GetEnumerator()
-    {
-        var current = this.head;
-        while(current != null) { 
-            yield return current.Value;
-            current = current.Next;
-        }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.cs
@@ -21,7 +21,7 @@ public class SimpleLinkedList<T> : IEnumerable<T>
     }
 
     public int Count { get; private set; } = 0;
-
+    
     public void Push(T value)
     {
         var node = new Node { Value = value, Next = this.head };

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.cs
@@ -1,48 +1,49 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 public class SimpleLinkedList<T> : IEnumerable<T>
 {
-    public SimpleLinkedList(T value)
+    private class Node { 
+        public T Value { get; set; }
+        public Node Next { get; set; }
+    }
+    
+    private Node head;
+
+    public SimpleLinkedList() { }
+
+    public SimpleLinkedList(params T[] values)
     {
-        throw new NotImplementedException("You need to implement this function.");
+        foreach(var value in values) { 
+            Push(value);
+        }
     }
 
-    public SimpleLinkedList(IEnumerable<T> values)
+    public void Push(T value)
     {
-        throw new NotImplementedException("You need to implement this function.");
+        var node = new Node { Value = value, Next = this.head };
+        this.head = node;
     }
 
-    public T Value 
-    { 
-        get
-        {
-            throw new NotImplementedException("You need to implement this function.");
-        } 
-    }
-
-    public SimpleLinkedList<T> Next
-    { 
-        get
-        {
-            throw new NotImplementedException("You need to implement this function.");
-        } 
-    }
-
-    public SimpleLinkedList<T> Add(T value)
+    public T Pop()
     {
-        throw new NotImplementedException("You need to implement this function.");
+        if (this.head == null) { 
+            throw new InvalidOperationException("List is empty!");
+        }
+        var value = head.Value;
+        head = head.Next;
+        return value;
     }
 
     public IEnumerator<T> GetEnumerator()
     {
-        throw new NotImplementedException("You need to implement this function.");
+        var current = this.head;
+        while(current != null) { 
+            yield return current.Value;
+            current = current.Next;
+        }
     }
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        throw new NotImplementedException("You need to implement this function.");
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.cs
@@ -20,10 +20,13 @@ public class SimpleLinkedList<T> : IEnumerable<T>
         }
     }
 
+    public int Count { get; private set; } = 0;
+
     public void Push(T value)
     {
         var node = new Node { Value = value, Next = this.head };
         this.head = node;
+        this.Count++;
     }
 
     public T Pop()
@@ -33,6 +36,7 @@ public class SimpleLinkedList<T> : IEnumerable<T>
         }
         var value = head.Value;
         head = head.Next;
+        this.Count--;
         return value;
     }
 

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 
 public class SimpleLinkedList<T>
 {
+    public int Count => throw new NotImplementedException("You need to implement this function.");
+    
     public void Push(T value)
     {
         throw new NotImplementedException("You need to implement this function.");

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.cs
@@ -6,11 +6,11 @@ public class SimpleLinkedList<T>
 {
     public void Push(T value)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("You need to implement this function.");
     }
 
     public T Pop()
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("You need to implement this function.");
     }
 }

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 public class SimpleLinkedListTests
 {
-    [Fact(Skip = "Remove this Skip property to run this test")] 
+    [Fact] 
     public void Empty_list_has_no_elements()
     {
         var list = new SimpleLinkedList<int>();

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -69,7 +69,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Singlevalue_initialisation()
+    public void Single_value_initialisation()
     {
         var list = CreateSimpleLinkedList(7);
         Assert.Equal(1, list.Count);

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -1,21 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using Exercism.Tests;
 using Xunit;
 
 public class SimpleLinkedListTests
 {
-    [Fact] 
-    [Task(1)]
+    [Fact(Skip = "Remove this Skip property to run this test")] 
     public void Empty_list_has_no_elements()
     {
         var list = new SimpleLinkedList<int>();
         Assert.Equal(0, list.Count);
     }
 
-    [Fact]
-    [Task(1)]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     public void Count_cannot_be_changed_from_the_outside()
     {
         var count = typeof(SimpleLinkedList<>).GetProperty("Count");
@@ -24,7 +21,6 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    [Task(2)]
     public void Pushing_elements_to_the_list_increases_the_count()
     {
         var list = new SimpleLinkedList<int>();
@@ -35,7 +31,6 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    [Task(3)]
     public void Popping_elements_from_the_list_decreases_the_count()
     {
         var list = new SimpleLinkedList<int>();
@@ -47,7 +42,6 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    [Task(4)]
     public void Elements_pop_back_in_lifo_order()
     {
         var list = new SimpleLinkedList<int>();
@@ -75,7 +69,6 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    [Task(5)]
     public void Singlevalue_initialisation()
     {
         var list = CreateSimpleLinkedList(7);
@@ -84,7 +77,6 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    [Task(5)]
     public void Multivalue_initialisation()
     {
         var list = CreateSimpleLinkedList(2, 1, 3);
@@ -94,7 +86,6 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    [Task(5)]
     public void From_enumerable()
     {
         var list = CreateSimpleLinkedList(new[] { 11, 7, 5, 3, 2 });
@@ -106,7 +97,6 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    [Task(6)]
     public void Reverse_enumerable()
     {
         var values = Enumerable.Range(1, 5).ToArray();
@@ -117,7 +107,6 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    [Task(6)]
     public void Roundtrip()
     {
         var values = Enumerable.Range(1, 7);

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -14,6 +14,15 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(1)]
+    public void Count_cannot_be_changed_from_the_outside()
+    {
+        var count = typeof(SimpleLinkedList<>).GetProperty("Count");
+        Assert.True(count?.GetGetMethod().IsPublic);
+        Assert.False(count?.GetSetMethod(true).IsPublic);
+    }
+
+    [Fact]
     [Task(2)]
     public void Pushing_elements_to_the_list_increases_the_count()
     {

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -1,10 +1,12 @@
 using System.Linq;
 using System.Collections.Generic;
+using Exercism.Tests;
 using Xunit;
 
 public class SimpleLinkedListTests
 {
     [Fact] 
+    [Task(1)]
     public void Empty_list_has_no_elements()
     {
         var list = new SimpleLinkedList<int>();
@@ -12,6 +14,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(2)]
     public void Pushing_elements_to_the_list_increases_the_count()
     {
         var list = new SimpleLinkedList<int>();
@@ -22,6 +25,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(3)]
     public void Popping_elements_from_the_list_decreases_the_count()
     {
         var list = new SimpleLinkedList<int>();
@@ -33,6 +37,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(4)]
     public void Elements_pop_back_in_lifo_order()
     {
         var list = new SimpleLinkedList<int>();
@@ -45,6 +50,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(5)]
     public void Singlevalue_initialisation()
     {
         var list = new SimpleLinkedList<int>(7);
@@ -53,6 +59,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(5)]
     public void Multivalue_initialisation()
     {
         var list = new SimpleLinkedList<int>(2, 1, 3);
@@ -62,6 +69,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(5)]
     public void From_enumerable()
     {
         var list = new SimpleLinkedList<int>(new[] { 11, 7, 5, 3, 2 });
@@ -73,6 +81,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(6)]
     public void Reverse_enumerable()
     {
         var values = Enumerable.Range(1, 5).ToArray();
@@ -83,6 +92,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact]
+    [Task(6)]
     public void Roundtrip()
     {
         var values = Enumerable.Range(1, 7);

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Xunit;
+using System.Collections.Generic;
 
 public class SimpleLinkedListTests
 {
@@ -7,77 +8,58 @@ public class SimpleLinkedListTests
     public void Single_item_list_value()
     {
         var list = new SimpleLinkedList<int>(1);
-        Assert.Equal(1, list.Value);
+        Assert.Equal(1, list.Remove());
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Single_item_list_has_no_next_item()
-    {
-        var list = new SimpleLinkedList<int>(1);
-        Assert.Null(list.Next);
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
+    [Fact]
     public void Two_item_list_first_value()
     {
-        var list = new SimpleLinkedList<int>(2).Add(1);
-        Assert.Equal(2, list.Value);
+        var list = new SimpleLinkedList<int>(1, 2);
+        Assert.Equal(2, list.Remove());
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
+    [Fact]
     public void Two_item_list_second_value()
     {
-        var list = new SimpleLinkedList<int>(2).Add(1);
-        Assert.Equal(1, list.Next.Value);
+        var list = new SimpleLinkedList<int>(1, 2);
+        list.Remove();
+        Assert.Equal(1, list.Remove());
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Two_item_list_second_item_has_no_next()
+    [Fact]
+    public void Multivalue_initialisation()
     {
-        var list = new SimpleLinkedList<int>(2).Add(1);
-        Assert.Null(list.Next.Next);
+        var values = new SimpleLinkedList<int>(2, 1, 3);
+        Assert.Equal(new[] { 3, 1, 2 }, values);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Implements_enumerable()
-    {
-        var values = new SimpleLinkedList<int>(2).Add(1);
-        Assert.Equal(new[] { 2, 1 }, values);
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
+    [Fact]
     public void From_enumerable()
     {
         var list = new SimpleLinkedList<int>(new[] { 11, 7, 5, 3, 2 });
-        Assert.Equal(11, list.Value);
-        Assert.Equal(7, list.Next.Value);
-        Assert.Equal(5, list.Next.Next.Value);
-        Assert.Equal(3, list.Next.Next.Next.Value);
-        Assert.Equal(2, list.Next.Next.Next.Next.Value);
+        Assert.Equal(2, list.Remove());
+        Assert.Equal(3, list.Remove());
+        Assert.Equal(5, list.Remove());
+        Assert.Equal(7, list.Remove());
+        Assert.Equal(11, list.Remove());
     }
 
-    [Theory(Skip = "Remove this Skip property to run this test")]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(10)]
-    [InlineData(100)]
-    public void Reverse(int length)
+    [Fact]
+    public void Reverse_enumerable()
     {
-        var values = Enumerable.Range(1, length).ToArray();
+        var values = Enumerable.Range(1, 5).ToArray();
         var list = new SimpleLinkedList<int>(values);
-        var reversed = list.Reverse();
-        Assert.Equal(values.Reverse(), reversed);
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
+        var reversed = enumerable.Reverse();
+        Assert.Equal(values, reversed);
     }
 
-    [Theory(Skip = "Remove this Skip property to run this test")]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(10)]
-    [InlineData(100)]
-    public void Roundtrip(int length)
+    [Fact]
+    public void Roundtrip()
     {
-        var values = Enumerable.Range(1, length);
-        var listValues = new SimpleLinkedList<int>(values);
-        Assert.Equal(values, listValues);
+        var values = Enumerable.Range(1, 7);
+        var list = new SimpleLinkedList<int>(values.ToArray());
+        var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
+        Assert.Equal(values.Reverse(), enumerable);
     }
 }

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -77,7 +77,7 @@ public class SimpleLinkedListTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Multivalue_initialisation()
+    public void Multi_value_initialisation()
     {
         var list = CreateSimpleLinkedList(2, 1, 3);
         Assert.Equal(3, list.Pop());

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -4,33 +4,61 @@ using Xunit;
 
 public class SimpleLinkedListTests
 {
-    [Fact]
-    public void Single_item_list_value()
+    [Fact] 
+    public void Empty_list_has_no_elements()
     {
-        var list = new SimpleLinkedList<int>(1);
-        Assert.Equal(1, list.Pop());
+        var list = new SimpleLinkedList<int>();
+        Assert.Equal(0, list.Count);
     }
 
     [Fact]
-    public void Two_item_list_first_value()
+    public void Pushing_elements_to_the_list_increases_the_count()
     {
-        var list = new SimpleLinkedList<int>(1, 2);
-        Assert.Equal(2, list.Pop());
+        var list = new SimpleLinkedList<int>();
+        list.Push(0);
+        Assert.Equal(1, list.Count);
+        list.Push(0);
+        Assert.Equal(2, list.Count);
     }
 
     [Fact]
-    public void Two_item_list_second_value()
+    public void Popping_elements_from_the_list_decreases_the_count()
     {
-        var list = new SimpleLinkedList<int>(1, 2);
+        var list = new SimpleLinkedList<int>();
+        list.Push(0);
+        list.Push(0);
+        Assert.Equal(2, list.Count);
         list.Pop();
-        Assert.Equal(1, list.Pop());
+        Assert.Equal(1, list.Count);
+    }
+
+    [Fact]
+    public void Elements_pop_back_in_lifo_order()
+    {
+        var list = new SimpleLinkedList<int>();
+        list.Push(3);
+        list.Push(5);
+        Assert.Equal(5, list.Pop());
+        list.Push(7);        
+        Assert.Equal(7, list.Pop());
+        Assert.Equal(3, list.Pop());
+    }
+
+    [Fact]
+    public void Singlevalue_initialisation()
+    {
+        var list = new SimpleLinkedList<int>(7);
+        Assert.Equal(1, list.Count);
+        Assert.Equal(7, list.Pop());
     }
 
     [Fact]
     public void Multivalue_initialisation()
     {
-        var values = new SimpleLinkedList<int>(2, 1, 3);
-        Assert.Equal(new[] { 3, 1, 2 }, values);
+        var list = new SimpleLinkedList<int>(2, 1, 3);
+        Assert.Equal(3, list.Pop());
+        Assert.Equal(1, list.Pop());
+        Assert.Equal(2, list.Pop());
     }
 
     [Fact]

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -61,7 +61,7 @@ public class SimpleLinkedListTests
 			?? CreateSimpleLinkedList(new int[] { value });
     }
 	
-	private static SimpleLinkedList<int> CreateSimpleLinkedList(params int[] values)
+    private static SimpleLinkedList<int> CreateSimpleLinkedList(params int[] values)
     {
         var type = typeof(SimpleLinkedList<>).MakeGenericType(typeof(int));
 		var constructor = type.GetConstructor(new Type[]{typeof(int[])});	

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -23,7 +23,7 @@ public class SimpleLinkedListTests
         Assert.False(count?.GetSetMethod(true).IsPublic);
     }
 
-    [Fact]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     [Task(2)]
     public void Pushing_elements_to_the_list_increases_the_count()
     {
@@ -34,7 +34,7 @@ public class SimpleLinkedListTests
         Assert.Equal(2, list.Count);
     }
 
-    [Fact]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     [Task(3)]
     public void Popping_elements_from_the_list_decreases_the_count()
     {
@@ -46,7 +46,7 @@ public class SimpleLinkedListTests
         Assert.Equal(1, list.Count);
     }
 
-    [Fact]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     [Task(4)]
     public void Elements_pop_back_in_lifo_order()
     {
@@ -74,7 +74,7 @@ public class SimpleLinkedListTests
 		return (SimpleLinkedList<int>)constructor.Invoke(new object[]{ values });
     }
 
-    [Fact]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     [Task(5)]
     public void Singlevalue_initialisation()
     {
@@ -83,7 +83,7 @@ public class SimpleLinkedListTests
         Assert.Equal(7, list.Pop());
     }
 
-    [Fact]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     [Task(5)]
     public void Multivalue_initialisation()
     {
@@ -93,7 +93,7 @@ public class SimpleLinkedListTests
         Assert.Equal(2, list.Pop());
     }
 
-    [Fact]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     [Task(5)]
     public void From_enumerable()
     {
@@ -105,7 +105,7 @@ public class SimpleLinkedListTests
         Assert.Equal(11, list.Pop());
     }
 
-    [Fact]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     [Task(6)]
     public void Reverse_enumerable()
     {
@@ -116,7 +116,7 @@ public class SimpleLinkedListTests
         Assert.Equal(values, reversed);
     }
 
-    [Fact]
+    [Fact(Skip = "Remove this Skip property to run this test")]
     [Task(6)]
     public void Roundtrip()
     {

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
-using Xunit;
 using System.Collections.Generic;
+using Xunit;
 
 public class SimpleLinkedListTests
 {
@@ -8,22 +8,22 @@ public class SimpleLinkedListTests
     public void Single_item_list_value()
     {
         var list = new SimpleLinkedList<int>(1);
-        Assert.Equal(1, list.Remove());
+        Assert.Equal(1, list.Pop());
     }
 
     [Fact]
     public void Two_item_list_first_value()
     {
         var list = new SimpleLinkedList<int>(1, 2);
-        Assert.Equal(2, list.Remove());
+        Assert.Equal(2, list.Pop());
     }
 
     [Fact]
     public void Two_item_list_second_value()
     {
         var list = new SimpleLinkedList<int>(1, 2);
-        list.Remove();
-        Assert.Equal(1, list.Remove());
+        list.Pop();
+        Assert.Equal(1, list.Pop());
     }
 
     [Fact]
@@ -37,11 +37,11 @@ public class SimpleLinkedListTests
     public void From_enumerable()
     {
         var list = new SimpleLinkedList<int>(new[] { 11, 7, 5, 3, 2 });
-        Assert.Equal(2, list.Remove());
-        Assert.Equal(3, list.Remove());
-        Assert.Equal(5, list.Remove());
-        Assert.Equal(7, list.Remove());
-        Assert.Equal(11, list.Remove());
+        Assert.Equal(2, list.Pop());
+        Assert.Equal(3, list.Pop());
+        Assert.Equal(5, list.Pop());
+        Assert.Equal(7, list.Pop());
+        Assert.Equal(11, list.Pop());
     }
 
     [Fact]

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using Exercism.Tests;
@@ -58,11 +59,26 @@ public class SimpleLinkedListTests
         Assert.Equal(3, list.Pop());
     }
 
+    private static SimpleLinkedList<int> CreateSimpleLinkedList(int value)
+    {
+        var type = typeof(SimpleLinkedList<>).MakeGenericType(typeof(int));
+		var constructor = type.GetConstructor(new Type[] { typeof(int) });
+		return (SimpleLinkedList<int>)constructor?.Invoke(new object[]{ value })
+			?? CreateSimpleLinkedList(new int[] { value });
+    }
+	
+	private static SimpleLinkedList<int> CreateSimpleLinkedList(params int[] values)
+    {
+        var type = typeof(SimpleLinkedList<>).MakeGenericType(typeof(int));
+		var constructor = type.GetConstructor(new Type[]{typeof(int[])});	
+		return (SimpleLinkedList<int>)constructor.Invoke(new object[]{ values });
+    }
+
     [Fact]
     [Task(5)]
     public void Singlevalue_initialisation()
     {
-        var list = new SimpleLinkedList<int>(7);
+        var list = CreateSimpleLinkedList(7);
         Assert.Equal(1, list.Count);
         Assert.Equal(7, list.Pop());
     }
@@ -71,7 +87,7 @@ public class SimpleLinkedListTests
     [Task(5)]
     public void Multivalue_initialisation()
     {
-        var list = new SimpleLinkedList<int>(2, 1, 3);
+        var list = CreateSimpleLinkedList(2, 1, 3);
         Assert.Equal(3, list.Pop());
         Assert.Equal(1, list.Pop());
         Assert.Equal(2, list.Pop());
@@ -81,7 +97,7 @@ public class SimpleLinkedListTests
     [Task(5)]
     public void From_enumerable()
     {
-        var list = new SimpleLinkedList<int>(new[] { 11, 7, 5, 3, 2 });
+        var list = CreateSimpleLinkedList(new[] { 11, 7, 5, 3, 2 });
         Assert.Equal(2, list.Pop());
         Assert.Equal(3, list.Pop());
         Assert.Equal(5, list.Pop());
@@ -94,7 +110,7 @@ public class SimpleLinkedListTests
     public void Reverse_enumerable()
     {
         var values = Enumerable.Range(1, 5).ToArray();
-        var list = new SimpleLinkedList<int>(values);
+        var list = CreateSimpleLinkedList(values);
         var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
         var reversed = enumerable.Reverse();
         Assert.Equal(values, reversed);
@@ -105,7 +121,7 @@ public class SimpleLinkedListTests
     public void Roundtrip()
     {
         var values = Enumerable.Range(1, 7);
-        var list = new SimpleLinkedList<int>(values.ToArray());
+        var list = CreateSimpleLinkedList(values.ToArray());
         var enumerable = Assert.IsAssignableFrom<IEnumerable<int>>(list);    
         Assert.Equal(values.Reverse(), enumerable);
     }


### PR DESCRIPTION
**Discussion on the forum:** [(link)](http://forum.exercism.org/t/incorrect-solutions-passing-tests-in-c-track/4840/14).
**The problem:** The exercise [Simple Linked List (specification)](https://github.com/exercism/problem-specifications/blob/main/exercises/simple-linked-list/description.md) explains simple linked list as something with Last In First Out (LIFO) behaviour. It is at odds with what is currently [the reference implementation](https://github.com/exercism/csharp/blob/main/exercises/practice/simple-linked-list/.meta/Example.cs) in C# track, and what is required to pass [the tests](https://github.com/exercism/csharp/blob/main/exercises/practice/simple-linked-list/SimpleLinkedListTests.cs). 

The track's expected behaviour is First In First Out (FIFO). At the same time, the implementation, while technically correct, it is less classic, especially in the context of object oriented language like C#. There is no encapsulation of the list internals which can lead to problems with references should LIFO behaviour be implemented. Imagine the below situation:

```csharp
var a = new SimpleLinkedList<int>(1,2,3);
var b = a;
/* at this stage both a and b point to node with value 3 */
a = a.Remove();  /* LIFO pop operation */
/* now a points to 2 but b still points to 3 */
```

That is why the common implementation (examples from other tracks: [go](https://github.com/exercism/go/blob/main/exercises/practice/simple-linked-list/.meta/example.go), [c++](https://github.com/exercism/cpp/blob/main/exercises/practice/simple-linked-list/.meta/example.h), [java](https://github.com/exercism/java/blob/main/exercises/practice/simple-linked-list/.meta/src/reference/java/SimpleLinkedList.java)) uses a container external object encapsulating the linked list logic. As you can see in the provided ode the implementation is actually simpler than doing it without encapsulation.

**The solution:** What I'm proposing means big changes, but it bring the c# track in line with tracks from languages with similar philosophies while at the same time maintaining the .net / C# feel by maintaining `IEnumerable`, using `Add(T value)` and `Remove()` rather than `Push()` or `Pop()`. It introduces or exercises the concept without forcing solutions that have significant problems (hanging references). 

This is not finished product. I have done minimal work on the tests, only enough to make them work with the new structure again. If this is the direction we want to go in, I will work on more comprehensive test suite. 

**Open questions:**
* Is this a step we can take considering all the existing solutions would be invalidated (but future user will have better learning experience)
* Should we introduce `Count()` function in line with the problem spec?
* Is Remove the right method name? In C# typically it is used to remove a specific element from a collection. Perhaps RemoveFirst() would be an option, ~~or perhaps building on top of `IEnumerable` we could use Next()?~~ *(This would not work as iterating over the list would empty it!)*