### PR TITLE
Consolidate `object-relational-mapping` invalidator entries

### DIFF
--- a/exercises/concept/object-relational-mapping/.meta/config.json
+++ b/exercises/concept/object-relational-mapping/.meta/config.json
@@ -13,13 +13,11 @@
     "test": [
       "ObjectRelationalMappingTests.cs"
     ],
-  "invalidator": [
-      "Database.cs"
-    ],
     "exemplar": [
       ".meta/Exemplar.cs"
     ],
     "invalidator": [
+      "Database.cs",
       "ObjectRelationalMapping.csproj"
     ]
   },


### PR DESCRIPTION
Fixes CI breakage in #2424 since `configlet fmt` doesn't seem to like duplicate invalidator sections.