### PR TITLE
Salvatore piccione patch 1

### DIFF
--- a/exercises/concept/authentication-system/.meta/Exemplar.cs
+++ b/exercises/concept/authentication-system/.meta/Exemplar.cs
@@ -40,7 +40,7 @@ public class Authenticator
         get { return new Identity { Email = admin.Email, EyeColor = admin.EyeColor }; }
     }
 
-    public IReadOnlyDictionary<string, Identity> GetDevelopers()
+    public IDictionary<string, Identity> GetDevelopers()
     {
         return new ReadOnlyDictionary<string, Identity>(developers);
     }

--- a/exercises/concept/authentication-system/AuthenticationSystemTests.cs
+++ b/exercises/concept/authentication-system/AuthenticationSystemTests.cs
@@ -15,6 +15,17 @@ public class AuthenticationSystemTests
     }
 
     [Fact]
+    [Task(4)]
+    public void CheckAdminCannotBeTampered()
+    {
+        var admin = new Identity { EyeColor = "green", Email = "admin@ex.ism" };
+        var authenticator = new Authenticator(admin);
+        var tamperedAdmin = authenticator.Admin;
+        tamperedAdmin.Email = "admin@hack.ed";
+        Assert.NotEqual(tamperedAdmin.Email, authenticator.Admin.Email);
+    }
+
+    [Fact]
     [Task(5)]
     public void GetDevelopers()
     {
@@ -23,5 +34,23 @@ public class AuthenticationSystemTests
         bool?[] actual = { devs != null, devs?.Count == 2, devs?["Anders"].EyeColor == "brown" };
         bool?[] expected = { true, true, true };
         Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    [Task(5)]
+    public void CheckDevelopersCannotBeTampered()
+    {
+        var authenticator = new Authenticator(new Identity { EyeColor = "green", Email = "admin@ex.ism" });
+        IDictionary<string, Identity> devs = authenticator.GetDevelopers();
+
+        Identity tamperedDev = new Identity { EyeColor = "grey", Email = "anders@hack.ed" };
+        try
+        {
+            devs["Anders"] = tamperedDev;
+            Assert.True(false, "Unexpected change to developers list.");
+        } catch (NotSupportedException)
+        {
+            Assert.True(true);            
+        }
     }
 }


### PR DESCRIPTION
Tests for `Authentication System` exercises 4 and 5 can be improved by trying to actually tamper the data to ensure that the expected changes have been done. This PR adds two test cases:

- the former is about the tampering check on the admin
- the latter is about the tampering of developers by replacing an element in the dictionary

Exemplar solution has been updated to be more inline with the exercise request (i.e. `getDevelopers()` returns an instance of the interface `IDictionary` despite of an instance of `ReadOnlyDictionary`).