### PR TITLE
Update GameOfLifeTests.cs

### DIFF
--- a/exercises/practice/game-of-life/GameOfLifeTests.cs
+++ b/exercises/practice/game-of-life/GameOfLifeTests.cs
@@ -83,18 +83,18 @@ public class GameOfLifeTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Dead_cells_with_three_live_neighbors_become_alive()
+    public void Dead_cells_with_exactly_three_live_neighbors_become_alive()
     {
         var matrix = new[,]
         {
-             { 1, 1, 0 },
+             { 1, 1, 1 },
              { 0, 0, 0 },
              { 1, 0, 0 }
         };
         var expected = new[,]
         {
-             { 0, 0, 0 },
-             { 1, 1, 0 },
+             { 0, 1, 0 },
+             { 1, 0, 0 },
              { 0, 0, 0 }
         };
         Assert.Equal(expected, GameOfLife.Tick(matrix));


### PR DESCRIPTION
The rule in the instructions "Any dead cell with exactly three live neighbors becomes a live cell." is not explicitly covered by the test "Dead_cells_with_three_live_neighbors_become_alive". 

This PR updates the relevant test to match the rule from the instructions more explicitly by covering both the scenarios where there are exactly 3 live neighbors and when there are 4 live neighbors for a cell.