### PR TITLE
test: Add edge case tests for YearsBeforeDesiredBalance in Interest_Is_Interesting

### DIFF
--- a/exercises/concept/interest-is-interesting/.meta/config.json
+++ b/exercises/concept/interest-is-interesting/.meta/config.json
@@ -1,7 +1,8 @@
 {
   "authors": [
     "ErikSchierboom",
-    "yzAlvin"
+    "yzAlvin",
+    "karanchadha10"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/interest-is-interesting/InterestIsInterestingTests.cs
+++ b/exercises/concept/interest-is-interesting/InterestIsInterestingTests.cs
@@ -197,4 +197,18 @@ public class InterestIsInterestingTests
     {
         Assert.Equal(85, SavingsAccount.YearsBeforeDesiredBalance(2_345.67m, 12_345.6789m));
     }
+
+    [Fact]
+    [Task(4)]
+    public void Years_before_desired_balance_when_target_already_met()
+    {
+        Assert.Equal(0, SavingsAccount.YearsBeforeDesiredBalance(1_000.0m, 1_000.0m));
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Years_before_desired_balance_when_target_already_exceeded()
+    {
+        Assert.Equal(0, SavingsAccount.YearsBeforeDesiredBalance(1_200.0m, 1_000.0m));
+    }
 }


### PR DESCRIPTION
**Description**

This PR contains the following points:

- Add test case for when target balance equals current balance
- Add test case for when target balance is already exceeded
- Both cases should return 0 years as target is already met
- Prevents incorrect do-while implementations from passing tests

Fixes #1976 