### PR TITLE
tim-from-marketing exercise docs mistake.

### DIFF
--- a/exercises/concept/tim-from-marketing/.docs/introduction.md
+++ b/exercises/concept/tim-from-marketing/.docs/introduction.md
@@ -61,10 +61,10 @@ The `??` operator allows one to return a default value when the value is `null`:
 
 ```csharp
 string? name1 = "John";
-name1 ?? "Paul"; // => "John"
+name1 ??= "Paul"; // => "John"
 
 string? name2 = null;
-name2 ?? "George"; // => "George"
+name2 ??= "George"; // => "George"
 ```
 
 The `?.` operator allows one to call members safely on a possibly `null` value:


### PR DESCRIPTION
Fixed a mistake in tim-from-marketing exercise introduction where the null-coalescing operator (??) was shown to be used without an assignment operator.