### PR TITLE
Improved test for roll_the_die

### DIFF
--- a/exercises/concept/roll-the-die/.meta/config.json
+++ b/exercises/concept/roll-the-die/.meta/config.json
@@ -5,7 +5,8 @@
   "contributors": [
     "ErikSchierboom",
     "yzAlvin",
-    "aage"
+    "aage",
+    "karanchadha10"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/roll-the-die/RollTheDieTests.cs
+++ b/exercises/concept/roll-the-die/RollTheDieTests.cs
@@ -1,4 +1,5 @@
 using Exercism.Tests;
+using System.Collections.Generic;
 
 public class RollTheDieTests
 {
@@ -6,19 +7,31 @@ public class RollTheDieTests
     [Task(1)]
     public void RollDie()
     {
+        var rollCount = 1000;
+        var rolls = new HashSet<int>(rollCount);
         var player = new Player();
-        for (var i = 0; i < 100; i++)
+        for (var i = 0; i < rollCount; i++)
         {
+            var roll = player.RollDie();
+            rolls.Add(roll);
             Assert.InRange(player.RollDie(), 1, 18);
         }
+        Assert.Equal(18, rolls.Count);
     }
 
     [Fact]
     [Task(2)]
     public void GenerateSpellStrength()
     {
+        var rollCount = 100;
+        var rolls = new HashSet<double>(rollCount);
         var player = new Player();
-        var strength = player.GenerateSpellStrength();
-        Assert.InRange(strength, 0.0, 100.0);
+        for (var i = 0; i < rollCount; i++)
+        {
+            var strength = player.GenerateSpellStrength();
+            rolls.Add(strength);
+            Assert.InRange(strength, 0.0, 100.0);
+        }
+        Assert.Equal(rollCount, rolls.Count);
     }
 }

--- a/exercises/concept/roll-the-die/RollTheDieTests.cs
+++ b/exercises/concept/roll-the-die/RollTheDieTests.cs
@@ -24,6 +24,7 @@ public class RollTheDieTests
     public void GenerateSpellStrength()
     {
         var rollCount = 100;
+        var minUniqueValues = rollCount - 5; // Allow up to 5 duplicates
         var rolls = new HashSet<double>(rollCount);
         var player = new Player();
         for (var i = 0; i < rollCount; i++)
@@ -32,6 +33,8 @@ public class RollTheDieTests
             rolls.Add(strength);
             Assert.InRange(strength, 0.0, 100.0);
         }
-        Assert.Equal(rollCount, rolls.Count);
+        
+        Assert.True(rolls.Count >= minUniqueValues, 
+            $"Expected at least {minUniqueValues} unique values, but got {rolls.Count}");
     }
 }

--- a/exercises/concept/roll-the-die/RollTheDieTests.cs
+++ b/exercises/concept/roll-the-die/RollTheDieTests.cs
@@ -34,7 +34,6 @@ public class RollTheDieTests
             Assert.InRange(strength, 0.0, 100.0);
         }
         
-        Assert.True(rolls.Count >= minUniqueValues, 
-            $"Expected at least {minUniqueValues} unique values, but got {rolls.Count}");
+        Assert.InRange(rolls.Count, minUniqueValues, rollCount);
     }
 }


### PR DESCRIPTION
Tests now check whether multiple rolls supply different results
- RollDie is checked for returning all values in the expected range
- Increased for-loop from 100 times to 1000 times to prevent false negative. Encountered that 100 rolls was not sufficient to have all numbers in range(1, 18) to be generated.
