### PR TITLE
Adds Convert_kebab_to_camel_case_already_upper to Update SqueakyCleanTests

### DIFF
--- a/exercises/concept/squeaky-clean/SqueakyCleanTests.cs
+++ b/exercises/concept/squeaky-clean/SqueakyCleanTests.cs
@@ -46,6 +46,13 @@ public class SqueakyCleanTests
     }
 
     [Fact]
+    [Task(3)]
+    public void Convert_kebab_to_camel_case_already_upper()
+    {
+        Assert.Equal("àḂç", Identifier.Clean("à-Ḃç"));
+    }
+
+    [Fact]
     [Task(4)]
     public void Clean_string_with_special_characters()
     {


### PR DESCRIPTION
I noticed that the tests in the C# track for this exercise did not completely cover the requirement to convert kebab case to camel case, so I added this test.