### PR TITLE
fix: Greek character in SqueakyCleanTests.cs file

### DIFF
--- a/exercises/concept/squeaky-clean/SqueakyCleanTests.cs
+++ b/exercises/concept/squeaky-clean/SqueakyCleanTests.cs
@@ -63,7 +63,7 @@ public class SqueakyCleanTests
     [Task(5)]
     public void Omit_lower_case_greek_letters()
     {
-        Assert.Equal("MyΟFinder", Identifier.Clean("MyΟβιεγτFinder"));
+        Assert.Equal("MyFinder", Identifier.Clean("MyΟβιεγτFinder"));
     }
 
     [Fact]


### PR DESCRIPTION
Just a simple fix:
```csharp
Assert.Equal("MyΟFinder", Identifier.Clean("MyΟβιεγτFinder")); // before
```
The string `"MyΟFinder"` contains a Greek character remaining: `Ο` (_omicron_)