### PR TITLE
Correct wrong claim about StringBuilder performance.

### DIFF
--- a/exercises/practice/reverse-string/.approaches/introduction.md
+++ b/exercises/practice/reverse-string/.approaches/introduction.md
@@ -63,7 +63,7 @@ If readability is your primary concern (and it usually should be), the LINQ-base
 The `Array.Reverse()` approach is the best performing apporach.
 For a more detailed breakdown, check the [performance article][article-performance].
 
-The `StringBuilder` approach has the worst performance of the listed approach, and is more error-prone to write as it has to deal with lower and upper bounds checking.
+The `StringBuilder` approach has the second worst performance (after the LINQ-based) of the listed approach, and is more error-prone to write as it has to deal with lower and upper bounds checking.
 
 [constructor-array-chars]: https://learn.microsoft.com/en-us/dotnet/api/system.string.-ctor
 [article-performance]: https://exercism.org/tracks/csharp/exercises/reverse-string/articles/performance


### PR DESCRIPTION
The current text on the Dig Deeper article for the C# exercise "Reverse String" incorrectly says the `StringBuilder` approach has the worst performance of those listed, but it's actually the 2nd worst, behind the LINQ-based.

Probably just a typo, for which this PR provides a correction.