### PR TITLE
Updated DiamondTests.cs

### DIFF
--- a/exercises/practice/diamond/DiamondTests.cs
+++ b/exercises/practice/diamond/DiamondTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 public class DiamondTests
 {
     public static readonly char[] AllLetters = GetLetterRange('A', 'Z');
-    private static string[] Rows(string x) => x.Split(new[] { '\n' }, StringSplitOptions.None);
+    private static string[] Rows(string x) => x.Split(Environment.NewLine);
 
     private static string LeadingSpaces(string x) => x.Substring(0, x.IndexOfAny(AllLetters));
     private static string TrailingSpaces(string x) => x.Substring(x.LastIndexOfAny(AllLetters) + 1);


### PR DESCRIPTION
`Rows` method adjusted to use system dependent new line characters.

Using '\n' instead of `Environment.NewLine` caused an issue, when all strings except the last one contain '\r' extra character, which leads to property tests failure.