### PR TITLE
Fix brackets in Developers Dictionary description

### DIFF
--- a/exercises/concept/developer-privileges/.docs/instructions.md
+++ b/exercises/concept/developer-privileges/.docs/instructions.md
@@ -34,7 +34,7 @@ Implement the `Authenticator.Developers()` method to return the developers' iden
 ```csharp
 var authenticator = new Authenticator();
 authenticator.Developers;
-// => {"Bertrand" = {"bert@ex.ism", {"blue", 0.8m}, ["Bertrand", "Paris", "France"]},
-// ["Anders" = {"anders@ex.ism", {"brown", 0.85m}, ["Anders", "Redmond", "USA"]},
+// => ["Bertrand"] = {"bert@ex.ism", {"blue", 0.8m}, ["Bertrand", "Paris", "France"]},
+// ["Anders"] = {"anders@ex.ism", {"brown", 0.85m}, ["Anders", "Redmond", "USA"]},
 
 ```


### PR DESCRIPTION
The description of the content of the Developers Dictionary was written in a inconsistent syntax.

The number of opening brackets and braces didn't match the corresponding number of closing brackets and braces.

I wrote both items in a uniform `[key] = value` syntax.