### PR TITLE
fix: update expected value for unit test on Attack of the Trolls

### DIFF
--- a/exercises/concept/attack-of-the-trolls/AttackOfTheTrollsTests.cs
+++ b/exercises/concept/attack-of-the-trolls/AttackOfTheTrollsTests.cs
@@ -151,7 +151,7 @@ public class AttackOfTheTrollsTests
     [Task(4)]
     public void Check_all_for_read_and_write()
     {
-        Assert.True(Permissions.Check(Permission.Read | Permission.Write, Permission.Read | Permission.Write));
+        Assert.True(Permissions.Check(Permission.All, Permission.Read | Permission.Write));
     }
 
     [Fact]


### PR DESCRIPTION
One of the test case for the 4th task of the exercise [Attack of the Trolls](https://exercism.org/tracks/csharp/exercises/attack-of-the-trolls) had a wrong expected case. 
Specifically the test case `Check_all_for_read_and_write()` should have `Permission.All` as expected value instead of `Permission.Read | Permission.Write`.