### PR TITLE
fix: remove exceptions from football match reports

### DIFF
--- a/exercises/concept/football-match-reports/.docs/hints.md
+++ b/exercises/concept/football-match-reports/.docs/hints.md
@@ -6,7 +6,7 @@
 
 - The [`break`][break] statement is useful.
 
-## 2. Raise an alert if an unknown shirt number is encountered
+## 2. Handle unknown shirt numbers
 
 - The [`default`][default] statement is useful.
 

--- a/exercises/concept/football-match-reports/.docs/instructions.md
+++ b/exercises/concept/football-match-reports/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-You are developing a system to help the staff of a football/soccer club's web site report on matches. 
+You are developing a system to help the staff of a football/soccer club's web site report on matches.
 This system is capable of analyzing different aspects in the match, both on and off the field, and converts them into a stream of events.
 
 ## 1. Output descriptions of the players based on their shirt number
@@ -9,7 +9,7 @@ The team only ever plays a 4-3-3 formation and has never agreed with the 1965 ch
 
 The player descriptions are as follows:
 
-```
+```text
 1 -> "goalie"
 2 -> "left back"
 3 & 4 -> "center back"
@@ -27,9 +27,9 @@ PlayAnalyzer.AnalyzeOnField(10);
 // => "striker"
 ```
 
-## 2. Raise an alert if an unknown shirt number is encountered
+## 2. Handle unknown shirt numbers
 
-Modify the `PlayAnalyzer.AnalyzeOnField()` method to throw an `ArgumentOutOfRangeException` when a shirt number outside the range 1-11 is processed.
+Modify the `PlayAnalyzer.AnalyzeOnField()` method to report `UNKNOWN` when a shirt number outside the range 1-11 is processed.
 
 ## 3. Extend the coverage to include off field activity
 
@@ -41,7 +41,7 @@ To start off, we will cover data about the stadium:
 - The current number of supporters in the stadium (any `int`)
 - Announcements made over the stadium's PA system (any `string`)
 
-Unknown types of data should not be processed, so if the method receives data of a different type an `ArgumentException` should be thrown.
+Unknown types of data should not be processed, so if the method receives data of a different type an empty string should be returned.
 
 ```csharp
 PlayAnalyzer.AnalyzeOffField(5000);
@@ -51,15 +51,15 @@ PlayAnalyzer.AnalyzeOffField("5 minutes to go!");
 // => "5 minutes to go!"
 
 PlayAnalyzer.AnalyzeOffField(0.5);
-// => throws ArgumentException
+// => ""
 ```
 
 ## 4. Report on incidents during the match
 
-Modify the `PlayAnalyzer.AnalyzeOffField()` method to output descriptions of incidents that happen during the match. 
+Modify the `PlayAnalyzer.AnalyzeOffField()` method to output descriptions of incidents that happen during the match.
 
-Incidents can be any subclass of the `Incident` type, and will contain a description of the incident. 
-Injuries are a special kind of incident because they cause the match to be put on hold, so they should be treated differently. 
+Incidents can be any subclass of the `Incident` type, and will contain a description of the incident.
+Injuries are a special kind of incident because they cause the match to be put on hold, so they should be treated differently.
 
 ```csharp
 PlayAnalyzer.AnalyzeOffField(new Foul());
@@ -73,8 +73,8 @@ PlayAnalyzer.AnalyzeOffField(new Injury(8));
 
 Modify the `PlayAnalyzer.AnalyzeOffField()` method to mention the club managers present during the match.
 
-Managers are instances of the `Manager` type and have a name and the name of the club they manage. 
-The manager's club may be unknown, in which case it will be set to `null`. 
+Managers are instances of the `Manager` type and have a name and the name of the club they manage.
+The manager's club may be unknown, in which case it will be set to `null`.
 If a manager's club is not known, it should not be part of the description.
 
 ```csharp

--- a/exercises/concept/football-match-reports/.meta/Exemplar.cs
+++ b/exercises/concept/football-match-reports/.meta/Exemplar.cs
@@ -26,7 +26,7 @@ public static class PlayAnalyzer
             case 10:
                 return "striker";
             default:
-                throw new ArgumentOutOfRangeException();
+                return "UNKNOWN";
         }
     }
 
@@ -47,7 +47,7 @@ public static class PlayAnalyzer
             case Manager manager:
                 return manager.Name;
             default:
-                throw new ArgumentException();
+                return "";
         }
     }
 }

--- a/exercises/concept/football-match-reports/.meta/design.md
+++ b/exercises/concept/football-match-reports/.meta/design.md
@@ -11,6 +11,7 @@
 - switch expressions
 - pattern matching tuples
 - enums
+- exceptions
 
 ## Concepts
 

--- a/exercises/concept/football-match-reports/FootballMatchReportsTests.cs
+++ b/exercises/concept/football-match-reports/FootballMatchReportsTests.cs
@@ -34,9 +34,9 @@ public class FootballMatchReportsTests
 
     [Fact]
     [Task(2)]
-    public void AnalyzeOnField_throws_unknown_shirt_number()
+    public void AnalyzeOnField_with_unknown_shirt_number()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => PlayAnalyzer.AnalyzeOnField(1729));
+        Assert.Equal("UNKNOWN", PlayAnalyzer.AnalyzeOnField(1729));
     }
     
     [Fact]
@@ -50,7 +50,7 @@ public class FootballMatchReportsTests
     [Task(3)]
     public void AnalyzeOffField_throws_unknown_type()
     {
-        Assert.Throws<ArgumentException>(() => PlayAnalyzer.AnalyzeOffField(90.0f));
+        Assert.Equal("", PlayAnalyzer.AnalyzeOffField(90.0f));
     }
 
     [Fact]


### PR DESCRIPTION
Exceptions are introduced in a later concept and should be removed here.

Fixes #2306