### PR TITLE
Binary search tree encapsulated

### DIFF
--- a/exercises/practice/binary-search-tree/.meta/Example.cs
+++ b/exercises/practice/binary-search-tree/.meta/Example.cs
@@ -1,79 +1,57 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 
-public class BinarySearchTree : IEnumerable<int>
+public class BinarySearchTree<T> where T : IComparable
 {
-    public BinarySearchTree(int value)
+    class Node
     {
-        Value = value;
+        public T Value { get; set; }
+        public Node Left { get; set; }
+        public Node Right { get; set; }
     }
 
-    public BinarySearchTree(IEnumerable<int> values)
+    Node head;
+    
+    public int Count { get; private set; }
+    public int Depth { get; private set; }
+
+    public void Add(T value)
     {
-        var array = values.ToArray();
+        Count++;
 
-        if (array.Length == 0)
-        {
-            throw new ArgumentException("Cannot create tree from empty list");
+        var depth = 1;
+        
+        if (head == null) {
+            head = new Node { Value = value };
+            Depth = 1;
+            return;
         }
 
-        Value = array[0];
-
-        foreach (var value in array.Skip(1))
+        var node = head;
+        while(node.Value.CompareTo(value) != 0)
         {
-            Add(value);
+            depth++;
+            if (node.Value.CompareTo(value) < 0) 
+            {
+                node.Left ??= new Node { Value = value };
+                node = node.Left;
+            } else { 
+                node.Right ??= new Node { Value = value };
+                node = node.Right;
+            }
         }
+        Depth = depth;
     }
 
-    public int Value { get; }
-
-    public BinarySearchTree Left { get; private set; }
-
-    public BinarySearchTree Right { get; private set; }
-
-    public BinarySearchTree Add(int value)
+    public bool Contains(T value)
     {
-        if (value <= Value)
+        var node = head;
+        while(node != null) 
         {
-            Left = Add(value, Left);
+            if (node.Value.CompareTo(value) == 0) { return true; }
+
+            if (node.Value.CompareTo(value) < 0) { node = node.Left; }
+            else { node = node.Right; }
         }
-        else
-        {
-            Right = Add(value, Right);
-        }
-
-        return this;
-    }
-
-    private static BinarySearchTree Add(int value, BinarySearchTree tree)
-    {
-        if (tree == null)
-        {
-            return new BinarySearchTree(value);
-        }
-
-        return tree.Add(value);
-    }
-
-    public IEnumerator<int> GetEnumerator()
-    {
-        foreach (var left in Left?.AsEnumerable() ?? Enumerable.Empty<int>())
-        {
-            yield return left;
-        }
-
-        yield return Value;
-
-        foreach (var right in Right?.AsEnumerable() ?? Enumerable.Empty<int>())
-        {
-            yield return right;
-        }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
+        return false;
     }
 }

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -7,7 +7,8 @@
     "j2jensen",
     "robkeim",
     "ShamilS",
-    "wolf99"
+    "wolf99",
+    "michalporeba"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/binary-search-tree/BinarySearchTree.cs
+++ b/exercises/practice/binary-search-tree/BinarySearchTree.cs
@@ -1,53 +1,10 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 
-public class BinarySearchTree : IEnumerable<int>
+public class BinarySearchTree<T> where T : IComparable
 {
-    public BinarySearchTree(int value)
-    {
-    }
+    public int Count => throw new NotImplementedException("You need to implement this function.");
+    public int Depth => throw new NotImplementedException("You need to implement this function.");
 
-    public BinarySearchTree(IEnumerable<int> values)
-    {
-    }
-
-    public int Value
-    {
-        get
-        {
-            throw new NotImplementedException("You need to implement this function.");
-        }
-    }
-
-    public BinarySearchTree Left
-    {
-        get
-        {
-            throw new NotImplementedException("You need to implement this function.");
-        }
-    }
-
-    public BinarySearchTree Right
-    {
-        get
-        {
-            throw new NotImplementedException("You need to implement this function.");
-        }
-    }
-
-    public BinarySearchTree Add(int value)
-    {
-        throw new NotImplementedException("You need to implement this function.");
-    }
-
-    public IEnumerator<int> GetEnumerator()
-    {
-        throw new NotImplementedException("You need to implement this function.");
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        throw new NotImplementedException("You need to implement this function.");
-    }
+    public void Add(T value) => throw new NotImplementedException("You need to implement this function.");
+    public bool Contains(T value) => throw new NotImplementedException("You need to implement this function.");
 }

--- a/exercises/practice/binary-search-tree/BinarySearchTreeTests.cs
+++ b/exercises/practice/binary-search-tree/BinarySearchTreeTests.cs
@@ -1,84 +1,66 @@
-using System.Linq;
 using Xunit;
 
 public class BinarySearchTreeTests
 {
     [Fact]
-    public void Data_is_retained()
+    public void New_bst_is_empty()
     {
-        var tree = new BinarySearchTree(4);
-        Assert.Equal(4, tree.Value);
+        var sut = new BinarySearchTree<int>();
+        Assert.Equal(0, sut.Count);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Smaller_number_at_left_node()
+    [Fact]
+    public void New_bst_has_no_depth()
     {
-        var tree = new BinarySearchTree(new[] { 4, 2 });
-        Assert.Equal(4, tree.Value);
-        Assert.Equal(2, tree.Left.Value);
+        var sut = new BinarySearchTree<int>();
+        Assert.Equal(0, sut.Depth);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Same_number_at_left_node()
+    [Fact]
+    public void Single_value_results_in_depth_one()
     {
-        var tree = new BinarySearchTree(new[] { 4, 4 });
-        Assert.Equal(4, tree.Value);
-        Assert.Equal(4, tree.Left.Value);
+        var sut = new BinarySearchTree<int>();
+        sut.Add(1);
+        Assert.Equal(1, sut.Depth);
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Greater_number_at_right_node()
+    [Fact]
+    public void Single_value_can_be_found()
     {
-        var tree = new BinarySearchTree(new[] { 4, 5 });
-        Assert.Equal(4, tree.Value);
-        Assert.Equal(5, tree.Right.Value);
+        var sut = new BinarySearchTree<int>();
+        sut.Add(2);
+        Assert.True(sut.Contains(2));
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Can_create_complex_tree()
+    [Fact]
+    public void Balanced_three_is_well_behaved()
     {
-        var tree = new BinarySearchTree(new[] { 4, 2, 6, 1, 3, 5, 7 });
-        Assert.Equal(4, tree.Value);
-        Assert.Equal(2, tree.Left.Value);
-        Assert.Equal(1, tree.Left.Left.Value);
-        Assert.Equal(3, tree.Left.Right.Value);
-        Assert.Equal(6, tree.Right.Value);
-        Assert.Equal(5, tree.Right.Left.Value);
-        Assert.Equal(7, tree.Right.Right.Value);
+        var sut = new BinarySearchTree<int>();
+        sut.Add(5);
+        sut.Add(3);
+        sut.Add(7);
+        Assert.Equal(3, sut.Count);
+        Assert.Equal(2, sut.Depth);
+        Assert.True(sut.Contains(3));
+        Assert.True(sut.Contains(5));
+        Assert.True(sut.Contains(7));
+        Assert.False(sut.Contains(4));
+        Assert.False(sut.Contains(6));
     }
 
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Can_sort_single_number()
+    [Fact]
+    public void Left_heavy_five_is_well_behaved()
     {
-        var tree = new BinarySearchTree(2);
-        Assert.Equal(new[] { 2 }, tree.AsEnumerable());
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Can_sort_if_second_number_is_smaller_than_first()
-    {
-        var tree = new BinarySearchTree(new[] { 2, 1 });
-        Assert.Equal(new[] { 1, 2 }, tree.AsEnumerable());
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Can_sort_if_second_number_is_same_as_first()
-    {
-        var tree = new BinarySearchTree(new[] { 2, 2 });
-        Assert.Equal(new[] { 2, 2 }, tree.AsEnumerable());
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Can_sort_if_second_number_is_greater_than_first()
-    {
-        var tree = new BinarySearchTree(new[] { 2, 3 });
-        Assert.Equal(new[] { 2, 3 }, tree.AsEnumerable());
-    }
-
-    [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Can_sort_complex_tree()
-    {
-        var tree = new BinarySearchTree(new[] { 2, 1, 3, 6, 7, 5 });
-        Assert.Equal(new[] { 1, 2, 3, 5, 6, 7 }, tree.AsEnumerable());
+        var sut = new BinarySearchTree<int>();
+        sut.Add(5);
+        sut.Add(3);
+        sut.Add(2);
+        sut.Add(5);
+        sut.Add(1);
+        Assert.Equal(5, sut.Count);
+        Assert.Equal(4, sut.Depth);
+        Assert.True(sut.Contains(1));
+        Assert.True(sut.Contains(2));
+        Assert.False(sut.Contains(8));
     }
 }


### PR DESCRIPTION
As explained and approved [on the forum](https://forum.exercism.org/t/binary-search-tree-improvements-in-c-track/5581)

This is to match with both similar exercise in this and other tracks, as well as with the .net approach to doing things. Binary Search Tree is now an encapsulated structure. To solve the problem a node has to be implemented internally. 

The idea is similar to what we have previously implemented in Simple Linked List exercise as discussed [on the forum](https://forum.exercism.org/t/incorrect-solutions-passing-tests-in-c-track/4840) and [described in previous PR](https://github.com/exercism/csharp/pull/2102).

Since the BST structure is a search one, I removed the `IEnumerable` elements and instead added a constraint on the `T` to be `IComparable`. The `BinarySearchTree<T>` type to implement two properties Count and Depth and two methods Add and Contains.

Two remaining questions is 

1. Whether to leave the `where T: IComparable` in the stub or not. As this is a medium difficulty exercise I would be tempted to remove it. Users implementing the solution soon will realise that they cannot compare `T` and either they will know about `IComparable`, or will search for solutions online and find out about it. 

2. Whether to add a test that explicitly follows the example from the description. 
