### PR TITLE
Collatz Conjecture / Dig Deeper / Append optional parameter version to recursion approach

### DIFF
--- a/exercises/practice/collatz-conjecture/.approaches/introduction.md
+++ b/exercises/practice/collatz-conjecture/.approaches/introduction.md
@@ -59,7 +59,25 @@ private static int Steps(int number, int stepCount)
 }
 ```
 
-This approach uses a recursion to calculate the steps, with each call to `Steps(int number, int stepCount)` representing a single application of the algorithm.
+To make the recursion approach even more concise you can combine the overloaded methods into a single method using a default parameter for `stepCount`.
+
+```csharp
+public static int Steps(int number, int stepCount = 0)
+{
+    if (number <= 0)
+        throw new ArgumentOutOfRangeException(nameof(number));
+
+    if (number == 1)
+        return stepCount;
+
+    if (number % 2 == 0)
+        return Steps(number / 2, stepCount + 1);
+
+    return Steps(number * 3 + 1, stepCount + 1);
+}
+```
+
+These approaches use a recursion to calculate the steps, with each call to `Steps(int number, int stepCount)` representing a single application of the algorithm.
 For more information, check the [recursion approach][approach-recursion].
 
 ### Approach: sequence

--- a/exercises/practice/collatz-conjecture/.approaches/introduction.md
+++ b/exercises/practice/collatz-conjecture/.approaches/introduction.md
@@ -59,25 +59,7 @@ private static int Steps(int number, int stepCount)
 }
 ```
 
-To make the recursion approach even more concise you can combine the overloaded methods into a single method using a default parameter for `stepCount`.
-
-```csharp
-public static int Steps(int number, int stepCount = 0)
-{
-    if (number <= 0)
-        throw new ArgumentOutOfRangeException(nameof(number));
-
-    if (number == 1)
-        return stepCount;
-
-    if (number % 2 == 0)
-        return Steps(number / 2, stepCount + 1);
-
-    return Steps(number * 3 + 1, stepCount + 1);
-}
-```
-
-These approaches use a recursion to calculate the steps, with each call to `Steps(int number, int stepCount)` representing a single application of the algorithm.
+This approach uses a recursion to calculate the steps, with each call to `Steps(int number, int stepCount)` representing a single application of the algorithm.
 For more information, check the [recursion approach][approach-recursion].
 
 ### Approach: sequence

--- a/exercises/practice/collatz-conjecture/.approaches/recursion/content.md
+++ b/exercises/practice/collatz-conjecture/.approaches/recursion/content.md
@@ -122,3 +122,27 @@ return Steps(number % 2 == 0 ? number / 2 : number * 3 + 1, stepCount + 1);
 ```
 
 [ternary-operator]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/conditional-operator
+
+## Optional parameter
+
+As an alternative to overloading the methods, as seen in the code snippets above, it is also possible to use an [optional parameter][optional-parameter] to solve the problem with only a single method implementation.
+
+This allows callers to use the method either with a single parameter (`number`) or both parameters, as used in the recursive method call. If only the `number` parameter is provided the `stepCount` parameter uses the defined default value.
+
+```csharp
+public static int Steps(int number, int stepCount = 0)
+{
+    if (number <= 0)
+        throw new ArgumentOutOfRangeException(nameof(number));
+
+    if (number == 1)
+        return stepCount;
+
+    if (number % 2 == 0)
+        return Steps(number / 2, stepCount + 1);
+
+    return Steps(number * 3 + 1, stepCount + 1);
+}
+```
+
+[optional-parameter]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#optional-arguments

--- a/exercises/practice/collatz-conjecture/.approaches/recursion/content.md
+++ b/exercises/practice/collatz-conjecture/.approaches/recursion/content.md
@@ -145,4 +145,6 @@ public static int Steps(int number, int stepCount = 0)
 }
 ```
 
+This version is more concise than the overloading version, but it comes with the drawback that the method API publicly exposes the `stepCount` parameter and callers might not know how to use this parameter correctly or may even provide invalid data, which then falsifies the result. 
+
 [optional-parameter]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#optional-arguments


### PR DESCRIPTION
The recursion approach in the Dig Deeper section for the Collatz Conjecture exercise can be presented in a more concise way using a default parameter for `stepCount` instead of overloading the method. 
This version of the recursion approach is currently added as an alternative to the overloaded version, which is still kept at it's place. It might also be possible that this updated solution replaces the code snippet using overloading.