### PR TITLE
weighing-machine: Clarify return type for display property

### DIFF
--- a/exercises/concept/weighing-machine/.docs/instructions.md
+++ b/exercises/concept/weighing-machine/.docs/instructions.md
@@ -61,14 +61,14 @@ var wm = new WeighingMachine(precision: 3);
 
 ## 6. Allow the weight to be retrieved
 
-Implement the `WeighingMachine.DisplayWeight` property which shows weight after tare adjustment and with the correct precision applied:
+Implement the `WeighingMachine.DisplayWeight` property which should return a string showing the weight after tare adjustment, with the correct precision applied, and the unit added.
 Note that:
 ``` display-weight = input-weight - tare-adjustment ```
 
 ```csharp
 var wm = new WeighingMachine(precision: 3);
-wm.TareAdjustment = 10;
 wm.Weight = 60.567;
+wm.TareAdjustment = 10;
 
 // => wm.DisplayWeight == "50.567 kg"
 ```


### PR DESCRIPTION
From Discord:

<img width="484" alt="Screenshot 2023-09-05 at 13 18 52" src="https://github.com/exercism/csharp/assets/286476/d82a1c1c-1808-4167-a53c-dbeeb616710f">

The example subtly shows "...kg" but the text doesn't really imply it's a string.