### PR TITLE
chore: fix typo

### DIFF
--- a/exercises/concept/jedliks-toys/.docs/hints.md
+++ b/exercises/concept/jedliks-toys/.docs/hints.md
@@ -14,8 +14,8 @@
 
 ## 3. Display the battery percentage
 
-- Keep track of the distance driven in a [field][fields].
-- Initialize the field to a specific value to correspond to the initial battery charge.
+- Keep track of the initial battery charge in a [field][fields].
+- Initialize the field to a specific value that corresponds to the expected initial battery charge.
 - Consider what visibility to use for the field (does it need to be used outside the class?).
 - Consider using [string interpolation][string-interpolation] to format the string to return.
 


### PR DESCRIPTION
Initially, this hint wasn't indicating that we need an extra, separate field to track the battery charge, as demonstrated by many popular solutions. This led me to think that I should keep the field I made from answer 2 as it is, and calculate the battery charge based on that.

I propose to change this to better reflect expectations: that the solver has to create a field that tracks the battery charge value separately.