### PR TITLE
Fix prefix description in Log Files Description

### DIFF
--- a/exercises/concept/parsing-log-files/.docs/instructions.md
+++ b/exercises/concept/parsing-log-files/.docs/instructions.md
@@ -90,7 +90,7 @@ Lines with quoted passwords have already been removed and you process lines irre
 
 Lines containing an offending password should be returned prefixed with "<password>: ".
 
-Lines not containing an offending password should be returned prefixed with "-------: ".
+Lines not containing an offending password should be returned prefixed with "--------: ".
 
 ```csharp
 var lp = new LogParser();


### PR DESCRIPTION
The lines not containing an offending password should be returned prefixed with `"--------: "`, and so does the unit test expect.

I fixed the prefix in the exercise description, which was missing one "-".