### PR TITLE
Configlet beta11 has a peculiar test for formatting

### DIFF
--- a/.github/workflows/pssanalyzer.yml
+++ b/.github/workflows/pssanalyzer.yml
@@ -13,5 +13,5 @@ jobs:
   analyze:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - run: pwsh ./powershell-script-analyzer.ps1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a
         with:
           dotnet-version: "7.0.100"

--- a/exercises/concept/high-school-sweethearts/.docs/instructions.md
+++ b/exercises/concept/high-school-sweethearts/.docs/instructions.md
@@ -4,7 +4,8 @@ In this exercise, you are going to help high school sweethearts profess their lo
 
 ## 1. Display the couple's name separated by a heart
 
-Please implement the static `HighSchoolSweethearts.DisplaySingleLine()` method to take 2 names and display them separated by a heart centered in a 61 character line.
+Please implement the static `HighSchoolSweethearts.DisplaySingleLine()` method to take two names and display them separated by a heart.
+The formatted text should be 61 characters wide, with the heart in the center of the string.
 
 All names are guaranteed to fit well within the width of the line.
 

--- a/exercises/practice/bank-account/.approaches/config.json
+++ b/exercises/practice/bank-account/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "lock-statement",
       "title": "Use a lock statement",
       "blurb": "Use a lock statement to prevent concurrent balance updates.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "b6d6ab21-82bb-4285-a840-5bc209ec9524",
       "slug": "mutex",
       "title": "Use a Mutex",
       "blurb": "Use a Mutex to prevent concurrent balance updates.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/bob/.approaches/config.json
+++ b/exercises/practice/bob/.approaches/config.json
@@ -1,7 +1,11 @@
 {
   "introduction": {
-    "authors": ["bobahop"],
-    "contributors": ["erikschierboom"]
+    "authors": [
+      "bobahop"
+    ],
+    "contributors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -9,28 +13,36 @@
       "slug": "if",
       "title": "If",
       "blurb": "Use if statements to return the answer.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "567f04d3-368e-4874-9fde-07ce1f7b199f",
       "slug": "switch-on-tuple",
       "title": "Switch on a tuple",
       "blurb": "Use switch on a tuple to return the answer.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "8b31fcf5-229e-474a-aaf5-b00dc5d977c5",
       "slug": "answer-array",
       "title": "Answer array",
       "blurb": "Index into an array to return the answer.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "4fb2cc1b-197f-458f-80fb-cdc6746ff0d6",
       "slug": "regular-expressions",
       "title": "Regular expressions",
       "blurb": "Use regular expressions to return the answer.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/bob/.articles/config.json
+++ b/exercises/practice/bob/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant approach for Bob's response.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/collatz-conjecture/.approaches/config.json
+++ b/exercises/practice/collatz-conjecture/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,21 +10,27 @@
       "slug": "while-loop",
       "title": "while loop",
       "blurb": "Use a while loop to find the number of steps.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "8c7199ed-d74d-4e3d-b9d0-5f8595597528",
       "slug": "recursion",
       "title": "Recursion",
       "blurb": "Use recursion to find the number of steps.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "4f91abfb-4c83-4e6d-84bc-bd08211d34d6",
       "slug": "sequence",
       "title": "Sequence",
       "blurb": "Use a (lazy) sequence and count its elements to find the number of steps.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/darts/.approaches/config.json
+++ b/exercises/practice/darts/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "if-statements",
       "title": "if statements",
       "blurb": "Use if statements.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "5f0878ae-8faf-4db9-b3d5-775e2d9bff37",
       "slug": "switch-expression",
       "title": "switch expression",
       "blurb": "Use a switch expression.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/difference-of-squares/.approaches/config.json
+++ b/exercises/practice/difference-of-squares/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,21 +10,27 @@
       "slug": "linq",
       "title": "Use LINQ",
       "blurb": "Use LINQ to calculate the sums.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "a6118dd7-26d5-4576-919f-11a584beeef8",
       "slug": "for-statement",
       "title": "Use a for statement",
       "blurb": "Use a for statement to calculate the sums.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "bdcb02d2-1a34-4a52-a80c-ca94907ba721",
       "slug": "math",
       "title": "Use math",
       "blurb": "Use math to calculate the sums.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/diffie-hellman/.approaches/config.json
+++ b/exercises/practice/diffie-hellman/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,7 +10,9 @@
       "slug": "big-integer",
       "title": "Use BigInteger",
       "blurb": "Use the BigInteger class to easily implement diffie-hellman.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/gigasecond/.approaches/config.json
+++ b/exercises/practice/gigasecond/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "add-seconds",
       "title": "Use AddSeconds",
       "blurb": "Add a gigasecond via AddSeconds().",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "f241c90d-6cba-49ad-9e8e-59cac73ca6e5",
       "slug": "time-span",
       "title": "Use a TimeSpan",
       "blurb": "Add a gigasecond via a TimeSpan.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/grade-school/.approaches/config.json
+++ b/exercises/practice/grade-school/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,7 +10,9 @@
       "slug": "sorted-collections",
       "title": "Use specialized sorted collections",
       "blurb": "Use specialized sorted collections for automatic sorting.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/grains/.approaches/config.json
+++ b/exercises/practice/grains/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["bobahop"]
+    "authors": [
+      "bobahop"
+    ]
   },
   "approaches": [
     {
@@ -8,21 +10,27 @@
       "slug": "pow",
       "title": "Pow",
       "blurb": "Use Math.Pow to raise 2 by a specified power.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "71f823dc-c667-46ee-875f-6e73918d0336",
       "slug": "bit-shifting",
       "title": "Bit-shifting",
       "blurb": "Use bit-shifting to raise 2 by a specified power.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "076f430a-3779-4249-a190-b75110da455b",
       "slug": "max-value",
       "title": "Max value",
       "blurb": "Use UInt64.MaxValue for Total.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/grains/.articles/config.json
+++ b/exercises/practice/grains/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant approach to calculating Grains.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/hamming/.approaches/config.json
+++ b/exercises/practice/hamming/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "linq",
       "title": "Use LINQ",
       "blurb": "Calculate the hamming distance via LINQ.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "d210b47c-b61d-4a73-be55-23c68ce1b600",
       "slug": "for-loop",
       "title": "Use a for-loop",
       "blurb": "Calculate the hamming distance using a for-loop.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/isogram/.approaches/config.json
+++ b/exercises/practice/isogram/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["bobahop"]
+    "authors": [
+      "bobahop"
+    ]
   },
   "approaches": [
     {
@@ -8,21 +10,27 @@
       "slug": "distinct",
       "title": "Distinct",
       "blurb": "Use Distinct with Count to return the answer.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "78bc9485-94b7-4bac-8ce6-d577e85670a1",
       "slug": "groupby",
       "title": "GroupBy",
       "blurb": "Use GroupBy with All and Count to return the answer.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "5a77a3ff-8474-4238-bf23-c7c657f27e34",
       "slug": "bitfield",
       "title": "Bit field",
       "blurb": "Use a bit field to keep track of used letters.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/isogram/.articles/config.json
+++ b/exercises/practice/isogram/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant approach to determining an isogram.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/leap/.approaches/config.json
+++ b/exercises/practice/leap/.approaches/config.json
@@ -1,7 +1,11 @@
 {
   "introduction": {
-    "authors": ["bobahop"],
-    "contributors": ["erikschierboom"]
+    "authors": [
+      "bobahop"
+    ],
+    "contributors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -9,35 +13,45 @@
       "slug": "boolean-chain",
       "title": "Boolean chain",
       "blurb": "Use a chain of boolean expressions.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "eebe5a57-7e58-44c2-92e6-50f46f1251ac",
       "slug": "ternary-operator",
       "title": "Ternary operator",
       "blurb": "Use a ternary operator of boolean expressions.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "cb7c88a6-49f3-4744-a3e8-fcc7acc0770d",
       "slug": "switch-on-a-tuple",
       "title": "switch on a tuple",
       "blurb": "Use a switch on a tuple made from boolean expressions.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "1691a675-03a5-47da-a878-f76cfb895dc6",
       "slug": "datetime-addition",
       "title": "DateTime addition",
       "blurb": "Use DateTime addition.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "28483396-da67-4f59-8388-4c63065dab00",
       "slug": "built-in-method",
       "title": "Built-in method",
       "blurb": "Use the built-in method.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/leap/.articles/config.json
+++ b/exercises/practice/leap/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant approach for determining a leap year.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/palindrome-products/.articles/config.json
+++ b/exercises/practice/palindrome-products/.articles/config.json
@@ -4,7 +4,7 @@
             "uuid": "987cf2d1-7225-436f-9228-b88120ae2e70",
             "slug": "is-palindrome-check",
             "title": "Is a palindrome number check",
-            "blurb": "A few ways to check if a number is a palindrome.",
+            "blurb": "Different ways to check if a number is a palindrome.",
             "authors": ["michalporeba"]
         }
     ]

--- a/exercises/practice/palindrome-products/.articles/config.json
+++ b/exercises/practice/palindrome-products/.articles/config.json
@@ -1,11 +1,13 @@
 {
-    "articles": [
-        {
-            "uuid": "987cf2d1-7225-436f-9228-b88120ae2e70",
-            "slug": "is-palindrome-check",
-            "title": "Is a palindrome number check",
-            "blurb": "Different ways to check if a number is a palindrome.",
-            "authors": ["michalporeba"]
-        }
-    ]
+  "articles": [
+    {
+      "uuid": "987cf2d1-7225-436f-9228-b88120ae2e70",
+      "slug": "is-palindrome-check",
+      "title": "Is a palindrome number check",
+      "blurb": "Different ways to check if a number is a palindrome.",
+      "authors": [
+        "michalporeba"
+      ]
+    }
+  ]
 }

--- a/exercises/practice/palindrome-products/.articles/config.json
+++ b/exercises/practice/palindrome-products/.articles/config.json
@@ -1,0 +1,11 @@
+{
+    "articles": [
+        {
+            "uuid": "987cf2d1-7225-436f-9228-b88120ae2e70",
+            "slug": "is-palindrome-check",
+            "title": "Is a palindrome number check",
+            "blurb": "A few ways to check if a number is a palindrome.",
+            "authors": ["michalporeba"]
+        }
+    ]
+}

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/code/BenchmarkIsPalindrome.cs
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/code/BenchmarkIsPalindrome.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+
+public class BenchmarkIsPalindrome {
+    private static bool StringReversalSolution(int number)
+    {
+        var original = number.ToString();
+        var reversed = new String(original.Reverse().ToArray());
+        return original.Equals(reversed);
+    }
+
+    private static bool StringReversalWithInterpolationSolution(int number)
+    =>  $"{number}".Equals(new String($"{number}".Reverse().ToArray()));
+
+    private static bool MathOnListOfDigitsSolution(int number) { 
+        var original = number;
+        var digits = new List<int>();
+        
+        while (number > 0) { 
+            digits.Add(number % 10);
+            number /= 10;
+        }
+
+        var reversed = 0;
+        foreach(var digit in digits) {
+            reversed = reversed * 10 + digit;
+        }
+        
+        return original == reversed;
+    }
+
+    private static bool MathInALoopSolution(int number) {         
+        var original = number;
+        var reversed = 0;
+        
+        while (number > 0) { 
+            reversed = reversed * 10 + number % 10;
+            number /= 10;
+        }
+        
+        return original == reversed;
+    }
+
+    const int TOP_RANGE = 100_000;
+
+    [Benchmark]
+    public void StringReversal() { 
+        Enumerable.Range(1,TOP_RANGE).Where(StringReversalSolution).ToList();
+    }
+
+    [Benchmark]
+    public void StringReversalWithInterpolation() { 
+        Enumerable.Range(1,TOP_RANGE).Where(StringReversalWithInterpolationSolution).ToList();
+    }
+
+    [Benchmark]
+    public void MathOnListOfDigits() { 
+        Enumerable.Range(1,TOP_RANGE).Where(MathOnListOfDigitsSolution).ToList();
+    }
+
+    [Benchmark]
+    public void MathInALoop() { 
+        Enumerable.Range(1,TOP_RANGE).Where(MathInALoopSolution).ToList();
+    }
+}
+
+public class BenchmarkPalindromes {
+    public static void Main(string[] args)
+    {
+        var summary = BenchmarkRunner.Run<BenchmarkIsPalindrome>();
+    }
+}

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/code/BenchmarkIsPalindrome.csproj
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/code/BenchmarkIsPalindrome.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+  </ItemGroup>
+</Project>

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -46,8 +46,8 @@ Before we look at the code, let's look at an example. The number is 754.
 | Step | number | n % 10 | n / 10 |    list |
 |-----:|-------:|-------:|-------:|:--------|
 |    1 |    754 |      4 |     75 | [4]     |
-|    2 |     75 |      5 |      7 | [4,5]   |
-|    3 |      7 |      7 |      0 | [4,5,7] |
+|    2 |     75 |      5 |      7 | [5,4]   |
+|    3 |      7 |      7 |      0 | [7,5,4] |
 
 So now we have digits, already in reversed order `[7,5,4]`. We have to combine them into a number.
 

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -8,10 +8,79 @@ There are multiple ways to do it in C# and we will look at them in this article.
 ## Approaches
 ### String reversal
 
-### Math and stack
+```csharp
+private static bool IsPalindrome(int number)
+{
+    var original = number.ToString();
+    var reversed = new String(original.Reverse().ToArray());
+    return original.Equals(reversed);
+}
+```
 
-### Just math
+```csharp
+private static bool IsPalindromeString(int number)
+=>  $"{number}".Equals(new String($"{number}".Reverse().ToArray()));
+```
+
+### List of digits
+
+```csharp
+private static bool IsPalindrome(int number) { 
+    var original = number;
+    var digits = new List<int>();
+    
+    while (number > 0) { 
+        digits.Add(number % 10);
+        number /= 10;
+    }
+
+    var reversed = 0;
+    foreach(var digit in digits) {
+        reversed = reversed * 10 + digit;
+    }
+    
+    return original == reversed;
+}
+```
+
+### Math 
+
+```csharp
+private static bool IsPalindrome(int number) { 
+    var original = number;
+    var reversed = 0;
+    
+    while (number > 0) { 
+        reversed = reversed * 10 + number % 10;
+        number /= 10;
+    }
+    
+    return original == reversed;
+}
+```
 
 ## Performance considerations
 
 ## Which one to choose?
+
+
+
+## The extension method options
+
+```csharp
+private static bool IsPalindrome(int number) { /*...*/ }
+
+public static void Main() 
+{
+    if (IsPalindrome(123)) { /* do something */ };
+}
+```
+
+```csharp
+private static bool IsPalindrome(this int number) { /*...*/ }
+
+public static void Main() 
+{
+    if (123.IsPalindrome()) { /* do something */ };
+}
+```

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -41,21 +41,21 @@ private static bool IsPalindrome(int number)
 
 Another approach is to use [modulo division][modulo-division-link] to extract individual digits from the least significant to the most significant. 
 We can capture them in a list, and then read them again using maths to reconstruct the number in the reverse order. 
-Before we look at the code, let's look at an example. The number is 123. 
+Before we look at the code, let's look at an example. The number is 754. 
 
 | Step | number | n % 10 | n / 10 |    list |
 |-----:|-------:|-------:|-------:|:--------|
-|    1 |    123 |      3 |     12 | [3]     |
-|    2 |     12 |      2 |      1 | [3,2]   |
-|    3 |      1 |      1 |      0 | [3,2,1] |
+|    1 |    754 |      4 |     75 | [4]     |
+|    2 |     75 |      5 |      7 | [4,5]   |
+|    3 |      7 |      7 |      0 | [4,5,7] |
 
-So now we have digits, already in reversed order `[3,2,1]`. We have to combine them into a number.
+So now we have digits, already in reversed order `[7,5,4]`. We have to combine them into a number.
 
 | Step | number | digit | number * 10 + digit |
 |-----:|-------:|------:|:--------------------|
-|    1 |      0 |     3 | 3                   |
-|    2 |      3 |     2 | 32                  |
-|    3 |     32 |     1 | 321                 |
+|    1 |      0 |     7 | 7                   |
+|    2 |      7 |     5 | 75                  |
+|    3 |     75 |     4 | 754                 |
 
 And now the same in code:
 

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -7,7 +7,10 @@ There are multiple ways to do it in C# and we will look at them in this article.
 
 ## The string reversal method
 
-Possibly the most obvious solution is to treat a number as a string of characters and reverse it. Let's have a look:
+Possibly the most obvious solution is to treat a number as a string of characters.
+We can then use string operations to see if the string is equal to its reversed version. 
+We are checking if it "reads" the same left-to-right and right-to-left.  
+Let's have a look:
 
 ```csharp
 using System.Linq;
@@ -26,7 +29,9 @@ We have to use `.Reverse()` extension method provided by [Language-Integrated Qu
 However, it returns an iterator and so, it has to be collected with `.ToArray()` and converted into a `String` with `new String(char[])` constructor. 
 
 
-Does this looks like a lot of code? 
+## The string reversal with string interpolation method
+
+Does the above, the [string reversal method](#the-string-reversal-method) look like a lot of code? 
 It might be slightly shortened using [string interpolation][interpolation-link] to convert a number into a text like in the example below. 
 However, before you use it read [the performance considerations](#performance-considerations) below.
 
@@ -103,12 +108,8 @@ private static bool IsPalindrome(int number)
 ```
 
 ## Converting to an extension method
-All of the above solutions correctly check if a number is a palindrome. 
-They differ in performance, something we will look at in a moment.
-But they also differ in readability. You will have to decide which one makes the most sense to you. 
-
-Talking about readability of code, we have another decision to make. 
-All of the above solutions can be implemented like they are above, or as an [extension method][extension-methods-link].
+Talking about readability of code, we have another point to make. 
+All of the above solutions can be implemented like they are above, or as an [extension methods][extension-methods-link].
 
 What does it change? The code reads differently. Instead of: 
 
@@ -127,14 +128,15 @@ if (number.IsPalindrome()){
 }
 ```
 
-You decide which one fits better with your code and expectations. 
+You decide which one fits better with your code and your expectations. 
 
 
 ## Performance considerations
 
-OK, let's talk performance. I have tested the four methods above using [BenchmarkDotNet][benchmark-link].
-I won't share the details of where I run it, on what hardware as we are interested in relative performance only. 
-What is important, that in an individual test I am checking all number between 1 and 100,000 to see if they are a palindrome or not.
+OK, let's talk performance. We have tested the four methods above using [BenchmarkDotNet][benchmark-link].
+The details of where we run it, on what hardware are not important.
+We are interested in relative performance only here. 
+Each test checked all numbers between 1 and 100,000 to see if they are a palindrome or not.
 Here are the results:
 
 |        Method |        Mean |     Error |    StdDev |

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -1,12 +1,11 @@
-# Is number a palindrome? 
+# Checking if a number is a palindrome
 
 There are multiple approaches to solve the palindrome product exercise. 
 Most of them require us to check if a given number is a palindrome. 
 
-## Approaches
 There are multiple ways to do it in C# and we will look at them in this article. 
 
-### String reversal
+## String reversal method
 
 Possibly the most obvious solution is to treat a number as a string of characters
 and reverse it. Let's have a look:
@@ -41,7 +40,7 @@ private static bool IsPalindrome(int number)
 =>  $"{number}".Equals(new String($"{number}".Reverse().ToArray()));
 ```
 
-### List of digits
+## List of digits method
 
 Another approach is to use [modulo division](https://en.wikipedia.org/wiki/Modulo)
 to extract individual digits from the least significant to the most significant. 
@@ -86,7 +85,7 @@ private static bool IsPalindrome(int number) {
 }
 ```
 
-### The math without the list
+## Pure math method
 
 The list in the above code helps us to see what is going on. 
 The numbers are extracted, stored in the list and then collected. 
@@ -106,7 +105,7 @@ private static bool IsPalindrome(int number) {
 }
 ```
 
-## The extension method options
+## Converting to an extension method
 All of the above solutions correctly check if a number is a palindrome. 
 They differ in performance, something we will look at in a moment.
 But they also differ in readability. You will have to decide which one makes

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -7,8 +7,7 @@ There are multiple ways to do it in C# and we will look at them in this article.
 
 ## The string reversal method
 
-Possibly the most obvious solution is to treat a number as a string of characters
-and reverse it. Let's have a look:
+Possibly the most obvious solution is to treat a number as a string of characters and reverse it. Let's have a look:
 
 ```csharp
 using System.Linq;
@@ -23,15 +22,13 @@ private static bool IsPalindrome(int number)
 
 If you come from some other languages you might be surprised by the above code.
 Unfortunately, C# doesn't come with a built in method to reverse a string. 
-We have to use `.Reverse()` extension method provided by 
-[Language-Integrated Query (LINQ)][linq-link]. However, it returns an iterator and so it has to be collected with `.ToArray()` 
-and converted into a `String` with `new String(char[])` constructor. 
+We have to use `.Reverse()` extension method provided by [Language-Integrated Query (LINQ)][linq-link].
+However, it returns an iterator and so, it has to be collected with `.ToArray()` and converted into a `String` with `new String(char[])` constructor. 
 
 
-If this looks like a lot of code to you, it might be slightly shortened using 
-[string interpolation][interpolation-link]
-to convert a number into a text like in the example below. However, before you use it
-read the performance considerations below.
+Does this looks like a lot of code? 
+It might be slightly shortened using [string interpolation][interpolation-link] to convert a number into a text like in the example below. 
+However, before you use it read [the performance considerations](#performance-considerations) below.
 
 ```csharp
 using System.Linq;
@@ -42,11 +39,9 @@ private static bool IsPalindrome(int number)
 
 ## The list of digits method
 
-Another approach is to use [modulo division][modulo-division-link]
-to extract individual digits from the least significant to the most significant. 
-We can capture them in a list, and then read them again using maths again, 
-to reconstruct the number in the reverse order. Before we look at the code, 
-let's look at an example. The number is 123. 
+Another approach is to use [modulo division][modulo-division-link] to extract individual digits from the least significant to the most significant. 
+We can capture them in a list, and then read them again using maths to reconstruct the number in the reverse order. 
+Before we look at the code, let's look at an example. The number is 123. 
 
 | Step | number | n % 10 | n / 10 |    list |
 |-----:|-------:|-------:|-------:|:--------|
@@ -110,14 +105,12 @@ private static bool IsPalindrome(int number)
 ## Converting to an extension method
 All of the above solutions correctly check if a number is a palindrome. 
 They differ in performance, something we will look at in a moment.
-But they also differ in readability. You will have to decide which one makes
-the most sense to you. 
+But they also differ in readability. You will have to decide which one makes the most sense to you. 
 
 Talking about readability of code, we have another decision to make. 
-All of the above solutions can be implemented like they are above, or 
-as an [extension method][extension-methods-link]
+All of the above solutions can be implemented like they are above, or as an [extension method][extension-methods-link].
 
-What does it change? The code reads differently. Instead of 
+What does it change? The code reads differently. Instead of: 
 
 ```csharp
 if (IsPalindrome(number))
@@ -139,12 +132,10 @@ You decide which one fits better with your code and expectations.
 
 ## Performance considerations
 
-OK, let's talk performance. I have tested the four methods above using
-[BenchmarkDotNet][benchmark-link]. I won't share the details
-of where I run it, on what hardware as we are interested in relative performance only. 
-What is important, that in an individual test I am checking all number between 1 and 100,000
-to see if they are a palindrome or not. Here are the results:
-
+OK, let's talk performance. I have tested the four methods above using [BenchmarkDotNet][benchmark-link].
+I won't share the details of where I run it, on what hardware as we are interested in relative performance only. 
+What is important, that in an individual test I am checking all number between 1 and 100,000 to see if they are a palindrome or not.
+Here are the results:
 
 |        Method |        Mean |     Error |    StdDev |
 |-------------- |------------:|----------:|----------:|
@@ -154,21 +145,19 @@ to see if they are a palindrome or not. Here are the results:
 | MathLoopCheck |    935.2 μs |  12.60 μs |  11.79 μs |
 
 There appears to be a big difference between almost 20ms and just under 1ms. 
-It is also worth to observe that the MathLoop is not only the fastest, but also
-the most predictable, the one with the smallest standard deviation. 
+It is also worth to observe that the MathLoop is not only the fastest, but also the most predictable, the one with the smallest standard deviation. 
 
 String interpolation `String2Check` is not only the slowest but also the least predictable. 
 
 ## Which one to choose?
 
-So which one to chose? The fastest always will be the fastest. But the difference is too small
-to perceive in human scales, even when comparing 100,000 numbers it is at most 20ms. 
+So which one to chose? The fastest always will be the fastest. 
+But the difference is too small to perceive in human scales, even when comparing 100,000 numbers it is at most 20ms. 
 
 For 1,000,000 checks  the difference between the first string option and the math loop is 163ms to 12ms. 
 Still almost impossible to spot with our human senses. 
 
-And so, with performance so close, you can choose the one which is easiest to understand,
-one that reads the best. 
+And so, with performance so close, you can choose the one which is easiest to understand, one that reads the best. 
 
 [benchmark-link]: https://benchmarkdotnet.org/
 [extension-methods-link]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -3,12 +3,17 @@
 There are multiple approaches to solve the palindrome product exercise. 
 Most of them require us to check if a given number is a palindrome. 
 
+## Approaches
 There are multiple ways to do it in C# and we will look at them in this article. 
 
-## Approaches
 ### String reversal
 
+Possibly the most obvious solution is to treat a number as a string of characters
+and reverse it. Let's have a look:
+
 ```csharp
+using System.Linq;
+
 private static bool IsPalindrome(int number)
 {
     var original = number.ToString();
@@ -17,14 +22,52 @@ private static bool IsPalindrome(int number)
 }
 ```
 
+If you come from some other languages you might be surprised by the above code.
+Unfortunately, C# doesn't come with a built in method to reverse a string. 
+We have to use `.Reverse()` extension method provided by 
+[Language-Integrated Query (LINQ)](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/). However, it returns an iterator and so it has to be collected with `.ToArray()` 
+and converted into a `String` with `new String(char[])` constructor. 
+
+
+If this looks like a lot of code to you, it might be slightly shortened using 
+[string interpolation](https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/string-interpolation)
+to convert a number into a text like in the example below. However, before you use it
+read the performance considerations below.
+
 ```csharp
-private static bool IsPalindromeString(int number)
+using System.Linq;
+
+private static bool IsPalindrome(int number)
 =>  $"{number}".Equals(new String($"{number}".Reverse().ToArray()));
 ```
 
 ### List of digits
 
+Another approach is to use [modulo division](https://en.wikipedia.org/wiki/Modulo)
+to extract individual digits from the least significant to the most significant. 
+We can capture them in a list, and then read them again using maths again, 
+to reconstruct the number in the reverse order. Before we look at the code, 
+let's look at an example. The number is 123. 
+
+| Step | number | n % 10 | n / 10 |    list |
+|-----:|-------:|-------:|-------:|:--------|
+|    1 |    123 |      3 |     12 | [3]     |
+|    2 |     12 |      2 |      1 | [3,2]   |
+|    3 |      1 |      1 |      0 | [3,2,1] |
+
+So now we have digits, already in reversed order `[3,2,1]`. We have to combine them into a number.
+
+| Step | number | digit | number * 10 + digit |
+|-----:|-------:|------:|:--------------------|
+|    1 |      0 |     3 | 3                   |
+|    2 |      3 |     2 | 32                  |
+|    3 |     32 |     1 | 321                 |
+
+And now the same in code:
+
 ```csharp
+using System.Collections.Generic;
+
 private static bool IsPalindrome(int number) { 
     var original = number;
     var digits = new List<int>();
@@ -43,7 +86,11 @@ private static bool IsPalindrome(int number) {
 }
 ```
 
-### Math 
+### The math without the list
+
+The list in the above code helps us to see what is going on. 
+The numbers are extracted, stored in the list and then collected. 
+But, this can be done on the fly, using just math and loops without the storage. 
 
 ```csharp
 private static bool IsPalindrome(int number) { 
@@ -59,28 +106,60 @@ private static bool IsPalindrome(int number) {
 }
 ```
 
+## The extension method options
+All of the above solutions correctly check if a number is a palindrome. 
+They differ in performance, something we will look at in a moment.
+But they also differ in readability. You will have to decide which one makes
+the most sense to you. 
+
+Talking about readability of code, we have another decision to make. 
+All of the above solutions can be implemented like they are above, or 
+as an [[extension method](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods)]
+
+What does it change? The code reads differently. Instead of 
+
+```csharp
+if (IsPalindrome(number)) { /* do something */ }
+```
+
+you could have
+
+```csharp
+if (number.IsPalindrome()) { /* do something */ }
+```
+
+You decide which one fits better with your code and expectations. 
+
+
 ## Performance considerations
+
+OK, let's talk performance. I have tested the four methods above using
+[BenchmarkDotNet](https://benchmarkdotnet.org/). I won't share the details
+of where I run it, on what hardware as we are interested in relative performance only. 
+What is important, that in an individual test I am checking all number between 1 and 100,000
+to see if they are a palindrome or not. Here are the results:
+
+
+|        Method |        Mean |     Error |    StdDev |
+|-------------- |------------:|----------:|----------:|
+|  String1Check | 13,131.6 μs | 100.98 μs |  94.45 μs |
+|  String2Check | 19,578.5 μs | 324.35 μs | 303.40 μs |
+|     ListCheck |  5,690.9 μs |  59.71 μs |  52.93 μs |
+| MathLoopCheck |    935.2 μs |  12.60 μs |  11.79 μs |
+
+There appears to be a big difference between almost 20ms and just under 1ms. 
+It is also worth to observe that the MathLoop is not only the fastest, but also
+the most predictable, the one with the smallest standard deviation. 
+
+String interpolation `String2Check` is not only the slowest but also the least predictable. 
 
 ## Which one to choose?
 
+So which one to chose? The fastest always will be the fastest. But the difference is too small
+to perceive in human scales, even when comparing 100,000 numbers it is at most 20ms. 
 
+For 1,000,000 checks  the difference between the first string option and the math loop is 163ms to 12ms. 
+Still almost impossible to spot with our human senses. 
 
-## The extension method options
-
-```csharp
-private static bool IsPalindrome(int number) { /*...*/ }
-
-public static void Main() 
-{
-    if (IsPalindrome(123)) { /* do something */ };
-}
-```
-
-```csharp
-private static bool IsPalindrome(this int number) { /*...*/ }
-
-public static void Main() 
-{
-    if (123.IsPalindrome()) { /* do something */ };
-}
-```
+And so, with performance so close, you can choose the one which is easiest to understand,
+one that reads the best. 

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -5,7 +5,7 @@ Most of them require us to check if a given number is a palindrome.
 
 There are multiple ways to do it in C# and we will look at them in this article. 
 
-## String reversal method
+## The string reversal method
 
 Possibly the most obvious solution is to treat a number as a string of characters
 and reverse it. Let's have a look:
@@ -40,7 +40,7 @@ private static bool IsPalindrome(int number)
 =>  $"{number}".Equals(new String($"{number}".Reverse().ToArray()));
 ```
 
-## List of digits method
+## The list of digits method
 
 Another approach is to use [modulo division](https://en.wikipedia.org/wiki/Modulo)
 to extract individual digits from the least significant to the most significant. 
@@ -67,7 +67,8 @@ And now the same in code:
 ```csharp
 using System.Collections.Generic;
 
-private static bool IsPalindrome(int number) { 
+private static bool IsPalindrome(int number)
+{ 
     var original = number;
     var digits = new List<int>();
     
@@ -85,14 +86,15 @@ private static bool IsPalindrome(int number) {
 }
 ```
 
-## Pure math method
+## The pure math method
 
 The list in the above code helps us to see what is going on. 
 The numbers are extracted, stored in the list and then collected. 
 But, this can be done on the fly, using just math and loops without the storage. 
 
 ```csharp
-private static bool IsPalindrome(int number) { 
+private static bool IsPalindrome(int number)
+{ 
     var original = number;
     var reversed = 0;
     
@@ -118,13 +120,18 @@ as an [[extension method](https://learn.microsoft.com/en-us/dotnet/csharp/progra
 What does it change? The code reads differently. Instead of 
 
 ```csharp
-if (IsPalindrome(number)) { /* do something */ }
+if (IsPalindrome(number))
+{ 
+    /* do something */
+}
 ```
 
 you could have
 
 ```csharp
-if (number.IsPalindrome()) { /* do something */ }
+if (number.IsPalindrome()){
+    /* do something */
+}
 ```
 
 You decide which one fits better with your code and expectations. 

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -139,24 +139,24 @@ We are interested in relative performance only here.
 Each test checked all numbers between 1 and 100,000 to see if they are a palindrome or not.
 Here are the results:
 
-|        Method |        Mean |     Error |    StdDev |
-|-------------- |------------:|----------:|----------:|
-|  String1Check | 13,131.6 μs | 100.98 μs |  94.45 μs |
-|  String2Check | 19,578.5 μs | 324.35 μs | 303.40 μs |
-|     ListCheck |  5,690.9 μs |  59.71 μs |  52.93 μs |
-| MathLoopCheck |    935.2 μs |  12.60 μs |  11.79 μs |
+|                          Method |        Mean |    Error |   StdDev |
+|-------------------------------- |------------:|---------:|---------:|
+|                  StringReversal |  9,499.5 μs | 81.39 μs | 72.15 μs |
+| StringReversalWithInterpolation | 13,677.6 μs | 72.24 μs | 64.04 μs |
+|              MathOnListOfDigits |  4,074.9 μs | 42.06 μs | 39.35 μs |
+|                     MathInALoop |    680.5 μs |  5.77 μs |  4.82 μs |
 
-There appears to be a big difference between almost 20ms and just under 1ms. 
-It is also worth to observe that the MathLoop is not only the fastest, but also the most predictable, the one with the smallest standard deviation. 
+There appears to be a big difference between almost 14 ms and just under 1 ms. 
+It is also worth to observe that the `MathInALoop` is not only the fastest, but also the most predictable, the one with the smallest standard deviation. 
 
-String interpolation `String2Check` is not only the slowest but also the least predictable. 
+The `StringReversalWithInterpolation` is not only the slowest but also the least predictable. 
 
 ## Which one to choose?
 
 So which one to chose? The fastest always will be the fastest. 
-But the difference is too small to perceive in human scales, even when comparing 100,000 numbers it is at most 20ms. 
+But the difference is too small to perceive in human scales, even when comparing 100,000 numbers it is at most 14 ms. 
 
-For 1,000,000 checks  the difference between the first string option and the math loop is 163ms to 12ms. 
+For 1,000,000 checks  the difference between the first string option and the math loop is 163 ms to 12 ms. 
 Still almost impossible to spot with our human senses. 
 
 And so, with performance so close, you can choose the one which is easiest to understand, one that reads the best. 

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -1,0 +1,17 @@
+# Is number a palindrome? 
+
+There are multiple approaches to solve the palindrome product exercise. 
+Most of them require us to check if a given number is a palindrome. 
+
+There are multiple ways to do it in C# and we will look at them in this article. 
+
+## Approaches
+### String reversal
+
+### Math and stack
+
+### Just math
+
+## Performance considerations
+
+## Which one to choose?

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/content.md
@@ -24,12 +24,12 @@ private static bool IsPalindrome(int number)
 If you come from some other languages you might be surprised by the above code.
 Unfortunately, C# doesn't come with a built in method to reverse a string. 
 We have to use `.Reverse()` extension method provided by 
-[Language-Integrated Query (LINQ)](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/). However, it returns an iterator and so it has to be collected with `.ToArray()` 
+[Language-Integrated Query (LINQ)][linq-link]. However, it returns an iterator and so it has to be collected with `.ToArray()` 
 and converted into a `String` with `new String(char[])` constructor. 
 
 
 If this looks like a lot of code to you, it might be slightly shortened using 
-[string interpolation](https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/string-interpolation)
+[string interpolation][interpolation-link]
 to convert a number into a text like in the example below. However, before you use it
 read the performance considerations below.
 
@@ -42,7 +42,7 @@ private static bool IsPalindrome(int number)
 
 ## The list of digits method
 
-Another approach is to use [modulo division](https://en.wikipedia.org/wiki/Modulo)
+Another approach is to use [modulo division][modulo-division-link]
 to extract individual digits from the least significant to the most significant. 
 We can capture them in a list, and then read them again using maths again, 
 to reconstruct the number in the reverse order. Before we look at the code, 
@@ -115,7 +115,7 @@ the most sense to you.
 
 Talking about readability of code, we have another decision to make. 
 All of the above solutions can be implemented like they are above, or 
-as an [[extension method](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods)]
+as an [extension method][extension-methods-link]
 
 What does it change? The code reads differently. Instead of 
 
@@ -140,7 +140,7 @@ You decide which one fits better with your code and expectations.
 ## Performance considerations
 
 OK, let's talk performance. I have tested the four methods above using
-[BenchmarkDotNet](https://benchmarkdotnet.org/). I won't share the details
+[BenchmarkDotNet][benchmark-link]. I won't share the details
 of where I run it, on what hardware as we are interested in relative performance only. 
 What is important, that in an individual test I am checking all number between 1 and 100,000
 to see if they are a palindrome or not. Here are the results:
@@ -169,3 +169,9 @@ Still almost impossible to spot with our human senses.
 
 And so, with performance so close, you can choose the one which is easiest to understand,
 one that reads the best. 
+
+[benchmark-link]: https://benchmarkdotnet.org/
+[extension-methods-link]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods
+[interpolation-link]: https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/string-interpolation
+[linq-linl]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/
+[modulo-division-link]: https://en.wikipedia.org/wiki/Modulo

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/snippet.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/snippet.md
@@ -1,0 +1,1 @@
+*I don't really know what this file is for, but the github action is failing without it*

--- a/exercises/practice/palindrome-products/.articles/is-palindrome-check/snippet.md
+++ b/exercises/practice/palindrome-products/.articles/is-palindrome-check/snippet.md
@@ -1,1 +1,4 @@
-*I don't really know what this file is for, but the github action is failing without it*
+private static bool IsPalindrome(int number)
+{
+    /* implementation details */
+}

--- a/exercises/practice/pangram/.approaches/config.json
+++ b/exercises/practice/pangram/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["bobahop"]
+    "authors": [
+      "bobahop"
+    ]
   },
   "approaches": [
     {
@@ -8,21 +10,27 @@
       "slug": "all-contains-tolower",
       "title": "All with Contains on lower case",
       "blurb": "Use All with Contains on lowercased letters.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "8886e091-72bf-40c7-9e86-fdde96bbbae2",
       "slug": "all-contains-case-insensitive",
       "title": "All with Contains using case insensitve",
       "blurb": "Use All with Contains using case insensitive.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "7eeae24f-d815-400c-9749-b617864e185f",
       "slug": "bitfield",
       "title": "Bit field",
       "blurb": "Use a bit field to keep track of used letters.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/pangram/.articles/config.json
+++ b/exercises/practice/pangram/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant approach to determining a pangram.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/parallel-letter-frequency/.approaches/config.json
+++ b/exercises/practice/parallel-letter-frequency/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,7 +10,9 @@
       "slug": "as-parallel",
       "title": "Use AsParallel()",
       "blurb": "Use AsParallel() to parallelize counting characters.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/perfect-numbers/.approaches/config.json
+++ b/exercises/practice/perfect-numbers/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,7 +10,9 @@
       "slug": "if-statements",
       "title": "Use if statements",
       "blurb": "Use if statements to check for a perfect number.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/phone-number/.approaches/config.json
+++ b/exercises/practice/phone-number/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,7 +10,9 @@
       "slug": "regular-expression",
       "title": "Use a regular expression",
       "blurb": "Use a regular expression to check and parse the phone number.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/pig-latin/.approaches/config.json
+++ b/exercises/practice/pig-latin/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,7 +10,9 @@
       "slug": "regular-expressions",
       "title": "Use regular expressions",
       "blurb": "Use regular expressions to match and rewrite a sentence.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/poker/.approaches/config.json
+++ b/exercises/practice/poker/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "icomparer",
       "title": "Use IComparer<T>",
       "blurb": "Use IComparer<T> to compare hands.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "0d49c2c9-6ec7-4dda-9a23-bb8d77823aea",
       "slug": "integer-score",
       "title": "Score each hand as an integer",
       "blurb": "Score each hand as an integer.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/protein-translation/.approaches/config.json
+++ b/exercises/practice/protein-translation/.approaches/config.json
@@ -1,7 +1,8 @@
 {
   "introduction": {
-    "authors": ["bobahop"],
-    "contributors": []
+    "authors": [
+      "bobahop"
+    ]
   },
   "approaches": [
     {
@@ -9,35 +10,45 @@
       "slug": "substring-dict",
       "title": "Substring with Dictionary",
       "blurb": "Iterate Substrings with Dictionary.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "8f8a9272-74d7-47f7-8d66-e4b280c67de5",
       "slug": "substring-switch",
       "title": "Switch on a tuple",
       "blurb": "Iterate Substrings with switch.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "2a050672-c9ac-40e7-a836-9a844f8811e8",
       "slug": "linq-dict",
       "title": "LINQ with Dictionary",
       "blurb": "Use LINQ with Dictionary.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "07202257-f3b8-4008-b661-91234f26a6ff",
       "slug": "yield-dict",
       "title": "yield with Dictionary",
       "blurb": "Iterate using yield with Dictionary.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "621d443b-74a7-48d9-8339-7f1fcec53a15",
       "slug": "yield-switch",
       "title": "yield with switch",
       "blurb": "Iterate using yield with switch.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/protein-translation/.articles/config.json
+++ b/exercises/practice/protein-translation/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant approach for solving Protein Translation.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/proverb/.approaches/config.json
+++ b/exercises/practice/proverb/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "linq",
       "title": "Use LINQ",
       "blurb": "Use LINQ to to iterate over the subjects and recite the song.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "17a95b9d-af7a-4e8d-9086-aa4522c21dd9",
       "slug": "for-loop",
       "title": "Use a for loop",
       "blurb": "Use a for loop to to iterate over the subjects and recite the song.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/raindrops/.approaches/config.json
+++ b/exercises/practice/raindrops/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["bobahop"]
+    "authors": [
+      "bobahop"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "if-statements",
       "title": "if statements",
       "blurb": "Use a chain of if statements.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     },
     {
       "uuid": "dc8fca24-1a44-4bb6-a08b-50d47de757c4",
       "slug": "aggregate",
       "title": "Aggregate",
       "blurb": "Use the LINQ Aggregate method.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/raindrops/.articles/config.json
+++ b/exercises/practice/raindrops/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant approach to calculating Raindrops.",
-      "authors": ["bobahop"]
+      "authors": [
+        "bobahop"
+      ]
     }
   ]
 }

--- a/exercises/practice/reverse-string/.approaches/config.json
+++ b/exercises/practice/reverse-string/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,28 +10,36 @@
       "slug": "array-reverse",
       "title": "Array.Reverse",
       "blurb": "Use Array.Reverse to reverse a string.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "581af3cf-5218-41cc-84ff-50fbb2d9601a",
       "slug": "linq",
       "title": "LINQ",
       "blurb": "Use LINQ to concisely reverse a string.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "448fb2b4-18ab-4e55-aa54-ad4ed6d5f7f6",
       "slug": "span",
       "title": "Span<T>",
       "blurb": "Use Span<T> and stack allocation for hyper-optimized string reversal.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "053bd627-c362-4f2e-8e2f-01bd279b0ef6",
       "slug": "string-builder",
       "title": "StringBuilder",
       "blurb": "Reverse a string using the StringBuilder class.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/reverse-string/.articles/config.json
+++ b/exercises/practice/reverse-string/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant approach to reversing a string.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/rna-transcription/.approaches/config.json
+++ b/exercises/practice/rna-transcription/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "dictionary",
       "title": "Use a Dictionary",
       "blurb": "Use a Dictionary and some LINQ to translate the DNA strand.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "576af402-9b7f-46fd-8642-bf8fa6d0d4fa",
       "slug": "switch-expression",
       "title": "Use a switch expression",
       "blurb": "Use a switch expression and some LINQ to translate the DNA strand.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/series/.approaches/config.json
+++ b/exercises/practice/series/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "for-loop",
       "title": "For loop",
       "blurb": "Use a for loop to iterate over the slices.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "3857e426-8dac-41f2-bea0-4c8a0b8cd7bc",
       "slug": "linq",
       "title": "LINQ",
       "blurb": "Use LINQ to iterate over the slices.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/sieve/.approaches/config.json
+++ b/exercises/practice/sieve/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "bit-array",
       "title": "BitArray",
       "blurb": "Use a BitArray to sieve out primes.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "4d367233-9bd4-45f9-9b33-b08cb78e15fa",
       "slug": "hash-set",
       "title": "HashSet",
       "blurb": "Use a HashSet to sieve out primes.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/sieve/.articles/config.json
+++ b/exercises/practice/sieve/.articles/config.json
@@ -5,7 +5,9 @@
       "slug": "performance",
       "title": "Performance deep dive",
       "blurb": "Deep dive to find out the most performant sieve approach.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/two-bucket/.approaches/config.json
+++ b/exercises/practice/two-bucket/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,7 +10,9 @@
       "slug": "graph-shortest-path",
       "title": "Shortest path in graph",
       "blurb": "Model the problem as a graph and use Dijkstra's algorithm to find the shortest path.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/two-fer/.approaches/config.json
+++ b/exercises/practice/two-fer/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,14 +10,18 @@
       "slug": "optional-parameter",
       "title": "Optional parameter",
       "blurb": "Use an optional parameter and its default value.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "e3999368-f13c-42e9-a814-e385356fd640",
       "slug": "method-overloading",
       "title": "Method overloading",
       "blurb": "Use method overloading.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/two-fer/.articles/config.json
+++ b/exercises/practice/two-fer/.articles/config.json
@@ -5,14 +5,18 @@
       "slug": "optional-parameters-vs-method-overloading",
       "title": "Optional parameters vs. method overloading",
       "blurb": "Find out how optional parameters compare to method overloading.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     },
     {
       "uuid": "bc651e10-b512-442c-a568-559867d31c91",
       "slug": "string-formatting",
       "title": "Formatting the return string",
       "blurb": "Show the different ways in which the return string can be formatted.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }

--- a/exercises/practice/yacht/.approaches/config.json
+++ b/exercises/practice/yacht/.approaches/config.json
@@ -1,6 +1,8 @@
 {
   "introduction": {
-    "authors": ["erikschierboom"]
+    "authors": [
+      "erikschierboom"
+    ]
   },
   "approaches": [
     {
@@ -8,7 +10,9 @@
       "slug": "linq",
       "title": "Use LINQ",
       "blurb": "Use LINQ to score yacht hands.",
-      "authors": ["erikschierboom"]
+      "authors": [
+        "erikschierboom"
+      ]
     }
   ]
 }


### PR DESCRIPTION
The release of 4.0.0 beta.11 configlet broke all the builds in C# track as all existing article and approach configs were considered to be not-formatted. 

I have doing some reading and posting about it I followed suggestion of [MatthijsBlom](https://forum.exercism.org/u/MatthijsBlom) I have run `configlet fmt -u`. Here is the result. 

[The issue has been discussed in the forum](https://forum.exercism.org/t/configlet-4-0-0-beta-11-breaks-c-track-builds/5277).