### PR TITLE
Sync fetch-configlet.ps1 script

### DIFF
--- a/bin/fetch-configlet.ps1
+++ b/bin/fetch-configlet.ps1
@@ -1,34 +1,42 @@
+# This file is a copy of the
+# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1 file.
+# Please submit bugfixes/improvements to the above file to ensure that all tracks
+# benefit from the changes.
+
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-if ($PSVersionTable.PSVersion.Major -le 5) {
-    # PreserveAuthorizationOnRedirect requires PowerShell Core 7+
-    # TODO create a tool that install pwsh in the directory https://docs.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use
-    throw "Please run with PowerShell Core 'pwsh'. If you need to install pwsh globally: 'dotnet tool install --global PowerShell'"
-}
-
-function Get-DownloadUrl($FileName, $RequestOpts) {
-    $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
-    $assets = Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @RequestOpts | Select-Object -ExpandProperty assets
-    return $assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url -First 1
-}
-
-# Use GITHUB_TOKEN to download the configlet metadata and binaries from github releases for github actions.
 $requestOpts = @{
     Headers           = If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
     MaximumRetryCount = 3
     RetryIntervalSec  = 1
 }
+
+Function Get-DownloadUrl {
+    $arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
+    $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
+    Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts `
+    | Select-Object -ExpandProperty assets `
+    | Where-Object { $_.name -match "^configlet_.+_windows_${arch}.zip$" } `
+    | Select-Object -ExpandProperty browser_download_url -First 1
+}
+
 $outputDirectory = "bin"
-$arch = If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
-$fileName = "configlet-windows-$arch.zip"
+if (!(Test-Path -Path $outputDirectory)) {
+    Write-Output "Error: no ./bin directory found. This script should be ran from a repo root."
+    exit 1
+}
 
-Write-Output "Fetching configlet download URL"
-$downloadUrl = Get-DownloadUrl -FileName $fileName -RequestOpts $requestOpts
-$outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
+Write-Output "Fetching configlet..."
+$downloadUrl = Get-DownloadUrl
+$outputFileName = "configlet.zip"
+$outputPath = Join-Path -Path $outputDirectory -ChildPath $outputFileName
+Invoke-WebRequest -Uri $downloadUrl -OutFile $outputPath @requestOpts
 
-Write-Output "Fetching configlet binaries"
-# Use PreserveAuthorizationOnRedirect named parameter doesn't work on WSL
-Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts
-Expand-Archive -Path $outputFile -DestinationPath $outputDirectory -Force
-Remove-Item -Path $outputFile
+$configletPath = Join-Path -Path $outputDirectory -ChildPath "configlet.exe"
+if (Test-Path -Path $configletPath) { Remove-Item -Path $configletPath }
+[System.IO.Compression.ZipFile]::ExtractToDirectory($outputPath, $outputDirectory)
+Remove-Item -Path $outputPath
+
+$configletVersion = (Select-String -Pattern "/releases/download/(.+?)/" -InputObject $downloadUrl -AllMatches).Matches.Groups[1].Value
+Write-Output "Downloaded configlet ${configletVersion} to ${configletPath}"

--- a/exercises/practice/reverse-string/.approaches/span/content.md
+++ b/exercises/practice/reverse-string/.approaches/span/content.md
@@ -1,12 +1,20 @@
 # Span&lt;T&gt;
 
 ```csharp
-Span<char> chars = stackalloc[input.Length];
-for (var i = 0; i < input.Length; i++)
+public static class ReverseString
 {
-    chars[input.Length - 1 - i] = input[i];
+    public static string Reverse(string input)
+    {
+        Span<char> chars = stackalloc[input.Length];
+
+        for (var i = 0; i < input.Length; i++)
+        {
+            chars[input.Length - 1 - i] = input[i];
+        }
+
+        return new string(chars);
+    }
 }
-return new string(chars);
 ```
 
 C# 7.2. introduced the [`Span<T>`][span-t] class, which was specifically designed to allow performant iteration/mutation of _array-like_ objects.


### PR DESCRIPTION
This PR updates the bin/fetch-configlet.ps1 script to the latest version. This fixes the issue mentioned in this forum post: https://forum.exercism.org/t/problem-running-the-powershell-version-of-fetch-configlet/8383.

References https://github.com/exercism/configlet/issues/839