### PR TITLE
Fix about.md typos

### DIFF
--- a/concepts/const-readonly/about.md
+++ b/concepts/const-readonly/about.md
@@ -2,14 +2,19 @@
 
 By default, values in C# are _mutable_, that is they can change over time. To make a value _immutable_, there are two options:
 
-1. Add the [`const` modifier](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/const)
-2. Add the [`readonly` modifier](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/readonly#readonly-field-example)
+1. Add the [`const` modifier][const-modifier].
+2. Add the [`readonly` modifier][readonly-modifier].
 
 The `const` modifier has some restrictions:
 
 1. It can only be applied to "constant" types: strings, booleans and numbers.
 1. The `const` value must be initialized immediately.
 
-See [definining constants](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/how-to-define-constants) for more information.
+See [defining constants][defining-constants] for more information.
 
 If your value is a non-constant type or you need to initialize the value in a constructor, `readonly` can be used to enforce immutability.
+
+[const-modifier]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/const
+[readonly-modifier]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/readonly#readonly-field-example
+[defining-constants]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/how-to-define-constants
+

--- a/concepts/constants/about.md
+++ b/concepts/constants/about.md
@@ -60,7 +60,7 @@ To ensure that all members of a reference type are protected the fields can be m
 
 You should examine [read-only collections][readonly-collections] in the Base Class Library.
 
-For arrays the closest you can get to a read-only version is the [`Array.AsReadOnly<T>()][as-read-only] method.
+For arrays the closest you can get to a read-only version is the [`Array.AsReadOnly<T>()`][as-read-only] method.
 
 [readonly-fields]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/readonly#readonly-field-example
 [constants]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/constants

--- a/concepts/enumerables/about.md
+++ b/concepts/enumerables/about.md
@@ -1,6 +1,7 @@
 # About
 
-Types that implement the [`IEnumerable<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1
+Types that implement the [`IEnumerable<T>`][IEnumerable] interface are known as being _enumerable_.
+All built-in collection types implement this interface.
 
 An enumerable type can be iterated over using a `foreach` loop:
 
@@ -13,8 +14,12 @@ foreach (var prime in primes)
 // => 2357
 ```
 
-To implement `IEnumerable<T>`, a type has to implement one method: `IEnumerator<T> GetEnumerator()`. As seen, an enumerable defers the actual iterating over a collection to an `IEnumerator<T>` type. This interface has one property and three methods to implement:
+To implement `IEnumerable<T>`, a type has to implement one method: `IEnumerator<T> GetEnumerator()`.
+As seen, an enumerable defers the actual iterating over a collection to an `IEnumerator<T>` type.
+This interface has one property and three methods to implement:
 
 - `public T Current { get; }`: get the current element.
 - `public bool MoveNext ();`: move to the next element, returning `true` if the move to the next element was successful, and `false` if not (no more elements).
 - `public void Reset ();`: reset the enumerator to its initial state (before the first element).
+
+[IEnumerable]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1

--- a/concepts/flag-enums/about.md
+++ b/concepts/flag-enums/about.md
@@ -59,7 +59,7 @@ features.HasFlag(PhoneFeatures.Call); // => false
 features.HasFlag(PhoneFeatures.Text); // => true
 ```
 
-The [working with enums as bit flags tutorial][docs.microsoft.com-enumeration-types-as-bit-flags] goes into more detail how to work with flag enums. Another great resource is the [enum flags and bitwise operators page][alanzucconi.com-enum-flags-and-bitwise-operators].
+The [working with enums as bit flags tutorial][docs.microsoft.com-enumeration-types-as-bit-flags] goes into more detail how to work with flag enums. Another great resource is the [enum flags and bitwise operators page][enum-lags].
 
 By default, the `int` type is used for enum member values. One can use a different integer type by specifying the type in the enum declaration:
 
@@ -78,3 +78,4 @@ enum PhoneFeatures : byte
 [bitwise-complement-operator]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators#bitwise-complement-operator-
 [binary-literals]: https://riptutorial.com/csharp/example/6327/binary-literals
 [has-flag]: https://docs.microsoft.com/en-us/dotnet/api/system.enum.hasflag
+[enum-lags]: alanzucconi.com-enum-flags-and-bitwise-operators

--- a/concepts/parameters/about.md
+++ b/concepts/parameters/about.md
@@ -68,7 +68,7 @@ When studying the documentation note that it uses the following terms:
 
 Whilst `ref` is easy to use and has no performance penalties it is worth seeing how the problems it addresses are dealt with in a particular code base before using it widely. There are alternatives such as passing in by-value and using the value from the called method's return statement. Again, `tuples` can play a role.
 
-You will see from the [documentation][ref-parameter] that `out` and `ref` cannot be used in certain situations but you can ignore them for now. The compiler will let you know whwn such situations arise.
+You will see from the [documentation][ref-parameter] that `out` and `ref` cannot be used in certain situations but you can ignore them for now. The compiler will let you know when such situations arise.
 
 Note that `optional parameters` and `named arguments` are discussed in the `method-overloading` exercise.
 

--- a/concepts/readonly-collections/about.md
+++ b/concepts/readonly-collections/about.md
@@ -16,5 +16,8 @@ To ensure that all members of a reference type are protected the fields can be m
 
 The Base Class Library (BCL) provides some readonly versions of collections where there is a requirement to stop members of a collections being updated. These come in the form of wrappers:
 
-- [`ReadOnlyDictionary<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.readonlydictionary-2
-- [`ReadOnlyCollection<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.readonlycollection-1
+- [`ReadOnlyDictionary<T>`][ReadOnlyDictionary]
+- [`ReadOnlyCollection<T>`][ReadOnlyCollection]
+
+[ReadOnlyDictionary]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.readonlydictionary-2
+[ReadOnlyCollection]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.readonlycollection-1

--- a/concepts/sets/about.md
+++ b/concepts/sets/about.md
@@ -1,9 +1,12 @@
 # About
 
-A set is a collection of unique values. The default .NET implementation of a set is the [`HashSet<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1
+A set is a collection of unique values. The default .NET implementation of a set is the [`HashSet<T>`][HashSet].
 
-The `HashSet` class uses each element's [`GetHashCode()` method](https://docs.microsoft.com/en-us/dotnet/api/system.object.gethashcode
+The `HashSet` class uses each element's [`GetHashCode()` method][GetHashCode].
 
 By default, the `GetHashCode()` implementation for reference types returns a hash of its memory location. This means that different reference type objects will have a different hash code (this is known as reference equality). Value types by default return a hash of their fields/properties. This means that different value type objects with the same field/property values will have the same hash code (this is known as structural equality).
 
 You can override the `GetHashCode()` implementation on your own classes, which you could use to have a reference type have structural equality.
+
+[HashSet]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1
+[GetHashCode]: https://docs.microsoft.com/en-us/dotnet/api/system.object.gethashcode

--- a/concepts/structs/about.md
+++ b/concepts/structs/about.md
@@ -46,7 +46,7 @@ As a result of points 1 and 3 above there is no way for the developer of a `stru
 
 ## Common structs
 
-You will see from the documentation that there is a close relationship between primitives and structs. See [`Int32/int]`][int32], for an example. A more conventional example of a`struct`is the type [`TimeSpan`][time-span].
+You will see from the documentation that there is a close relationship between primitives and structs. See [`Int32/int`][int32], for an example. A more conventional example of a`struct`is the type [`TimeSpan`][time-span].
 
 Instances of `TimeSpan` behave much like numbers with comparison operators like `>` and `<` and arithmetic operators. You can implement these operators for your own `struct`s when you need them.
 

--- a/concepts/switch-expressions/about.md
+++ b/concepts/switch-expressions/about.md
@@ -29,5 +29,5 @@ An "arm" of the `switch` is selected when the pattern matches the range variable
 Switch expression also support [type patterns][pattern-matching] and recursive matching.
 
 [switch-expressions]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/switch-expression
-[switch-statement]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/switch
+[switch-statements]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/switch
 [pattern-matching]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/switch-expression#patterns-and-case-guards

--- a/concepts/time/about.md
+++ b/concepts/time/about.md
@@ -42,3 +42,5 @@ In case you were wondering, according to this [Wikipedia article][wiki-utc] the 
 [date-string-formatting]: https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings
 [time-span]: https://docs.microsoft.com/en-us/dotnet/api/system.timespan
 [wiki-utc]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[time-zone-info]: https://learn.microsoft.com/en-us/dotnet/api/system.timezoneinfo
+[cross-platform-time-zones]: https://devblogs.microsoft.com/dotnet/cross-platform-time-zones-with-net-core/

--- a/concepts/timezone/about.md
+++ b/concepts/timezone/about.md
@@ -1,7 +1,11 @@
 # About
 
-The [`TimeZoneInfo`](https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo
+The [`TimeZoneInfo`][TimeZoneInfo] class provides routines for handling the differences between time zones. The `TimeZoneInfo` class also contains methods that facilitate dealing with daylight saving time.
 
-The [`CultureInfo`](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo
+The [`CultureInfo`][CultureInfo] class supports locale dependent date time formats.
 
-To support cross-platform coding the [`RuntimeInformation`](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation
+To support cross-platform coding the [`RuntimeInformation`][RuntimeInformation] class allows you to detect which operating system your code is executing on, Linux, Windows or OSX.
+
+[TimeZoneInfo]: https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo
+[CultureInfo]: https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo
+[RuntimeInformation]: https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation


### PR DESCRIPTION
Mostly broken or missing links, also fixes the odd typo.