### PR TITLE
Improved test for roll_the_die

### DIFF
--- a/exercises/concept/roll-the-die/RollTheDieTests.cs
+++ b/exercises/concept/roll-the-die/RollTheDieTests.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using Exercism.Tests;
+using System.Collections.Generic;
 
 public class RollTheDieTests
 {
@@ -7,19 +8,31 @@ public class RollTheDieTests
     [Task(1)]
     public void RollDie()
     {
+        var rollCount = 1000;
+        var rolls = new HashSet<int>(rollCount);
         var player = new Player();
-        for (var i = 0; i < 100; i++)
+        for (var i = 0; i < rollCount; i++)
         {
+            var roll = player.RollDie();
+            rolls.Add(roll);
             Assert.InRange(player.RollDie(), 1, 18);
         }
+        Assert.Equal(18, rolls.Count);
     }
 
     [Fact]
     [Task(2)]
     public void GenerateSpellStrength()
     {
+        var rollCount = 100;
+        var rolls = new HashSet<double>(rollCount);
         var player = new Player();
-        var strength = player.GenerateSpellStrength();
-        Assert.InRange(strength, 0.0, 100.0);
+        for (var i = 0; i < rollCount; i++)
+        {
+            var strength = player.GenerateSpellStrength();
+            rolls.Add(strength);
+            Assert.InRange(strength, 0.0, 100.0);
+        }
+        Assert.Equal(rollCount, rolls.Count);
     }
 }


### PR DESCRIPTION
 - Tests now check whether multiple rolls supply different results
 - RollDie is checked for returning all values in the expected range
 - Increased for-loop from 100 times to 1000 times to prevent false negative. Encountered that 100 rolls was not sufficient to have all numbers in range(1, 18) to be generated.

Rationale:

My first implementation (thanks XKCD) made the test suite pass.

```
public int RollDie()
{
  return 4; // chosen by fair dice roll.
            // guaranteed to be random.
}
```