### PR TITLE
fix: change typo in Developer Privileges instructions

### DIFF
--- a/exercises/concept/developer-privileges/.docs/instructions.md
+++ b/exercises/concept/developer-privileges/.docs/instructions.md
@@ -29,7 +29,7 @@ The developers' details are as follows:
 | bert@ex.ism   | blue      | 0.8            | Bertrand | Paris     | France    |
 | anders@ex.ism | brown     | 0.85           | Anders   | Redmond   | USA       |
 
-Implement the `Authenticator.Developers()` method to return the developers' identity details. The dictionary key is the developer's name.
+Implement the `Authenticator.Developers` property to return the developers' identity details. The dictionary key is the developer's name.
 
 ```csharp
 var authenticator = new Authenticator();


### PR DESCRIPTION
The second task in the exercise "Developer Privileges" has a typo: it refers to `Authenticator.Developers` as a method but it is a property.