### PR TITLE
Fix `SwiftScheduling.cs` syntax error

### DIFF
--- a/exercises/practice/swift-scheduling/SwiftScheduling.cs
+++ b/exercises/practice/swift-scheduling/SwiftScheduling.cs
@@ -1,6 +1,6 @@
 public static class SwiftScheduling
 {
-    public static DateTime DeliveryDate(DateTime meetingStart, string description) =>
+    public static DateTime DeliveryDate(DateTime meetingStart, string description)
     {
         throw new NotImplementedException("You need to implement this method.");
     }


### PR DESCRIPTION
This PR aims to fix the syntax error explained in [this forum post](https://forum.exercism.org/t/invalid-c-syntax-in-swiftscheduling-cs-stub-file/59863).

I've removed the expression-body arrow (=>) in the `DeliveryDate` method inside the [`SwiftScheduling.cs`](https://github.com/exercism/csharp/blob/main/exercises/practice/swift-scheduling/SwiftScheduling.cs) stub file, which caused a compilation failure immediately after downloading the exercise.