### PR TITLE
Hyper-optimized telemetry: Provide clear explanation for unexpected value of prefix byte

### DIFF
--- a/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
+++ b/exercises/concept/hyper-optimized-telemetry/.docs/instructions.md
@@ -45,4 +45,4 @@ TelemetryBuffer.FromBuffer(new byte[] {0xfc, 0xff, 0xff, 0xff, 0x7f, 0x0, 0x0, 0
 // => 2147483647
 ```
 
-If the prefix byte is not one of `-8`, `-4`, `-2`, `2` or `4` then `0` should be returned.
+If the prefix byte is of unexpected value then `0` should be returned.


### PR DESCRIPTION
As discussed in #2160 here's a small change that hopefully makes the last sentence in instructions for the "Hyper-optimized telemetry" exercise a bit more clear.