### PR TITLE
Show Test Report Summary in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,7 @@ jobs:
         with:
           dotnet-version: "7.0.100"
       - run: pwsh ./test.ps1
+      - uses: test-summary/action@fee35d7df20790255fe6aa92cf0f6d28092ecf2f
+        with:
+          paths: build/**/results/**/*.xml
+        if: always()


### PR DESCRIPTION
### Description
This PR aims to resolve #1949.

### Changes
* Added [test-summary/action](https://github.com/test-summary/action) to the `Test` workflow
* Added `JunitXml.TestLogger` as a dependency to all existing exercises
* Added `JunitXml.TestLogger` as a dependency to new exercises via the `add-new-exercise.ps1` script
* Updated the `test.ps1` script to use the test logger when the `CI` environment variable evaluates to `true`

### Notes
Since the tests do not specify a namespace, the logger defaults to `UnknownNamespace`. [Here](https://github.com/putquo/csharp/actions/runs/7678263985) is an example of what this looks like.