### PR TITLE
Fix typo for Telemetry in remote-control-cleanup

### DIFF
--- a/exercises/concept/remote-control-cleanup/RemoteControlCleanup.cs
+++ b/exercises/concept/remote-control-cleanup/RemoteControlCleanup.cs
@@ -6,7 +6,7 @@ public class RemoteControlCar
 
     // TODO encapsulate the methods suffixed with "_Telemetry" in their own class
     // dropping the suffix from the method name
-    public void Calibrate_Telementry()
+    public void Calibrate_Telemetry()
     {
 
     }


### PR DESCRIPTION
Nothing major as it's going to be removed anyway to finish the exercise, but it's still a typo.