### PR TITLE
Add enum.parse task to attack-of-the-trolls exercise

### DIFF
--- a/exercises/concept/attack-of-the-trolls/.docs/instructions.md
+++ b/exercises/concept/attack-of-the-trolls/.docs/instructions.md
@@ -52,4 +52,11 @@ Implement the (_static_) `Permissions.Check()` method that takes the current acc
 ```csharp
 Permissions.Check(current: Permission.Write, check: Permission.Read)
 // => false
+
+## 5. Parse a permission from a string
+
+Implement the (_static_) `Permissions.ParsePermission()` method that parses a string representation of a permission into the `Permission` enum:
+```csharp
+Permissions.ParsePermission("Write")
+// => Permission.Write
 ```

--- a/exercises/concept/attack-of-the-trolls/.meta/Exemplar.cs
+++ b/exercises/concept/attack-of-the-trolls/.meta/Exemplar.cs
@@ -46,4 +46,9 @@ static class Permissions
     {
         return current.HasFlag(check);
     }
+
+    public static Permission ParsePermission(string permissionString)
+    {
+        return Enum.Parse<Permission>(permissionString, ignoreCase: true);
+    }
 }

--- a/exercises/concept/attack-of-the-trolls/.meta/config.json
+++ b/exercises/concept/attack-of-the-trolls/.meta/config.json
@@ -4,7 +4,8 @@
   ],
   "contributors": [
     "valentin-p",
-    "yzAlvin"
+    "yzAlvin",
+    "karanchadha10"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/attack-of-the-trolls/.meta/design.md
+++ b/exercises/concept/attack-of-the-trolls/.meta/design.md
@@ -9,6 +9,7 @@
 - Know how to unset a flag on an enum value.
 - Know that an enum's underlying type can be changed.
 - Know how to use bitwise operators to manipulate bits.
+- Know how to parse a string to an enum value using `Enum.Parse<TEnum>()`.
 
 ## Out of scope
 

--- a/exercises/concept/attack-of-the-trolls/AttackOfTheTrolls.cs
+++ b/exercises/concept/attack-of-the-trolls/AttackOfTheTrolls.cs
@@ -23,4 +23,9 @@ static class Permissions
     {
         throw new NotImplementedException("Please implement the (static) Permissions.Check() method");
     }
+
+    public static Permission ParsePermission(string permissionString)
+    {
+        throw new NotImplementedException("Please implement the (static) Permissions.ParsePermission() method");
+    }
 }

--- a/exercises/concept/attack-of-the-trolls/AttackOfTheTrollsTests.cs
+++ b/exercises/concept/attack-of-the-trolls/AttackOfTheTrollsTests.cs
@@ -173,4 +173,46 @@ public class AttackOfTheTrollsTests
     {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write | Permission.Delete, Permission.All));
     }
+
+    [Fact]
+    [Task(5)]
+    public void Parse_read_permission()
+    {
+        Assert.Equal(Permission.Read, Permissions.ParsePermission("Read"));
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Parse_write_permission()
+    {
+        Assert.Equal(Permission.Write, Permissions.ParsePermission("Write"));
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Parse_delete_permission()
+    {
+        Assert.Equal(Permission.Delete, Permissions.ParsePermission("Delete"));
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Parse_all_permission()
+    {
+        Assert.Equal(Permission.All, Permissions.ParsePermission("All"));
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Parse_none_permission()
+    {
+        Assert.Equal(Permission.None, Permissions.ParsePermission("None"));
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Parse_permission_case_insensitive()
+    {
+        Assert.Equal(Permission.Read, Permissions.ParsePermission("read"));
+    }
 }


### PR DESCRIPTION
**Description**

This PR contains the following points:

- Add Task 5 to parse permission strings using Enum.Parse<T>()
- Add 6 new test cases for permission parsing
- Update instructions.md with new task description
- Update hints.md with parsing guidance
- Update design.md with new learning objective and prerequisite
- Add generic-types as prerequisite concept

Closes #1467