### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to use bitwise operations. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators).

--- a/exercises/practice/alphametics/.docs/instructions.append.md
+++ b/exercises/practice/alphametics/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/).
 - You can solve this exercise with a brute force algorithm, but this will possibly have a poor runtime performance.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to handle data related to currency and money. A normal approach is to use the [Decimal](https://docs.microsoft.com/en-us/dotnet/api/system.decimal).
 Note though that you then only store the numeric value of a currency.

--- a/exercises/practice/beer-song/.docs/instructions.append.md
+++ b/exercises/practice/beer-song/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to implement a type-specific method for determining equality of instances.
 For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1)

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to create custom equality comparison logic.
 For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.object.equals).

--- a/exercises/practice/diamond/.docs/instructions.append.md
+++ b/exercises/practice/diamond/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 The tests in this exercise are different from your usual tests. Normally, a test checks if for a given input, the output matches the expected value. This is called _value-based testing_. However, this exercise uses _property-based testing_, where the tests check if for a range of inputs, the output has a specific property. The two key differences that differentiate property-based testing from value-based testing are:
 

--- a/exercises/practice/difference-of-squares/.docs/instructions.append.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to process a collection of data. You can simplify your code by using LINQ (Language Integrated Query).
 For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq).

--- a/exercises/practice/diffie-hellman/.docs/instructions.append.md
+++ b/exercises/practice/diffie-hellman/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to perform calculations on large numbers. To correctly represent large numbers, the
 [BigInteger](https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger

--- a/exercises/practice/dot-dsl/.docs/instructions.append.md
+++ b/exercises/practice/dot-dsl/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to implement classes with a custom equality check. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.object.equals).

--- a/exercises/practice/food-chain/.docs/instructions.append.md
+++ b/exercises/practice/food-chain/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/forth/.docs/instructions.append.md
+++ b/exercises/practice/forth/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/).

--- a/exercises/practice/hangman/.docs/instructions.append.md
+++ b/exercises/practice/hangman/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to work with Reactive extension. For more information, see
 [this page](http://reactivex.io/intro.html) .

--- a/exercises/practice/house/.docs/instructions.append.md
+++ b/exercises/practice/house/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Notes
+# Instructions append
+
+## Notes
 
 The DateTime class in C# provides a built-in [IsLeapYear](https://docs.microsoft.com/en-us/dotnet/api/system.datetime.isleapyear)
 which you should pretend doesn't exist for the purposes of implementing this exercise.

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 The `Foldl` and `Foldr` methods are "fold" functions, which is a concept well-known in the functional programming world, but less so in the object-oriented one. If you'd like more background information, check out this [fold](<https://en.wikipedia.org/wiki/Fold_(higher-order_function)>) page.

--- a/exercises/practice/markdown/.docs/instructions.append.md
+++ b/exercises/practice/markdown/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following C# feature comes in handy:
 

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following C# feature comes in handy:
 Enumerables are evaluated lazily. They allow you to work with an infinite sequence of values.

--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires the use of a Dictionary. For more information see
 [this page](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.idictionary-2).

--- a/exercises/practice/palindrome-products/.docs/instructions.append.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise, you will need to create a set of factors using tuples.
 For more information on tuples, see [this link](https://docs.microsoft.com/en-us/dotnet/api/system.tuple).

--- a/exercises/practice/proverb/.docs/instructions.append.md
+++ b/exercises/practice/proverb/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/react/.docs/instructions.append.md
+++ b/exercises/practice/react/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 In this exercise the following C# feature is used:
 

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to write an extension method. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods).

--- a/exercises/practice/saddle-points/.docs/instructions.append.md
+++ b/exercises/practice/saddle-points/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise, you will need to create a set of factors using tuples.
 For more information on tuples, see [this link](https://docs.microsoft.com/en-us/dotnet/api/system.tuple).

--- a/exercises/practice/sgf-parsing/.docs/instructions.append.md
+++ b/exercises/practice/sgf-parsing/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/).

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Instruction append
+# Instructions append
+
+## Notes
 
 This exercise requires you to create a linked list data structure which can be iterated. 
 

--- a/exercises/practice/sublist/.docs/instructions.append.md
+++ b/exercises/practice/sublist/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To be able to compare data, the IComparable interface is used.
 For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.icomparable)

--- a/exercises/practice/sum-of-multiples/.docs/instructions.append.md
+++ b/exercises/practice/sum-of-multiples/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to process a collection of data. You can simplify your code by using LINQ (Language Integrated Query).
 For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq).

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/variable-length-quantity/.docs/instructions.append.md
+++ b/exercises/practice/variable-length-quantity/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to use bitwise operations. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators).

--- a/exercises/practice/word-search/.docs/instructions.append.md
+++ b/exercises/practice/word-search/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 One of the uses of Tuples is returning multiple values from a function. In this exercise, write
 a function that returns a Tuple (the x- and y- part of a coordinate).

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/), and a blog with useful hints and snippets over [here](https://justinpealing.me.uk/post/2020-04-20-sprache7-operators/)

--- a/exercises/practice/zebra-puzzle/.docs/instructions.append.md
+++ b/exercises/practice/zebra-puzzle/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to process a collection of data. You can simplify your code by using lazy sequences to improve performance.
 For more information, see [this page](https://xosfaere.wordpress.com/2010/03/21/lazy-evaluation-in-csharp/).

--- a/exercises/practice/zipper/.docs/instructions.append.md
+++ b/exercises/practice/zipper/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise deals with custom equality. For more information see [this page.](http://www.loganfranken.com/blog/687/overriding-equals-in-c-part-1/)


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.