### PR TITLE
Fix typos and faulty hyperlink

### DIFF
--- a/exercises/practice/accumulate/.docs/instructions.append.md
+++ b/exercises/practice/accumulate/.docs/instructions.append.md
@@ -1,10 +1,10 @@
 # Instructions append
 
-To be more specific, you are not allowed to use any of the built-in [LINQ methods](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable
+To be more specific, you are not allowed to use any of the built-in [LINQ methods](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable).
 
 ## Laziness test
 
-Since `accumulate` returns an `IEnumerable`, it's execution is deferred until `ToList()` it is called on it, which is tested with the `Accumulate_is_lazy` method
+Since `accumulate` returns an `IEnumerable`, its execution is deferred until `ToList()` it is called on it, which is tested with the `Accumulate_is_lazy` method.
 
 ## Hints
 


### PR DESCRIPTION
The LINQ methods hyperlink should now work as intended. 
It's should be written its.