### PR TITLE
better clear() implementation, fixes #2109

### DIFF
--- a/exercises/practice/circular-buffer/CircularBufferTests.cs
+++ b/exercises/practice/circular-buffer/CircularBufferTests.cs
@@ -70,7 +70,7 @@ public class CircularBufferTests
     [Fact(Skip = "Remove this Skip property to run this test")]
     public void Items_cleared_out_of_buffer_cant_be_read()
     {
-        var buffer = new CircularBuffer<int>(capacity: 1);
+        var buffer = new CircularBuffer<int>(capacity: 3);
         buffer.Write(1);
         buffer.Write(2);
         buffer.Clear();

--- a/exercises/practice/circular-buffer/CircularBufferTests.cs
+++ b/exercises/practice/circular-buffer/CircularBufferTests.cs
@@ -72,6 +72,7 @@ public class CircularBufferTests
     {
         var buffer = new CircularBuffer<int>(capacity: 1);
         buffer.Write(1);
+        buffer.Write(2);
         buffer.Clear();
         Assert.Throws<InvalidOperationException>(() => buffer.Read());
     }


### PR DESCRIPTION
Problem: In the circular buffer the Clear method tests pass through implementations that remove a single item form the buffer while the typical implementation of Clear in .net is to remove all elements from a collection.

Solution: improve the test

Other things to consider: Similarly to simple linked list exercise it might be worth comparing this exercise with other languages and .net standards to provide better learning experience.

(This issue is just a reminder. I will raise a forum thread once I have actioned a few other threads I have already started).