### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/exercises/practice/bank-account/.approaches/introduction.md
+++ b/exercises/practice/bank-account/.approaches/introduction.md
@@ -78,12 +78,12 @@ Whilst using locks (or mutexes) makes for simple code, they come at a small perf
 Lock-free programming aims to provide alternative means of safe concurrent updating.
 One such mechanism is to use an atomic CPU instruction called [_compare and swap_][compare-and-swap].
 
-```exercism/note
+~~~~exercism/note
 The compare and swap instruction takes three arguments: the address of the memory you want to update, its current value and the new value.
 The memory will only be updated if the current value is equal to the provided value.
 If this is not the case, some other code must have updated the value, so in that case it is not safe to update the value.
 The instruction's return value indicates if the compare and swap exchange succeeded, and if not, you could retry with the newly updated value.
-```
+~~~~
 
 The .NET framework allows using this instruction via the [`Interlocked.CompareExchange()`][interlocked.compare-exchange] method.
 Unfortunately, we can't use this to solve in this exercise, as the value that we want to update is a `decimal` and compare and swap is not supported for `decimal` values.
@@ -94,9 +94,9 @@ This is due to decimals required too much memory to be swapped atomically.
 While both approaches basically are almost identical, the `lock` version is more idiomatic.
 They do offer different levels of concurrency guarantees though.
 
-```exercism/caution
+~~~~exercism/caution
 Locks offer protection against concurrent access via threads, but mutexes even offer protection against concurrent access via processes.
-```
+~~~~
 
 [approach-lock-statement]: https://exercism.org/tracks/csharp/exercises/bank-account/approaches/lock-statement
 [approach-mutex]: https://exercism.org/tracks/csharp/exercises/bank-account/approaches/mutex

--- a/exercises/practice/bank-account/.approaches/lock-statement/content.md
+++ b/exercises/practice/bank-account/.approaches/lock-statement/content.md
@@ -34,9 +34,9 @@ private decimal _balance;
 private bool _isOpen;
 ```
 
-```exercism/caution
+~~~~exercism/caution
 When dealing with monetary amount, _always_ use `decimal` instead of `float` or `double`, as the later suffer from rounding errors.
-```
+~~~~
 
 The `Open()` and `Close()` methods change the open state:
 
@@ -101,7 +101,7 @@ lock (_lock)
 
 As our lock object is unique per instance of the `BankAccount` class, we won't have any issues with locking other bank accounts when we lock on that object.
 
-````exercism/note
+~~~~exercism/note
 The `lock` statement is syntactic sugar for calls to `Monitor.Enter()` and `Monitor.Exit()`, using a `try/finally` block.
 
 ```csharp
@@ -124,7 +124,7 @@ finally
     Monitor.Exit(_lock);
 }
 ```
-````
+~~~~
 
 ## Shortening
 

--- a/exercises/practice/bank-account/.approaches/mutex/content.md
+++ b/exercises/practice/bank-account/.approaches/mutex/content.md
@@ -43,9 +43,9 @@ private decimal _balance;
 private bool _isOpen;
 ```
 
-```exercism/caution
+~~~~exercism/caution
 When dealing with monetary amount, _always_ use `decimal` instead of `float` or `double`, as the later suffer from rounding errors.
-```
+~~~~
 
 The `Open()` and `Close()` methods change the open state:
 

--- a/exercises/practice/bob/.approaches/answer-array/content.md
+++ b/exercises/practice/bob/.approaches/answer-array/content.md
@@ -28,11 +28,11 @@ The correct answer is selected from the array by using the score as the array in
 The `String` [TrimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-```exercism/caution
+~~~~exercism/caution
 Note that a `null` `string` would be different from a `string` of all whitespace.
 A `null` `string` would throw an `Exception` if `TrimEnd` were applied to it.
 To test a string that might be `null` or only whitespace, the [IsNullOrWhiteSpace](https://learn.microsoft.com/en-us/dotnet/api/system.string.isnullorwhitespace) method of `String` would be used.
-```
+~~~~
 
 The first half of the shout condition 
 

--- a/exercises/practice/bob/.approaches/if/content.md
+++ b/exercises/practice/bob/.approaches/if/content.md
@@ -60,11 +60,11 @@ This is because the second half of the condition tests that the uppercased input
 If the input were only `"123"` it would equal itself uppercased, but without letters it would not be a yell.
 The uppercasing is done by using the `String` method [ToUpperInvariant][toupperinvariant].
 
-```exercism/note
+~~~~exercism/note
 The invariant culture represents a culture that is culture-insensitive.
 It is associated with the English language but not with a specific country or region.
 For more information, see the [CultureInfo.InvariantCulture](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.invariantculture) property.
-```
+~~~~
 
 ## Extension methods
 

--- a/exercises/practice/bob/.approaches/regular-expressions/content.md
+++ b/exercises/practice/bob/.approaches/regular-expressions/content.md
@@ -42,11 +42,11 @@ public static class Bob
 In this approach you have a series of `if` statements using private methods that use [regular expressions][regular-expressions] to evaluate the conditions.
 As soon as the right condition is found, the correct response is returned.
 
-```exercism/note
+~~~~exercism/note
 Note that there are no `else if` or `else` statements.
 If an `if` statement returns, then an `else if` or `else` is not needed.
 Execution will either return or will continue to the next statement anyway.
-```
+~~~~
 
 ### Silence
 
@@ -60,9 +60,9 @@ To match on this regular expression, we use [`Regex.IsMatch()`][regex-ismatch], 
 Regex.IsMatch(message, @"^\s*$");
 ```
 
-```exercism/note
+~~~~exercism/note
 When defining regular expression patterns, consider defining them with a verbatim string literal (prefixed with `@`) to prevent having to escape any backslash characters.
-```
+~~~~
 
 ### Yell
 

--- a/exercises/practice/bob/.approaches/switch-on-tuple/content.md
+++ b/exercises/practice/bob/.approaches/switch-on-tuple/content.md
@@ -30,11 +30,11 @@ The `switch` returns the right response for a question, shout, shouted question,
 The `String` [TrimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-```exercism/caution
+~~~~exercism/caution
 Note that a `null` `string` would be different from a `string` of all whitespace.
 A `null` `string` would throw an `Exception` if `TrimEnd` were applied to it.
 To test a `string` that might be `null` or only whitespace, the [IsNullOrWhiteSpace](https://learn.microsoft.com/en-us/dotnet/api/system.string.isnullorwhitespace) method of `String` would be used.
-```
+~~~~
 
 Next a [tuple][tuple] is made from the conditions for a queston and a shout.
 The first half of the shout condition

--- a/exercises/practice/collatz-conjecture/.approaches/recursion/content.md
+++ b/exercises/practice/collatz-conjecture/.approaches/recursion/content.md
@@ -39,7 +39,7 @@ The next step is to call the overload `Steps()` method and return its value.
 return Steps(number, 0);
 ```
 
-````exercism/note
+~~~~exercism/note
 For someone new to the code, it might not be clear what the `0` argument in the `Steps(number, 0)` call represents.
 You could introduce an appropriately named variable and use that as the argument:
 
@@ -53,7 +53,7 @@ This is already much better, but another option is to use a [named argument](htt
 ```csharp
 return Steps(number, stepCount: 0);
 ```
-````
+~~~~
 
 Let's examine the overload `Steps()` method, which looks like this:
 

--- a/exercises/practice/collatz-conjecture/.approaches/sequence/content.md
+++ b/exercises/practice/collatz-conjecture/.approaches/sequence/content.md
@@ -71,9 +71,9 @@ private static IEnumerable<int> Sequence(int number)
 
 First, we start out with assigning the `number` parameter to a `currentNumber` variable, which we'll use to keep track of where in the collatz conjecture sequence we currently are.
 
-```exercism/note
+~~~~exercism/note
 Re-assiging values to a parameter _is_ possible, but it is considered good practice to not do that.
-```
+~~~~
 
 Then a `while` loop starts by checking whether the current number is not equal to `1`; if it is, the method terminates:
 
@@ -102,9 +102,9 @@ Note that even though we are yield indidivual elements, what is returned from a 
 Methods that use a `yield` statement are also _lazy_, which means that calling `Sequence(number)` by itself does not do anything.
 It is only when we call `Count()` on the sequence, that we're forcing iteration over the elements in the sequence.
 
-```exercism/note
+~~~~exercism/note
 Using `yield` statement to generate a lazy sequence allows one to work with "infinite" sequences efficiently, as only the element to be returned (and the generated state machine) take up memory.
-```
+~~~~
 
 ## Shortening
 

--- a/exercises/practice/collatz-conjecture/.approaches/while-loop/content.md
+++ b/exercises/practice/collatz-conjecture/.approaches/while-loop/content.md
@@ -45,9 +45,9 @@ var currentNumber = number;
 var stepCount = 0;
 ```
 
-```exercism/note
+~~~~exercism/note
 Re-assiging values to a parameter _is_ possible, but it is considered good practice to not do that.
-```
+~~~~
 
 Then a `while` loop starts by checking whether the current number is not equal to `1`; if it is, the method terminates:
 

--- a/exercises/practice/diffie-hellman/.approaches/big-integer/content.md
+++ b/exercises/practice/diffie-hellman/.approaches/big-integer/content.md
@@ -31,9 +31,9 @@ public static BigInteger PrivateKey(BigInteger p)
 
 This will generate a number `>= 1` and `< p`.
 
-```exercism/note
+~~~~exercism/note
 The `Random.Shared` instance if guaranteed to be thread-safe, so is usually preferrable over creating your own `Random` instance.
-```
+~~~~
 
 ## Calculate public key and secret
 

--- a/exercises/practice/gigasecond/.approaches/introduction.md
+++ b/exercises/practice/gigasecond/.approaches/introduction.md
@@ -7,9 +7,9 @@ As C# `DateTime` instances are immutable, this means that you'll need to return 
 
 A gigasecond is equal to one billion seconds, which we can write as `1_000_000_000`.
 
-```exercism/note
+~~~~exercism/note
 Using underscores as digit separators can help make large numbers a lot more readable.
-```
+~~~~
 
 Alternative, scientific notation can be used for a more compact notation: `1e9`.
 

--- a/exercises/practice/grade-school/.approaches/sorted-collections/content.md
+++ b/exercises/practice/grade-school/.approaches/sorted-collections/content.md
@@ -78,9 +78,9 @@ else
     _roster[grade] = new SortedSet<string> { student };
 ```
 
-```exercism/note
+~~~~exercism/note
 Not that we don't worry about sorting, this will all happen transparently due to our choice of data structures.
-```
+~~~~
 
 We could also rewrite this to:
 
@@ -161,14 +161,14 @@ public IEnumerable<string> Grade(int grade)
 }
 ```
 
-```exercism/note
+~~~~exercism/note
 The pattern of checking if a dictionary contains a key followed by accessing that value by key after that check is slightly wasteful, as it will require accessing the dictionary twice.
 For this pattern, you should instead use `TryGetValue()`, which returns a `bool` value indicating if the key exists and has an `out` parameter for the retrieved value (if any)
-```
+~~~~
 
-```exercism/note
+~~~~exercism/note
 We're using [`Enumerable.Empty<string>()`](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.empty), which is best practice when returning an empty enumerable (for performance reasons).
-```
+~~~~
 
 With this knowledge, let's rewrite out method a bit:
 

--- a/exercises/practice/hamming/.approaches/for-loop/content.md
+++ b/exercises/practice/hamming/.approaches/for-loop/content.md
@@ -42,9 +42,9 @@ We then use a [`for`-loop][for-statement] to iterate over each index of the firs
 for (var i = 0; i < strand1.Length; i++)
 ```
 
-```exercism/note
+~~~~exercism/note
 We could equally well have used `i < strand2.Length`, as both strings are guaranteed to have the same length.
-```
+~~~~
 
 Within the loop, we can then use a simple [`if`-statement][if-statement] to check if the two strings have different characters at the specified index, and if so, increment the `distance` by one:
 

--- a/exercises/practice/parallel-letter-frequency/.approaches/as-parallel/content.md
+++ b/exercises/practice/parallel-letter-frequency/.approaches/as-parallel/content.md
@@ -74,9 +74,9 @@ else
 
 We use `TryGetValue()` to check if there already is an existing count associated with the key, and if so, we increment the existing value, otherwise we'll assign a new value.
 
-```exercism/note
+~~~~exercism/note
 You don't have to worry about any concurrent updates to the dictionary, PLINQ will handle this for you.
-```
+~~~~
 
 Finally, we'll return the updated accumulator value:
 

--- a/exercises/practice/pig-latin/.approaches/regular-expressions/content.md
+++ b/exercises/practice/pig-latin/.approaches/regular-expressions/content.md
@@ -107,10 +107,10 @@ The regex pattern then becomes:
 
 As we are now using a backslash that should be interpreted as an escape character, we prefix the string with the `@` character, making it a [_verbatim string_](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim).
 
-```exercism/note
+~~~~exercism/note
 Verbatim strings ensure that characters like a backslash are not interpreted as escape characters, but instead inserted literally.
 This is especially convenient when working with regular expressions, as one often uses backslashes.
-```
+~~~~
 
 The next step is to replace all the words in our sentence using our regex pattern, which we can do with [`Regex.Replace()`][regex-replace].
 This method takes an input, a matching pattern _and_ a replacement pattern.

--- a/exercises/practice/proverb/.approaches/for-loop/content.md
+++ b/exercises/practice/proverb/.approaches/for-loop/content.md
@@ -61,9 +61,9 @@ var lines = new string[subjects.Length];
 
 To reiterate, there will be one line in the returned array for each adjacent subject pair.
 
-```exercism/note
+~~~~exercism/note
 Breaking up of a collection into adjacent sub-collection of a certain size of sometimes also referred to as a _sliding window_.
-```
+~~~~
 
 Let's look at an example, where the subjects array contains `"nail"`, `"shoe"` and `"horse"`.
 There are two adjacent subject pairs in this array:

--- a/exercises/practice/proverb/.approaches/linq/content.md
+++ b/exercises/practice/proverb/.approaches/linq/content.md
@@ -47,9 +47,9 @@ if (!subjects.Any())
     return Array.Empty<string>();
 ```
 
-```exercism/note
+~~~~exercism/note
 As the `!` operator can be easy to miss whilst reading code, try to write code that doesn't use negation (where possible).
-```
+~~~~
 
 ## Subjects: one
 
@@ -74,9 +74,9 @@ This has the benefit of being more expressive _and_ would also work for collecti
 Handling multiple subjects is where the fun begins!
 To reiterate, there will be one line in the returned array for each adjacent subject pair.
 
-```exercism/note
+~~~~exercism/note
 Breaking up of a collection into adjacent sub-collection of a certain size of sometimes also referred to as a _sliding window_.
-```
+~~~~
 
 Let's look at an example, where the subjects array contains `"nail"`, `"shoe"` and `"horse"`.
 There are two adjacent subject pairs in this array:
@@ -94,9 +94,9 @@ We can use a little trick by calling the [`Zip()` method][enumerable.zip] on the
 
 What `Zip()` does is that it works on two enumerables and creates a new enumerable where element is a pair (tuple) of values, the first element being the n-th value of the first enumerable and the second element being the n-th value of the second enumerable.
 
-```exercism/note
+~~~~exercism/note
 The number of elements returned by `Zip()` is equal to the minimum of the lengths of both enumerables.
-```
+~~~~
 
 As an example:
 

--- a/exercises/practice/reverse-string/.approaches/array-reverse/content.md
+++ b/exercises/practice/reverse-string/.approaches/array-reverse/content.md
@@ -16,10 +16,10 @@ public static class ReverseString
 
 The `string` class' [`ToCharArray()`][to-char-array] method returns the string's characters as a `char[]`.
 
-```exercism/caution
+~~~~exercism/caution
 The `char[]` returned by `ToCharArray()` is a **copy** of the `string`'s characters.
 Modifying the values in the `char[]` does **not** update the `string` it was created from.
-```
+~~~~
 
 We then pass the `char[]` to the [`Array.Reverse()`][array-reverse] method, which will reverse the array's content _in-place_ (meaning the argument is modified).
 

--- a/exercises/practice/reverse-string/.approaches/introduction.md
+++ b/exercises/practice/reverse-string/.approaches/introduction.md
@@ -8,10 +8,10 @@ The key to this exercise is to reverse a string's characters whilst C# strings b
 
 - The most common way to create a new `string` (apart from hardcoding a string literal) is to call the [constructor that takes an array of characters][constructor-array-chars] (`char []`).
 
-```exercism/note
+~~~~exercism/note
 C# strings represent text as a sequence of UTF-16 code units.
 This means that you don't have to worry about multi-byte Unicode characters, as those are treated as one character.
-```
+~~~~
 
 ## Approach: LINQ
 

--- a/exercises/practice/reverse-string/.approaches/span/content.md
+++ b/exercises/practice/reverse-string/.approaches/span/content.md
@@ -39,10 +39,10 @@ Span<char> chars = stackalloc char[input.Length];
 
 With this version, the memory allocated for the `Span<char>` is all on the stack and no garbage collection is needed for that data.
 
-```exercism/caution
+~~~~exercism/caution
 The stack has a finite amount of memory.
 This means that for large strings, the above code will result in a `StackOverflowException` being thrown.
-```
+~~~~
 
 So what is the limit for the amount of memory we can allocate?
 Well, this depends on how memory has already been allocated on the stack.

--- a/exercises/practice/reverse-string/.approaches/string-builder/content.md
+++ b/exercises/practice/reverse-string/.approaches/string-builder/content.md
@@ -20,9 +20,9 @@ public static class ReverseString
 Strings can also be created using the [`StringBuilder`][string-builder] class.
 The purpose of this class is to efficiently and incrementally build a `string`.
 
-```exercism/note
+~~~~exercism/note
 A `StringBuilder` is often overkill when used to create short strings, but can be very useful to create larger strings.
-```
+~~~~
 
 The first step is to create a `StringBuilder`.
 We then use a `for`-loop to walk through the string's characters in reverse order, appending them to the `StringBuilder` via its [`Append()`][string-builder-append] method.

--- a/exercises/practice/reverse-string/.articles/performance/content.md
+++ b/exercises/practice/reverse-string/.articles/performance/content.md
@@ -105,9 +105,9 @@ The `Span<T>` approach has the downside of being more error-prone to write and f
 
 The two slowest approaches, LINQ and `StringBuilder`, are also the ones that allocate (the most) memory.
 
-```exercism/note
+~~~~exercism/note
 Reducing memory allocation is often a great way to improve performance.
-```
+~~~~
 
 [approaches]: https://exercism.org/tracks/csharp/exercises/reverse-string/approaches
 [approach-linq]: https://exercism.org/tracks/csharp/exercises/reverse-string/approaches/linq

--- a/exercises/practice/series/.approaches/for-loop/content.md
+++ b/exercises/practice/series/.approaches/for-loop/content.md
@@ -53,14 +53,14 @@ The value we're returning is the substring of the input that starts at index `i`
 The `yield` statement then returns the slice to the caller.
 Even though we yield an indidivual string, what is returned from a caller's viewpoint is a sequence of strings.
 
-```exercism/note
+~~~~exercism/note
 When a `yield` statement is written, the compiler transforms the method into a state machine that is suspended after each yield statement.
-```
+~~~~
 
-```exercism/note
+~~~~exercism/note
 Methods that use a `yield` statement are also _lazy_, which means that calling `Sequence(number)` by itself does not do anything.
 It is only when a method is called that forces evaluation (like `Count()` or `ToArray()`), that we're forcing iteration over the elements in the sequence.
-```
+~~~~
 
 ## Shortening
 

--- a/exercises/practice/sieve/.approaches/bit-array/content.md
+++ b/exercises/practice/sieve/.approaches/bit-array/content.md
@@ -117,14 +117,14 @@ yield return i;
 
 Note that even though we yield an indidivual integer, what is returned from a caller's viewpoint is a sequence of integers.
 
-```exercism/note
+~~~~exercism/note
 When a `yield` statement is written, the compiler transforms the method into a state machine that is suspended after each yield statement.
-```
+~~~~
 
-```exercism/note
+~~~~exercism/note
 Methods that use a `yield` statement are also _lazy_, which means that calling `Sequence(number)` by itself does not do anything.
 It is only when a method is called that forces evaluation (like `Count()` or `ToArray()`), that we're forcing iteration over the elements in the sequence.
-```
+~~~~
 
 [yield-statement]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/yield
 [bit-array]: https://learn.microsoft.com/en-us/dotnet/api/system.collections.bitarray

--- a/exercises/practice/sieve/.approaches/hash-set/content.md
+++ b/exercises/practice/sieve/.approaches/hash-set/content.md
@@ -72,14 +72,14 @@ yield return i;
 
 Note that even though we yield an indidivual integer, what is returned from a caller's viewpoint is a sequence of integers.
 
-```exercism/note
+~~~~exercism/note
 When a `yield` statement is written, the compiler transforms the method into a state machine that is suspended after each yield statement.
-```
+~~~~
 
-```exercism/note
+~~~~exercism/note
 Methods that use a `yield` statement are also _lazy_, which means that calling `Sequence(number)` by itself does not do anything.
 It is only when a method is called that forces evaluation (like `Count()` or `ToArray()`), that we're forcing iteration over the elements in the sequence.
-```
+~~~~
 
 [yield-statement]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/yield
 [hash-set]: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1

--- a/exercises/practice/two-bucket/.approaches/graph-shortest-path/content.md
+++ b/exercises/practice/two-bucket/.approaches/graph-shortest-path/content.md
@@ -280,9 +280,9 @@ foreach (var newState in Moves(state))
 What we do here is to iterate over all the state's moves, as returned by the `Moves()` method (we'll get to its implementation in a bit).
 Then, for each move's state, we check if its number of moves is greater or equal to the current minimum number of moves for those bucket contents.
 
-```exercism/note
+~~~~exercism/note
 We use `int.MaxValue` as the default value for when no minimum number of moves have yet been found for the node, which should always be greater than the node's actual moves.
-```
+~~~~
 
 If the node's moves _are_ greater than or equal to the current minimum number of moves, we don't process the node as there is another, shorter path to that node.
 Otherwise, we'll update the minimum number of moves for the node and add it to the unprocessed states queue.
@@ -314,11 +314,11 @@ if (state.Buckets.One == 0)
 
 After checking if `state.Buckets.One` equals zero (meaning: bucket one is empty), we return a new state where the number of moves is incremented (after all, we've just applied a move), the first bucket is filled to its capacity and the second bucket is left unchanged.
 
-```exercism/note
+~~~~exercism/note
 We use a [`yield` statement](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/yield) to _yield_ the state.
 When a `yield` statement is written, the compiler transforms the method into a state machine that is suspended after each yield statement.
 Even though we yield indidivual elements, what is returned from a caller's viewpoint is a sequence of elements.
-```
+~~~~
 
 ### Move: fill bucket two when bucket two is empty and bucket one is not empty
 
@@ -463,10 +463,10 @@ to:
 var initialState = (Moves: 0, Buckets: (One: 0, Two: 0));
 ```
 
-```exercism/note
+~~~~exercism/note
 We have given our [tuple fields a name](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-tuples#tuple-field-names)
 This is not strictly necessary, but `initialState.Moves` is definitely more descriptive than `initialState.Item1`.
-```
+~~~~
 
 We then apply the same logic to the state creation in the `Moves()` method.
 As an example, this code:

--- a/exercises/practice/two-fer/.articles/optional-parameters-vs-method-overloading/content.md
+++ b/exercises/practice/two-fer/.articles/optional-parameters-vs-method-overloading/content.md
@@ -33,9 +33,9 @@ public static string Speak(string name = "you")
 Using an optional parameter, we can assign a default value to that parameter which is then used if no value is passed for that parameter: `Speak()` and `Speak("you")` are equivalent.
 This new syntax allowed for a more succinct way of defining default values for parameters.
 
-```exercism/note
+~~~~exercism/note
 Method overloading can do everything optional parameters can do, but the latter are arguably easier to read and write.
-```
+~~~~
 
 ## What are the differences?
 
@@ -164,9 +164,9 @@ The big differences are that the generated IL code:
 
 This demonstrates that optional parameters are _not_ overloaded methods in disguise.
 
-```exercism/note
+~~~~exercism/note
 Note how the interpolated string is actually converted to a `string.Concat` call in the IL code.
-```
+~~~~
 
 ## Conclusion
 


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

I'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705