### PR TITLE
Mark Scale Generator as deprecated

### DIFF
--- a/config.json
+++ b/config.json
@@ -1682,14 +1682,8 @@
         "slug": "scale-generator",
         "name": "Scale Generator",
         "uuid": "c7d5acc6-68a6-4cd8-a28b-359dceb1e56f",
-        "practices": [
-          "foreach-loops"
-        ],
-        "prerequisites": [
-          "strings",
-          "arrays",
-          "foreach-loops"
-        ],
+        "practices": [],
+        "prerequisites": [],
         "difficulty": 5,
         "status": "deprecated"
       },

--- a/config.json
+++ b/config.json
@@ -1690,7 +1690,8 @@
           "arrays",
           "foreach-loops"
         ],
-        "difficulty": 5
+        "difficulty": 5,
+        "status": "deprecated"
       },
       {
         "slug": "tree-building",


### PR DESCRIPTION
This syncs the status update from https://github.com/exercism/problem-specifications/pull/2343