### PR TITLE
Land Grab In Space: Remove testing for diagonal coordinate order (#2300)

### DIFF
--- a/exercises/concept/land-grab-in-space/.docs/instructions.md
+++ b/exercises/concept/land-grab-in-space/.docs/instructions.md
@@ -38,7 +38,7 @@ ch.IsLastClaim(new Plot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coor
 
 ## 4. Find the plot claimed that has the longest side for research purposes
 
-Implement the `ClaimsHandler.GetClaimWithLongestSide()` method to examine all registered claims and return the plot with the longest side.
+Implement the `ClaimsHandler.GetClaimWithLongestSide()` method to examine all registered claims and return the plot with the longest side. The coordinate data in a plot is guaranteed to be in a contiguous rectangular shape.
 
 ```csharp
 var ch = new ClaimsHandler();

--- a/exercises/concept/land-grab-in-space/LandGrabInSpaceTests.cs
+++ b/exercises/concept/land-grab-in-space/LandGrabInSpaceTests.cs
@@ -71,18 +71,6 @@ public class LandGrabInSpaceTests
         Assert.Equal(longer, ch.GetClaimWithLongestSide());
     }
 
-    [Fact]
-    [Task(4)]
-    public void GetLongestSideDiagonal1()
-    {
-        var ch = new ClaimsHandler();
-        var shorter = CreatePlot(new Coord(0, 0), new Coord(0, 10), new Coord(10, 0), new Coord(10, 10));
-        var longer = CreatePlot(new Coord(0, 0), new Coord(11, 0), new Coord(11, 11), new Coord(0, 11));
-        ch.StakeClaim(shorter);
-        ch.StakeClaim(longer);
-        Assert.Equal(longer, ch.GetClaimWithLongestSide());
-    }
-
     private Plot CreatePlot(Coord coord1, Coord coord2, Coord coord3, Coord coord4)
     {
         Type plotType = typeof(Plot);


### PR DESCRIPTION
This test was making this exercise more difficult than before, and probably invalidated a vast majority of all previous solutions.

Instead of testing for this, instead guarantee that the data received is "contiguous" and in a regular rectangular shape.